### PR TITLE
Ignore errors from run-stage by default and use strict mode

### DIFF
--- a/cmd/run-stage.go
+++ b/cmd/run-stage.go
@@ -47,4 +47,5 @@ var runStage = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(runStage)
+	runStage.Flags().Bool("strict", false, "Set strict checking for errors, i.e. fail if errors were found")
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/containerd/containerd v1.5.8 // indirect
 	github.com/docker/docker v20.10.10+incompatible
 	github.com/docker/go-units v0.4.0
+	github.com/hashicorp/go-multierror v1.1.0 // indirect
 	github.com/mudler/luet v0.0.0-20211228210804-80bc5429bc4a
 	github.com/mudler/yip v0.0.0-20211214150120-1d415391cc37
 	github.com/onsi/ginkgo v1.16.4


### PR DESCRIPTION
As cos-setup didnt raise any errors, we have to mimic the same behaviour
as some services depend on a clean exit to continue booting the system.

Also log those errors and introduce a check for strict mode in which the
errors are returned and elemental exits with an error in that case

Signed-off-by: Itxaka <igarcia@suse.com>