### PR TITLE
Fix chroot Prepare and Close methods

### DIFF
--- a/pkg/action/common.go
+++ b/pkg/action/common.go
@@ -24,7 +24,9 @@ import (
 	"github.com/rancher-sandbox/elemental/pkg/utils"
 )
 
-func actionHook(config *v1.RunConfig, hook string) error {
+// ActionHook is RunStage wrapper that only adds logic to ignore errors
+// in case v1.RunConfig.Strict is set to false
+func ActionHook(config *v1.RunConfig, hook string) error {
 	config.Logger.Infof("Running %s hook", hook)
 	err := utils.RunStage(hook, config)
 	if !config.Strict {
@@ -33,7 +35,8 @@ func actionHook(config *v1.RunConfig, hook string) error {
 	return err
 }
 
-func actionChrootHook(config *v1.RunConfig, hook string, chrootDir string, bindMounts map[string]string) (err error) {
+// ActionChrootHook executes ActionHook inside a chroot environment
+func ActionChrootHook(config *v1.RunConfig, hook string, chrootDir string, bindMounts map[string]string) (err error) {
 	chroot := utils.NewChroot(chrootDir, config)
 	chroot.SetExtraMounts(bindMounts)
 	err = chroot.Prepare()
@@ -45,10 +48,11 @@ func actionChrootHook(config *v1.RunConfig, hook string, chrootDir string, bindM
 			err = tmpErr
 		}
 	}()
-	return actionHook(config, hook)
+	return ActionHook(config, hook)
 }
 
-func setupLuet(config *v1.RunConfig) {
+// SetupLuet sets the Luet object with the appropriate plugins
+func SetupLuet(config *v1.RunConfig) {
 	if config.DockerImg != "" {
 		plugins := []string{}
 		if !config.NoVerify {
@@ -56,4 +60,84 @@ func setupLuet(config *v1.RunConfig) {
 		}
 		config.Luet = v1.NewLuet(config.Logger, context.NewContext(), &dockTypes.AuthConfig{}, plugins...)
 	}
+}
+
+// SetPartitionsFromScratch initiates all defaults partitions in order is they
+// would be on a fresh installation. It does not run any kind of block device analysis
+// it only populates partitions from defaults or configurations.
+func SetPartitionsFromScratch(config *v1.RunConfig) {
+	_, err := config.Fs.Stat(constants.EfiDevice)
+	efiExists := err == nil
+	statePartFlags := []string{}
+	var part *v1.Partition
+
+	if config.ForceEfi || efiExists {
+		config.PartTable = v1.GPT
+		config.BootFlag = v1.ESP
+		part = &v1.Partition{
+			Label:      constants.EfiLabel,
+			Size:       constants.EfiSize,
+			Name:       constants.EfiPartName,
+			FS:         constants.EfiFs,
+			MountPoint: constants.EfiDir,
+			Flags:      []string{v1.ESP},
+		}
+		config.Partitions = append(config.Partitions, part)
+	} else if config.ForceGpt {
+		config.PartTable = v1.GPT
+		config.BootFlag = v1.BIOS
+		part = &v1.Partition{
+			Label:      "",
+			Size:       constants.BiosSize,
+			Name:       constants.BiosPartName,
+			FS:         "",
+			MountPoint: "",
+			Flags:      []string{v1.BIOS},
+		}
+		config.Partitions = append(config.Partitions, part)
+	} else {
+		config.PartTable = v1.MSDOS
+		config.BootFlag = v1.BOOT
+		statePartFlags = []string{v1.BOOT}
+	}
+
+	part = &v1.Partition{
+		Label:      config.OEMLabel,
+		Size:       constants.OEMSize,
+		Name:       constants.OEMPartName,
+		FS:         constants.LinuxFs,
+		MountPoint: constants.OEMDir,
+		Flags:      []string{},
+	}
+	config.Partitions = append(config.Partitions, part)
+
+	part = &v1.Partition{
+		Label:      config.StateLabel,
+		Size:       constants.StateSize,
+		Name:       constants.StatePartName,
+		FS:         constants.LinuxFs,
+		MountPoint: constants.StateDir,
+		Flags:      statePartFlags,
+	}
+	config.Partitions = append(config.Partitions, part)
+
+	part = &v1.Partition{
+		Label:      config.RecoveryLabel,
+		Size:       constants.RecoverySize,
+		Name:       constants.RecoveryPartName,
+		FS:         constants.LinuxFs,
+		MountPoint: constants.RecoveryDir,
+		Flags:      []string{},
+	}
+	config.Partitions = append(config.Partitions, part)
+
+	part = &v1.Partition{
+		Label:      config.PersistentLabel,
+		Size:       constants.PersistentSize,
+		Name:       constants.PersistentPartName,
+		FS:         constants.LinuxFs,
+		MountPoint: constants.PersistentDir,
+		Flags:      []string{},
+	}
+	config.Partitions = append(config.Partitions, part)
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -109,6 +109,7 @@ var _ = Describe("Utils", Label("utils"), func() {
 			It("should return error if preparing twice before closing", func() {
 				Expect(chroot.Prepare()).To(BeNil())
 				defer chroot.Close()
+				Expect(syscall.WasChrootCalledWith("/whatever")).To(BeTrue())
 				Expect(chroot.Prepare()).NotTo(BeNil())
 				Expect(chroot.Close()).To(BeNil())
 				Expect(chroot.Prepare()).To(BeNil())


### PR DESCRIPTION
This fixes Chroot.Prepare and Chroot.Close methods so they fully set and unset the chroot environment.

This enables to run chrooted hooks stages without having to actually call the elemental or yip from the chroot.

In addition this PR also include a little change to make configuration methods public.

