### PR TITLE
Do not use cosign luet plugin

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -127,6 +127,10 @@ func ReadConfigRun(configDir string, mounter mount.Interface) (*v1.RunConfig, er
 	// the env stuff ourselves, as this will only match keys in the config root
 	replacer := strings.NewReplacer("-", "_")
 	viper.SetEnvKeyReplacer(replacer)
+
+	// Manually bind public key env variable as it uses a different name in config files or flags.
+	viper.BindEnv("CosingPubKey", "COSIGN_PUBLIC_KEY_LOCATION")
+
 	viper.AutomaticEnv() // read in environment variables that match
 
 	// unmarshal all the vars into the config object

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -70,6 +70,7 @@ func init() {
 	installCmd.Flags().StringP("partition-layout", "p", "", "Partitioning layout file")
 	installCmd.Flags().BoolP("no-verify", "", false, "Disable mtree checksum verification (requires images manifests generated with mtree separately)")
 	installCmd.Flags().BoolP("cosign", "", false, "Enable cosign verification (requires images with signatures)")
+	installCmd.Flags().BoolP("cosign-key", "", false, "Sets the URL of the public key to be used by cosign validation")
 	installCmd.Flags().BoolP("no-format", "", false, "Don’t format disks. It is implied that COS_STATE, COS_RECOVERY, COS_PERSISTENT, COS_OEM are already existing")
 	installCmd.Flags().BoolP("force-efi", "", false, "Forces an EFI installation")
 	installCmd.Flags().BoolP("force-gpt", "", false, "Forces a GPT partition table")

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -70,7 +70,7 @@ func init() {
 	installCmd.Flags().StringP("partition-layout", "p", "", "Partitioning layout file")
 	installCmd.Flags().BoolP("no-verify", "", false, "Disable mtree checksum verification (requires images manifests generated with mtree separately)")
 	installCmd.Flags().BoolP("cosign", "", false, "Enable cosign verification (requires images with signatures)")
-	installCmd.Flags().BoolP("cosign-key", "", false, "Sets the URL of the public key to be used by cosign validation")
+	installCmd.Flags().StringP("cosign-key", "", "", "Sets the URL of the public key to be used by cosign validation")
 	installCmd.Flags().BoolP("no-format", "", false, "Don’t format disks. It is implied that COS_STATE, COS_RECOVERY, COS_PERSISTENT, COS_OEM are already existing")
 	installCmd.Flags().BoolP("force-efi", "", false, "Forces an EFI installation")
 	installCmd.Flags().BoolP("force-gpt", "", false, "Forces a GPT partition table")

--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -277,6 +277,17 @@ func (c *Elemental) CopyActive() error {
 	var err error
 
 	if c.config.DockerImg != "" {
+		if c.config.Cosign {
+			c.config.Logger.Infof("Running cosing verification for %s", c.config.DockerImg)
+			out, err := utils.CosignVerify(
+				c.config.Fs, c.config.Runner, c.config.DockerImg,
+				c.config.CosignPubKey, v1.IsDebugLevel(c.config.Logger),
+			)
+			if err != nil {
+				c.config.Logger.Errorf("Cosign verification failed: %s", out)
+				return err
+			}
+		}
 		err = c.config.Luet.Unpack(c.config.ActiveImage.MountPoint, c.config.DockerImg)
 		if err != nil {
 			return err

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -184,7 +184,8 @@ type RunConfig struct {
 	Strict          bool   `yaml:"strict,omitempty" mapstructure:"strict"`
 	Iso             string `yaml:"iso,omitempty" mapstructure:"iso"`
 	DockerImg       string `yaml:"docker-image,omitempty" mapstructure:"docker-image"`
-	Cosign          bool   `yaml:"no-cosign,omitempty" mapstructure:"no-cosign"`
+	Cosign          bool   `yaml:"cosign,omitempty" mapstructure:"cosign"`
+	CosignPubKey    string `yaml:"cosign-key,omitempty" mapstructure:"cosign-key"`
 	NoVerify        bool   `yaml:"no-verify,omitempty" mapstructure:"no-verify"`
 	CloudInitPaths  string `yaml:"CLOUD_INIT_PATHS,omitempty" mapstructure:"CLOUD_INIT_PATHS"`
 	GrubDefEntry    string `yaml:"GRUB_ENTRY_NAME,omitempty" mapstructure:"GRUB_ENTRY_NAME"`
@@ -333,8 +334,8 @@ func (r *RunConfig) setupStyle() {
 func (r *RunConfig) setupLuet() {
 	if r.DockerImg != "" {
 		plugins := []string{}
-		if r.Cosign {
-			plugins = append(plugins, cnst.LuetCosignPlugin)
+		if r.Cosign && r.CosignPubKey == "" {
+			r.Logger.Warnf("Keyless cosign verification is experimental, consider setting a public key")
 		}
 		if !r.NoVerify {
 			plugins = append(plugins, cnst.LuetMtreePlugin)

--- a/pkg/types/v1/logger.go
+++ b/pkg/types/v1/logger.go
@@ -50,6 +50,13 @@ func DebugLevel() log.Level {
 	return l
 }
 
+func IsDebugLevel(l Logger) bool {
+	if l.GetLevel() == DebugLevel() {
+		return true
+	}
+	return false
+}
+
 type LoggerOptions func(l Logger) error
 
 func NewLogger() Logger {

--- a/pkg/types/v1/logger_test.go
+++ b/pkg/types/v1/logger_test.go
@@ -39,6 +39,14 @@ var _ = Describe("logger", func() {
 	It("DebugLevel returns the proper log level for debug output", func() {
 		Expect(v1.DebugLevel()).To(Equal(logrus.DebugLevel))
 	})
+	It("Returns true on IsDebugLevel when log level is set to debug", func() {
+		l := v1.NewLogger()
+		l.SetLevel(v1.DebugLevel())
+		Expect(v1.IsDebugLevel(l)).To(BeTrue())
+	})
+	It("Returns false on IsDebugLevel when log level is not set to debug", func() {
+		Expect(v1.IsDebugLevel(v1.NewLogger())).To(BeFalse())
+	})
 	It("NewBufferLogger stores content in a buffer", func() {
 		b := &bytes.Buffer{}
 		l1 := v1.NewBufferLogger(b)

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/zloylos/grsync"
 	"io"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -115,4 +116,28 @@ func SyncData(source string, target string, excludes ...string) error {
 	)
 
 	return task.Run()
+}
+
+func CosignVerify(fs afero.Fs, runner v1.Runner, image string, publicKey string, debug bool) (string, error) {
+	args := []string{}
+
+	if debug {
+		args = append(args, "-d=true")
+	}
+	if publicKey != "" {
+		args = append(args, "-key", publicKey)
+	}
+	args = append(args, image)
+
+	// Give each cosign its own tuf dir so it doesnt collide with others accessing the same files at the same time
+	tmpDir, err := afero.TempDir(fs, "", "cosign-tuf-")
+	if err != nil {
+		return "", err
+	}
+	_ = os.Setenv("TUF_ROOT", tmpDir)
+	defer fs.RemoveAll(tmpDir)
+	defer os.Unsetenv("TUF_ROOT")
+
+	out, err := runner.Run("cosign", args...)
+	return string(out), err
 }

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -126,6 +126,9 @@ func CosignVerify(fs afero.Fs, runner v1.Runner, image string, publicKey string,
 	}
 	if publicKey != "" {
 		args = append(args, "-key", publicKey)
+	} else {
+		os.Setenv("COSIGN_EXPERIMENTAL", "1")
+		defer os.Unsetenv("COSIGN_EXPERIMENTAL")
 	}
 	args = append(args, image)
 

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -175,6 +175,28 @@ var _ = Describe("Utils", func() {
 			Expect(runner.CmdsMatch(append(cmds, cmds...))).To(BeNil())
 		})
 	})
+	Context("CosignVerify", func() {
+		var runner *v1mock.TestRunnerV2
+		BeforeEach(func() {
+			runner = v1mock.NewTestRunnerV2()
+		})
+		It("runs a keyless verification", func() {
+			_, err := utils.CosignVerify(fs, runner, "some/image:latest", "", true)
+			Expect(err).To(BeNil())
+			Expect(runner.CmdsMatch([][]string{{"cosign", "-d=true", "some/image:latest"}})).To(BeNil())
+		})
+		It("runs a verification using a public key", func() {
+			_, err := utils.CosignVerify(fs, runner, "some/image:latest", "https://mykey.pub", false)
+			Expect(err).To(BeNil())
+			Expect(runner.CmdsMatch(
+				[][]string{{"cosign", "-key", "https://mykey.pub", "some/image:latest"}},
+			)).To(BeNil())
+		})
+		It("Fails to to create temporary directories", func() {
+			_, err := utils.CosignVerify(afero.NewReadOnlyFs(fs), runner, "some/image:latest", "", true)
+			Expect(err).NotTo(BeNil())
+		})
+	})
 	Context("CopyFile", func() {
 		It("Copies source to target", func() {
 			fs.Create("/some/file")


### PR DESCRIPTION
This commit instead of using luet's cosign plugin it just calls
cosign utility as needed. It facilitates a better use of environmental
variables and cosign specific flags.

Fixes rancher-sandbox/cOS-toolkit#1106

Signed-off-by: David Cassany <dcassany@suse.com>