### PR TITLE
Move docopy out of the installer

### DIFF
--- a/pkg/utils/copy.go
+++ b/pkg/utils/copy.go
@@ -1,0 +1,68 @@
+package utils
+
+import (
+	"fmt"
+	v1 "github.com/rancher-sandbox/elemental-cli/pkg/types/v1"
+	"github.com/zloylos/grsync"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+func DoCopy(config *v1.RunConfig) error {
+	fmt.Printf("Copying cOS..\n")
+	// Make sure the values have a / at the end.
+	var source, target string
+	if strings.HasSuffix(config.Source, "/") == false {
+		source = fmt.Sprintf("%s/", config.Source)
+	} else { source = config.Source }
+
+	if strings.HasSuffix(config.Target, "/") == false {
+		target = fmt.Sprintf("%s/", config.Target)
+	} else { target = config.Target }
+
+	// 1 - rsync all the system from source to target
+	task := grsync.NewTask(
+		source,
+		target,
+		grsync.RsyncOptions{
+			Quiet: false,
+			Archive: true,
+			XAttrs: true,
+			ACLs: true,
+			Exclude: []string{"mnt", "proc", "sys", "dev", "tmp"},
+		},
+	)
+	go func() {
+		for {
+			state := task.State()
+			fmt.Printf(
+				"progress: %.2f / rem. %d / tot. %d / sp. %s \n",
+				state.Progress,
+				state.Remain,
+				state.Total,
+				state.Speed,
+			)
+			<- time.After(time.Second)
+		}
+	}()
+	if err := task.Run(); err != nil {
+		return err
+	}
+	// 2 - if we got a cloud config file get it and store in the target
+	if config.CloudInit != "" {
+		client := &http.Client{}
+		customConfig := fmt.Sprintf("%s/oem/99_custom.yaml", config.Target)
+
+		if err :=
+			GetUrl(client, config.CloudInit, customConfig); err != nil {
+			return err
+		}
+
+		if err := os.Chmod(customConfig, 0600); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/utils/copy_test.go
+++ b/pkg/utils/copy_test.go
@@ -1,26 +1,9 @@
-/*
-Copyright © 2021 SUSE LLC
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
-
-package action
+package utils
 
 import (
 	"fmt"
 	. "github.com/onsi/gomega"
-	"github.com/rancher-sandbox/elemental-cli/pkg/types/v1"
+	v1 "github.com/rancher-sandbox/elemental-cli/pkg/types/v1"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -42,9 +25,7 @@ func TestDoCopyEmpty(t *testing.T) {
 		CloudInit: "",
 	}
 
-	install := NewInstallAction(cfg)
-
-	err = install.doCopy()
+	err = DoCopy(cfg)
 	Expect(err).To(BeNil())
 }
 
@@ -68,9 +49,8 @@ func TestDoCopy(t *testing.T) {
 		CloudInit: "",
 	}
 
-	install := NewInstallAction(cfg)
 
-	err = install.doCopy()
+	err = DoCopy(cfg)
 	Expect(err).To(BeNil())
 
 	filesDest, err := ioutil.ReadDir(d)
@@ -108,9 +88,7 @@ func TestDoCopyEmptyWithCloudInit(t *testing.T) {
 		CloudInit: cloudInit.Name(),
 	}
 
-	install := NewInstallAction(cfg)
-
-	err = install.doCopy()
+	err = DoCopy(cfg)
 	Expect(err).To(BeNil())
 	filesDest, err := ioutil.ReadDir(fmt.Sprintf("%s/oem", d))
 	destNames := getNamesFromListFiles(filesDest)


### PR DESCRIPTION
It doesnt neccesary has to be attached to it and can be reused by other
components

Signed-off-by: Itxaka <igarcia@suse.com>