### PR TITLE
Install config refactor

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"errors"
 	"github.com/rancher-sandbox/elemental/cmd/config"
 	"github.com/rancher-sandbox/elemental/pkg/action"
 	"github.com/spf13/cobra"
@@ -41,15 +42,30 @@ var installCmd = &cobra.Command{
 		mounter := mount.New(path)
 
 		cfg, err := config.ReadConfigRun(viper.GetString("config-dir"), mounter)
-
 		if err != nil {
 			cfg.Logger.Errorf("Error reading config: %s\n", err)
 		}
+
+		err = errors.New("Invalid options")
+		if viper.GetBool("reboot") && viper.GetBool("poweroff") {
+			cfg.Logger.Errorf("'reboot' and 'poweroff' are mutually exclusive options")
+			return err
+		}
+
+		if viper.GetString("cosign-key") != "" && !viper.GetBool("cosign") {
+			cfg.Logger.Errorf("'cosign-key' requires 'cosing' option to be enabled")
+			return err
+		}
+
+		if viper.GetBool("cosign") && viper.GetString("cosign-key") == "" {
+			cfg.Logger.Warnf("No 'cosign-key' option set, keyless cosign verification is experimental")
+		}
+
 		// Should probably load whatever env vars we want to overload here and merge them into the viper configs
 		// Note that vars with ELEMENTAL in front and that match entries in the config (only one level deep) are overwritten automatically
 		cfg.Target = args[0]
 
-		err = cfg.DigestSetup()
+		err = action.InstallSetup(cfg)
 		if err != nil {
 			return err
 		}
@@ -57,9 +73,7 @@ var installCmd = &cobra.Command{
 
 		cfg.Logger.Infof("Install called")
 
-		// Dont call it yet, not ready
-		install := action.NewInstallAction(cfg)
-		err = install.Run()
+		err = action.InstallRun(cfg)
 		if err != nil {
 			return err
 		}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -69,7 +69,6 @@ var installCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(installCmd)
-	installCmd.Flags().StringP("config-dir", "e", "/etc/elemental/", "dir where the elemental config resides")
 	installCmd.Flags().StringP("docker-image", "d", "", "Install a specified container image")
 	installCmd.Flags().StringP("cloud-init", "c", "", "Cloud-init config file")
 	installCmd.Flags().StringP("iso", "i", "", "Performs an installation from the ISO url")

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -54,7 +54,7 @@ var upgradeCmd = &cobra.Command{
 		}
 
 		// Init setup
-		err = cfg.DigestSetup()
+		err = action.InstallSetup(cfg)
 		if err != nil {
 			cfg.Logger.Errorf("Error digesting setup: %s\n", err)
 		}

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -54,6 +54,7 @@ var upgradeCmd = &cobra.Command{
 		}
 
 		// Init setup
+		// TBC action.InstallSetup is the exact equivalent of the old DigestSetup
 		err = action.InstallSetup(cfg)
 		if err != nil {
 			cfg.Logger.Errorf("Error digesting setup: %s\n", err)
@@ -89,7 +90,7 @@ func init() {
 	upgradeCmd.Flags().String("directory", "", "Use directory as source to install from")
 	upgradeCmd.Flags().Bool("recovery", false, "Upgrade the recovery")
 	upgradeCmd.Flags().Bool("no-verify", false, "Disable mtree verification")
-	upgradeCmd.Flags().Bool("no-cosign", false, "Disable cosign verification")
+	upgradeCmd.Flags().Bool("cosign", false, "Disable cosign verification")
 	upgradeCmd.Flags().Bool("strict", false, "Fail on any errors")
 	upgradeCmd.Flags().BoolP("reboot", "", false, "Reboot the system after install")
 	upgradeCmd.Flags().BoolP("poweroff", "", false, "Shutdown the system after install")

--- a/pkg/action/common.go
+++ b/pkg/action/common.go
@@ -1,0 +1,59 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package action
+
+import (
+	dockTypes "github.com/docker/docker/api/types"
+	"github.com/mudler/luet/pkg/api/core/context"
+	"github.com/rancher-sandbox/elemental/pkg/constants"
+	"github.com/rancher-sandbox/elemental/pkg/types/v1"
+	"github.com/rancher-sandbox/elemental/pkg/utils"
+)
+
+func actionHook(config *v1.RunConfig, hook string) error {
+	config.Logger.Infof("Running %s hook", hook)
+	err := utils.RunStage(hook, config)
+	if !config.Strict {
+		err = nil
+	}
+	return err
+}
+
+func actionChrootHook(config *v1.RunConfig, hook string, chrootDir string, bindMounts map[string]string) (err error) {
+	chroot := utils.NewChroot(chrootDir, config)
+	chroot.SetExtraMounts(bindMounts)
+	err = chroot.Prepare()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if tmpErr := chroot.Close(); tmpErr != nil && err == nil {
+			err = tmpErr
+		}
+	}()
+	return actionHook(config, hook)
+}
+
+func setupLuet(config *v1.RunConfig) {
+	if config.DockerImg != "" {
+		plugins := []string{}
+		if !config.NoVerify {
+			plugins = append(plugins, constants.LuetMtreePlugin)
+		}
+		config.Luet = v1.NewLuet(config.Logger, context.NewContext(), &dockTypes.AuthConfig{}, plugins...)
+	}
+}

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -93,68 +93,52 @@ func InstallSetup(config *v1.RunConfig) error {
 	}
 
 	part = &v1.Partition{
-		Label:      cnst.OEMLabel,
+		Label:      config.OEMLabel,
 		Size:       cnst.OEMSize,
 		Name:       cnst.OEMPartName,
 		FS:         cnst.LinuxFs,
 		MountPoint: cnst.OEMDir,
 		Flags:      []string{},
 	}
-	if config.OEMLabel != "" {
-		part.Label = config.OEMLabel
-	}
 	config.Partitions = append(config.Partitions, part)
 
 	part = &v1.Partition{
-		Label:      cnst.StateLabel,
+		Label:      config.StateLabel,
 		Size:       cnst.StateSize,
 		Name:       cnst.StatePartName,
 		FS:         cnst.LinuxFs,
 		MountPoint: cnst.StateDir,
 		Flags:      statePartFlags,
 	}
-	if config.StateLabel != "" {
-		part.Label = config.StateLabel
-	}
 	config.Partitions = append(config.Partitions, part)
 
 	part = &v1.Partition{
-		Label:      cnst.RecoveryLabel,
+		Label:      config.RecoveryLabel,
 		Size:       cnst.RecoverySize,
 		Name:       cnst.RecoveryPartName,
 		FS:         cnst.LinuxFs,
 		MountPoint: cnst.RecoveryDir,
 		Flags:      []string{},
 	}
-	if config.RecoveryLabel != "" {
-		part.Label = config.RecoveryLabel
-	}
 	config.Partitions = append(config.Partitions, part)
 
 	part = &v1.Partition{
-		Label:      cnst.PersistentLabel,
+		Label:      config.PersistentLabel,
 		Size:       cnst.PersistentSize,
 		Name:       cnst.PersistentPartName,
 		FS:         cnst.LinuxFs,
 		MountPoint: cnst.PersistentDir,
 		Flags:      []string{},
 	}
-	if config.PersistentLabel != "" {
-		part.Label = config.PersistentLabel
-	}
 	config.Partitions = append(config.Partitions, part)
 
 	config.ActiveImage = v1.Image{
-		Label:      cnst.ActiveLabel,
+		Label:      config.ActiveLabel,
 		Size:       cnst.ImgSize,
 		File:       filepath.Join(cnst.StateDir, "cOS", cnst.ActiveImgFile),
 		FS:         cnst.LinuxImgFs,
 		RootTree:   cnst.IsoBaseTree,
 		MountPoint: cnst.ActiveDir,
-	}
-
-	if config.ActiveLabel != "" {
-		config.ActiveImage.Label = config.ActiveLabel
 	}
 
 	if config.DockerImg != "" {

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -159,10 +159,8 @@ func (i InstallAction) Run() (err error) {
 
 	err = i.installHook(cnst.AfterInstallChrootHook, true)
 	if err != nil {
-		newElemental.UnmountImage(&i.Config.ActiveImage)
 		return err
 	}
-	//TODO rebrand here is really needed? see cos-installer script
 
 	// Unmount active image
 	err = newElemental.UnmountImage(&i.Config.ActiveImage)

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -19,25 +19,19 @@ package action
 import (
 	"errors"
 	"fmt"
+	dockTypes "github.com/docker/docker/api/types"
+	"github.com/mudler/luet/pkg/api/core/context"
 	cnst "github.com/rancher-sandbox/elemental/pkg/constants"
 	"github.com/rancher-sandbox/elemental/pkg/elemental"
-	part "github.com/rancher-sandbox/elemental/pkg/partitioner"
+	"github.com/rancher-sandbox/elemental/pkg/partitioner"
 	"github.com/rancher-sandbox/elemental/pkg/types/v1"
 	"github.com/rancher-sandbox/elemental/pkg/utils"
+	"path/filepath"
 )
 
-// InstallAction represents the struct that will run the full install from start to finish
-type InstallAction struct {
-	Config *v1.RunConfig
-}
-
-func NewInstallAction(config *v1.RunConfig) *InstallAction {
-	return &InstallAction{Config: config}
-}
-
-func (i InstallAction) installHook(hook string, chroot bool) (err error) {
+func installHook(config *v1.RunConfig, hook string, chroot bool) (err error) {
 	if chroot {
-		chroot := utils.NewChroot(i.Config.ActiveImage.MountPoint, i.Config)
+		chroot := utils.NewChroot(config.ActiveImage.MountPoint, config)
 		chroot.SetExtraMounts(map[string]string{
 			cnst.PersistentDir: "/usr/local",
 			cnst.OEMDir:        "/oem",
@@ -52,52 +46,166 @@ func (i InstallAction) installHook(hook string, chroot bool) (err error) {
 			}
 		}()
 	}
-	i.Config.Logger.Infof("Running %s hook", hook)
-	err = utils.RunStage(hook, i.Config)
-	if !i.Config.Strict {
+	config.Logger.Infof("Running %s hook", hook)
+	err = utils.RunStage(hook, config)
+	if !config.Strict {
 		err = nil
 	}
 	return err
 }
 
-// Run will install the cos system to a device by following several steps
-func (i InstallAction) Run() (err error) {
-	newElemental := elemental.NewElemental(i.Config)
+// InstallSetup will set installation parameters according to
+// the given configuration flags
+func InstallSetup(config *v1.RunConfig) error {
+	_, err := config.Fs.Stat(cnst.EfiDevice)
+	efiExists := err == nil
+	statePartFlags := []string{}
+	var part *v1.Partition
 
-	disk := part.NewDisk(
-		i.Config.Target,
-		part.WithRunner(i.Config.Runner),
-		part.WithFS(i.Config.Fs),
-		part.WithLogger(i.Config.Logger),
+	if config.ForceEfi || efiExists {
+		config.PartTable = v1.GPT
+		config.BootFlag = v1.ESP
+		part = &v1.Partition{
+			Label:      cnst.EfiLabel,
+			Size:       cnst.EfiSize,
+			Name:       cnst.EfiPartName,
+			FS:         cnst.EfiFs,
+			MountPoint: cnst.EfiDir,
+			Flags:      []string{v1.ESP},
+		}
+		config.Partitions = append(config.Partitions, part)
+	} else if config.ForceGpt {
+		config.PartTable = v1.GPT
+		config.BootFlag = v1.BIOS
+		part = &v1.Partition{
+			Label:      "",
+			Size:       cnst.BiosSize,
+			Name:       cnst.BiosPartName,
+			FS:         "",
+			MountPoint: "",
+			Flags:      []string{v1.BIOS},
+		}
+		config.Partitions = append(config.Partitions, part)
+	} else {
+		config.PartTable = v1.MSDOS
+		config.BootFlag = v1.BOOT
+		statePartFlags = []string{v1.BOOT}
+	}
+
+	part = &v1.Partition{
+		Label:      cnst.OEMLabel,
+		Size:       cnst.OEMSize,
+		Name:       cnst.OEMPartName,
+		FS:         cnst.LinuxFs,
+		MountPoint: cnst.OEMDir,
+		Flags:      []string{},
+	}
+	if config.OEMLabel != "" {
+		part.Label = config.OEMLabel
+	}
+	config.Partitions = append(config.Partitions, part)
+
+	part = &v1.Partition{
+		Label:      cnst.StateLabel,
+		Size:       cnst.StateSize,
+		Name:       cnst.StatePartName,
+		FS:         cnst.LinuxFs,
+		MountPoint: cnst.StateDir,
+		Flags:      statePartFlags,
+	}
+	if config.StateLabel != "" {
+		part.Label = config.StateLabel
+	}
+	config.Partitions = append(config.Partitions, part)
+
+	part = &v1.Partition{
+		Label:      cnst.RecoveryLabel,
+		Size:       cnst.RecoverySize,
+		Name:       cnst.RecoveryPartName,
+		FS:         cnst.LinuxFs,
+		MountPoint: cnst.RecoveryDir,
+		Flags:      []string{},
+	}
+	if config.RecoveryLabel != "" {
+		part.Label = config.RecoveryLabel
+	}
+	config.Partitions = append(config.Partitions, part)
+
+	part = &v1.Partition{
+		Label:      cnst.PersistentLabel,
+		Size:       cnst.PersistentSize,
+		Name:       cnst.PersistentPartName,
+		FS:         cnst.LinuxFs,
+		MountPoint: cnst.PersistentDir,
+		Flags:      []string{},
+	}
+	if config.PersistentLabel != "" {
+		part.Label = config.PersistentLabel
+	}
+	config.Partitions = append(config.Partitions, part)
+
+	config.ActiveImage = v1.Image{
+		Label:      cnst.ActiveLabel,
+		Size:       cnst.ImgSize,
+		File:       filepath.Join(cnst.StateDir, "cOS", cnst.ActiveImgFile),
+		FS:         cnst.LinuxImgFs,
+		RootTree:   cnst.IsoBaseTree,
+		MountPoint: cnst.ActiveDir,
+	}
+
+	if config.ActiveLabel != "" {
+		config.ActiveImage.Label = config.ActiveLabel
+	}
+
+	if config.DockerImg != "" {
+		plugins := []string{}
+		if !config.NoVerify {
+			plugins = append(plugins, cnst.LuetMtreePlugin)
+		}
+		config.Luet = v1.NewLuet(config.Logger, context.NewContext(), &dockTypes.AuthConfig{}, plugins...)
+	}
+
+	return nil
+}
+
+// Run will install the system from a given configuration
+func InstallRun(config *v1.RunConfig) (err error) {
+	newElemental := elemental.NewElemental(config)
+
+	disk := partitioner.NewDisk(
+		config.Target,
+		partitioner.WithRunner(config.Runner),
+		partitioner.WithFS(config.Fs),
+		partitioner.WithLogger(config.Logger),
 	)
 
-	err = i.installHook(cnst.BeforeInstallHook, false)
+	err = installHook(config, cnst.BeforeInstallHook, false)
 	if err != nil {
 		return err
 	}
 
-	if i.Config.Iso != "" {
+	if config.Iso != "" {
 		tmpDir, err := newElemental.GetIso()
 		if err != nil {
 			return err
 		}
 		defer func() {
-			i.Config.Logger.Infof("Unmounting downloaded ISO")
-			if tmpErr := i.Config.Mounter.Unmount(i.Config.IsoMnt); tmpErr != nil && err == nil {
+			config.Logger.Infof("Unmounting downloaded ISO")
+			if tmpErr := config.Mounter.Unmount(config.IsoMnt); tmpErr != nil && err == nil {
 				err = tmpErr
 			}
-			i.Config.Fs.RemoveAll(tmpDir)
+			config.Fs.RemoveAll(tmpDir)
 		}()
 	}
 
 	// Check device valid
 	if !disk.Exists() {
-		i.Config.Logger.Errorf("Disk %s does not exist", i.Config.Target)
-		return errors.New(fmt.Sprintf("Disk %s does not exist", i.Config.Target))
+		config.Logger.Errorf("Disk %s does not exist", config.Target)
+		return errors.New(fmt.Sprintf("Disk %s does not exist", config.Target))
 	}
 
 	// Check no-format flag
-	if i.Config.NoFormat {
+	if config.NoFormat {
 		// Check force flag against current device
 		err = newElemental.CheckNoFormat()
 		if err != nil {
@@ -122,18 +230,18 @@ func (i InstallAction) Run() (err error) {
 	}()
 
 	// create active file system image
-	err = newElemental.CreateFileSystemImage(i.Config.ActiveImage)
+	err = newElemental.CreateFileSystemImage(config.ActiveImage)
 	if err != nil {
 		return err
 	}
 
 	//mount file system image
-	err = newElemental.MountImage(&i.Config.ActiveImage, "rw")
+	err = newElemental.MountImage(&config.ActiveImage, "rw")
 	if err != nil {
 		return err
 	}
 	defer func() {
-		if tmpErr := newElemental.UnmountImage(&i.Config.ActiveImage); tmpErr != nil && err == nil {
+		if tmpErr := newElemental.UnmountImage(&config.ActiveImage); tmpErr != nil && err == nil {
 			err = tmpErr
 		}
 	}()
@@ -149,7 +257,7 @@ func (i InstallAction) Run() (err error) {
 		return err
 	}
 	// install grub
-	grub := utils.NewGrub(i.Config)
+	grub := utils.NewGrub(config)
 	err = grub.Install()
 	if err != nil {
 		return err
@@ -157,13 +265,13 @@ func (i InstallAction) Run() (err error) {
 	// Relabel SELinux
 	_ = newElemental.SelinuxRelabel(cnst.ActiveDir, false)
 
-	err = i.installHook(cnst.AfterInstallChrootHook, true)
+	err = installHook(config, cnst.AfterInstallChrootHook, true)
 	if err != nil {
 		return err
 	}
 
 	// Unmount active image
-	err = newElemental.UnmountImage(&i.Config.ActiveImage)
+	err = newElemental.UnmountImage(&config.ActiveImage)
 	if err != nil {
 		return err
 	}
@@ -178,7 +286,7 @@ func (i InstallAction) Run() (err error) {
 		return err
 	}
 
-	err = i.installHook(cnst.AfterInstallHook, false)
+	err = installHook(config, cnst.AfterInstallHook, false)
 	if err != nil {
 		return err
 	}
@@ -190,12 +298,12 @@ func (i InstallAction) Run() (err error) {
 	}
 
 	// Reboot, poweroff or nothing
-	if i.Config.Reboot {
-		i.Config.Logger.Infof("Rebooting in 5 seconds")
-		return utils.Reboot(i.Config.Runner, 5)
-	} else if i.Config.PowerOff {
-		i.Config.Logger.Infof("Shutting down in 5 seconds")
-		return utils.Shutdown(i.Config.Runner, 5)
+	if config.Reboot {
+		config.Logger.Infof("Rebooting in 5 seconds")
+		return utils.Reboot(config.Runner, 5)
+	} else if config.PowerOff {
+		config.Logger.Infof("Shutting down in 5 seconds")
+		return utils.Shutdown(config.Runner, 5)
 	}
 	return err
 }

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -18,13 +18,13 @@ package v1
 
 import (
 	"errors"
-	"fmt"
 	dockTypes "github.com/docker/docker/api/types"
 	"github.com/mudler/luet/pkg/api/core/context"
 	cnst "github.com/rancher-sandbox/elemental/pkg/constants"
 	"github.com/spf13/afero"
 	"k8s.io/mount-utils"
 	"net/http"
+	"path/filepath"
 )
 
 const (
@@ -132,7 +132,7 @@ func NewRunConfig(opts ...RunConfigOptions) *RunConfig {
 	r.ActiveImage = Image{
 		Label:      cnst.ActiveLabel,
 		Size:       cnst.ImgSize,
-		File:       fmt.Sprintf("%s/cOS/%s", cnst.StateDir, cnst.ActiveImgFile),
+		File:       filepath.Join(cnst.StateDir, "cOS", cnst.ActiveImgFile),
 		FS:         cnst.LinuxImgFs,
 		RootTree:   cnst.IsoBaseTree,
 		MountPoint: cnst.ActiveDir,

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -192,7 +192,7 @@ type RunConfig struct {
 	Strict           bool   `yaml:"strict,omitempty" mapstructure:"strict"`
 	Iso              string `yaml:"iso,omitempty" mapstructure:"iso"`
 	DockerImg        string `yaml:"docker-image,omitempty" mapstructure:"docker-image"`
-	Cosign           bool   `yaml:"no-cosign,omitempty" mapstructure:"no-cosign"`
+	Cosign           bool   `yaml:"cosign,omitempty" mapstructure:"cosign"`
 	CosignPubKey     string `yaml:"cosign-key,omitempty" mapstructure:"cosign-key"`
 	NoVerify         bool   `yaml:"no-verify,omitempty" mapstructure:"no-verify"`
 	CloudInitPaths   string `yaml:"CLOUD_INIT_PATHS,omitempty" mapstructure:"CLOUD_INIT_PATHS"`

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -137,7 +137,21 @@ func NewRunConfig(opts ...RunConfigOptions) *RunConfig {
 		r.SystemLabel = cnst.SystemLabel
 	}
 
-	//TODO add partition labels...
+	if r.RecoveryLabel == "" {
+		r.RecoveryLabel = cnst.RecoveryLabel
+	}
+
+	if r.PersistentLabel == "" {
+		r.PersistentLabel = cnst.PersistentLabel
+	}
+
+	if r.OEMLabel == "" {
+		r.OEMLabel = cnst.OEMLabel
+	}
+
+	if r.StateLabel == "" {
+		r.StateLabel = cnst.StateLabel
+	}
 
 	r.Partitions = PartitionList{}
 

--- a/pkg/types/v1/config_test.go
+++ b/pkg/types/v1/config_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1_test
 
 import (
-	"fmt"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/rancher-sandbox/elemental/pkg/constants"
@@ -29,61 +28,6 @@ import (
 
 var _ = Describe("Types", Label("types", "config"), func() {
 	Describe("Config", func() {
-		Describe("DigestSetup", Label("parttable", "bootflag"), func() {
-			Describe("On efi system", Label("efi"), func() {
-				It(fmt.Sprintf("sets part to %s and boot to %s", v1.GPT, v1.ESP), func() {
-					fs := afero.NewMemMapFs()
-					_, _ = fs.Create(constants.EfiDevice)
-
-					c := v1.NewRunConfig(
-						v1.WithFs(fs),
-						v1.WithMounter(&mount.FakeMounter{}),
-						v1.WithRunner(&v1mock.FakeRunner{}),
-						v1.WithSyscall(&v1mock.FakeSyscall{}))
-					c.DigestSetup()
-					Expect(c.PartTable).To(Equal(v1.GPT))
-					Expect(c.BootFlag).To(Equal(v1.ESP))
-				})
-			})
-			Describe("On --force-efi flag", func() {
-				It(fmt.Sprintf("sets part to %s and boot to %s", v1.GPT, v1.ESP), func() {
-					c := v1.NewRunConfig(
-						v1.WithFs(afero.NewMemMapFs()),
-						v1.WithMounter(&mount.FakeMounter{}),
-						v1.WithRunner(&v1mock.FakeRunner{}),
-						v1.WithSyscall(&v1mock.FakeSyscall{}))
-					c.ForceEfi = true
-					c.DigestSetup()
-					Expect(c.PartTable).To(Equal(v1.GPT))
-					Expect(c.BootFlag).To(Equal(v1.ESP))
-				})
-			})
-			Describe("On --force-gpt flag", func() {
-				It(fmt.Sprintf("sets part to %s and boot to %s", v1.GPT, v1.BIOS), func() {
-					c := v1.NewRunConfig(
-						v1.WithFs(afero.NewMemMapFs()),
-						v1.WithMounter(&mount.FakeMounter{}),
-						v1.WithRunner(&v1mock.FakeRunner{}),
-						v1.WithSyscall(&v1mock.FakeSyscall{}))
-					c.ForceGpt = true
-					c.DigestSetup()
-					Expect(c.PartTable).To(Equal(v1.GPT))
-					Expect(c.BootFlag).To(Equal(v1.BIOS))
-				})
-			})
-			Describe("On default values", func() {
-				It(fmt.Sprintf("sets part to %s and boot to %s", v1.MSDOS, v1.BOOT), func() {
-					c := v1.NewRunConfig(
-						v1.WithFs(afero.NewMemMapFs()),
-						v1.WithMounter(&mount.FakeMounter{}),
-						v1.WithRunner(&v1mock.FakeRunner{}),
-						v1.WithSyscall(&v1mock.FakeSyscall{}))
-					c.DigestSetup()
-					Expect(c.PartTable).To(Equal(v1.MSDOS))
-					Expect(c.BootFlag).To(Equal(v1.BOOT))
-				})
-			})
-		})
 		Describe("ConfigOptions", func() {
 			It("Sets the proper interfaces in the config struct", func() {
 				fs := afero.NewMemMapFs()
@@ -135,15 +79,22 @@ var _ = Describe("Types", Label("types", "config"), func() {
 					v1.WithMounter(&mount.FakeMounter{}),
 					v1.WithRunner(&v1mock.FakeRunner{}),
 					v1.WithSyscall(&v1mock.FakeSyscall{}))
-				c.DigestSetup()
+				c.Partitions = []*v1.Partition{
+					&v1.Partition{
+						Label:      constants.StateLabel,
+						Size:       constants.StateSize,
+						Name:       constants.StatePartName,
+						FS:         constants.LinuxFs,
+						MountPoint: constants.StateDir,
+						Flags:      []string{},
+					},
+				}
 			})
 			It("Finds a partition given a partition label", func() {
-				c.DigestSetup()
 				part := c.Partitions.GetByName(constants.StatePartName)
 				Expect(part.Name).To(Equal(constants.StatePartName))
 			})
 			It("Returns nil if requested partition label is not found", func() {
-				c.DigestSetup()
 				Expect(c.Partitions.GetByName("whatever")).To(BeNil())
 			})
 		})


### PR DESCRIPTION
With this refactor the install command can be expressed in three simple steps:
    
1. Basic checks on flags and config as part of 'cmd/install.go'
2. Setup install details from a rough RunConfig initiated and run all logic to determine partitions, images, etc. according to the install action specifics.
3. Run installation after installation setup is done