### PR TITLE
Restore CloudInitRunner modifier after runStage

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -52,6 +52,7 @@ var installCmd = &cobra.Command{
 		cfg.Target = args[0]
 
 		cfg.DigestSetup()
+		cmd.SilenceUsage = true
 
 		cfg.Logger.Infof("Install called")
 

--- a/pkg/utils/runstage.go
+++ b/pkg/utils/runstage.go
@@ -103,6 +103,9 @@ func RunStage(stage string, cfg *v1.RunConfig) error {
 	}
 
 	cfg.CloudInitRunner.SetModifier(schema.DotNotationModifier)
+	// After RunStage reset the modifier
+	defer cfg.CloudInitRunner.SetModifier(nil)
+
 	err = cfg.CloudInitRunner.Run(stageBefore, string(cmdLineOut))
 	if err != nil {
 		errors = multierror.Append(errors, err)


### PR DESCRIPTION
This commit ensure the yips loader modifier is reset to nil after
running utils.RunStage.

In addition this commit also hides the usage message on errors
during the installation.

Signed-off-by: David Cassany <dcassany@suse.com>