### PR TITLE
Add a Chroot.RunCallback method

### DIFF
--- a/pkg/action/common.go
+++ b/pkg/action/common.go
@@ -39,16 +39,10 @@ func ActionHook(config *v1.RunConfig, hook string) error {
 func ActionChrootHook(config *v1.RunConfig, hook string, chrootDir string, bindMounts map[string]string) (err error) {
 	chroot := utils.NewChroot(chrootDir, config)
 	chroot.SetExtraMounts(bindMounts)
-	err = chroot.Prepare()
-	if err != nil {
-		return err
+	callback := func() error {
+		return ActionHook(config, hook)
 	}
-	defer func() {
-		if tmpErr := chroot.Close(); tmpErr != nil && err == nil {
-			err = tmpErr
-		}
-	}()
-	return ActionHook(config, hook)
+	return chroot.RunCallback(callback)
 }
 
 // SetupLuet sets the Luet object with the appropriate plugins

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -97,6 +97,17 @@ var _ = Describe("Utils", Label("utils"), func() {
 				_, err = chroot.Run("chroot-another-command")
 				Expect(err).To(BeNil())
 			})
+			It("runs a callback in a custom chroot", func() {
+				called := false
+				callback := func() error {
+					called = true
+					return nil
+				}
+				err := chroot.RunCallback(callback)
+				Expect(err).To(BeNil())
+				Expect(syscall.WasChrootCalledWith("/whatever")).To(BeTrue())
+				Expect(called).To(BeTrue())
+			})
 		})
 		Describe("on failure", func() {
 			It("should return error if chroot-command fails", func() {
@@ -105,6 +116,17 @@ var _ = Describe("Utils", Label("utils"), func() {
 				_, err := chroot.Run("chroot-command")
 				Expect(err).NotTo(BeNil())
 				Expect(syscall.WasChrootCalledWith("/whatever")).To(BeTrue())
+			})
+			It("should return error if callback fails", func() {
+				called := false
+				callback := func() error {
+					called = true
+					return errors.New("Callback error")
+				}
+				err := chroot.RunCallback(callback)
+				Expect(err).NotTo(BeNil())
+				Expect(syscall.WasChrootCalledWith("/whatever")).To(BeTrue())
+				Expect(called).To(BeTrue())
 			})
 			It("should return error if preparing twice before closing", func() {
 				Expect(chroot.Prepare()).To(BeNil())


### PR DESCRIPTION
This commit add the RunCallback method on Chroot object.

This also fixes the action.ActionChrootHook.

Signed-off-by: David Cassany <dcassany@suse.com>