### PR TITLE
Hide yip errors under warning

### DIFF
--- a/pkg/utils/runstage.go
+++ b/pkg/utils/runstage.go
@@ -108,8 +108,8 @@ func RunStage(stage string, cfg *v1.RunConfig) error {
 	}
 
 	if errors != nil && !cfg.Strict {
-		cfg.Logger.Info("Some errors found but were ignored:")
-		cfg.Logger.Info(errors)
+		cfg.Logger.Info("Some errors found but were ignored. Enable --strict mode to fail on those or --debug to see them in the log")
+		cfg.Logger.Warn(errors)
 		return nil
 	}
 


### PR DESCRIPTION
Instead of showing them, just hide them under debug and notify that
there were ignored errors and how to see them/fail on them

Related https://github.com/rancher-sandbox/cOS-toolkit/issues/1109

Signed-off-by: Itxaka <igarcia@suse.com>