### PR TITLE
Refactor CopyActive method to turn tin CopyImage

### DIFF
--- a/pkg/types/v1/common.go
+++ b/pkg/types/v1/common.go
@@ -16,8 +16,8 @@ limitations under the License.
 
 package v1
 
-// InstallUpgradeSource represents the source from where the installation or upgrade is being done for easy identification
-type InstallUpgradeSource struct {
+// ImageSource represents the source from where an image is created for easy identification
+type ImageSource struct {
 	Source    string
 	IsDir     bool
 	IsChannel bool

--- a/pkg/types/v1/common_test.go
+++ b/pkg/types/v1/common_test.go
@@ -25,7 +25,7 @@ import (
 var _ = Describe("Types", Label("types", "common"), func() {
 	FDescribe("Common", func() {
 		It("Can create it?? Like what is expected to be test of a simple struct?", func() {
-			o := v1.InstallUpgradeSource{}
+			o := v1.ImageSource{}
 			Expect(o).ToNot(BeNil())
 		})
 	})

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -241,12 +241,11 @@ type PartitionList []*Partition
 
 // Image struct represents a file system image with its commonly configurable values, size in MiB
 type Image struct {
-	File  string
-	Label string
-	Size  uint
-	FS    string
-	// Path of the root tree
-	RootTree   string
+	File       string
+	Label      string
+	Size       uint
+	FS         string
+	Source     ImageSource
 	MountPoint string
 	LoopDevice string
 }


### PR DESCRIPTION
This commit refactors CopyActive method to become CopyImage, where
the image being copied is passed as a parameter. This makes it easy to
reuse it other contexts beyond copying the active image.

In the same scope the refactor includes the image source struct as part
of the v1.Image struct. So all the details of the image are
self contained.

Signed-off-by: David Cassany <dcassany@suse.com>