### PR TITLE
Fix luet not having a logger and changing context

### DIFF
--- a/pkg/types/v1/luet.go
+++ b/pkg/types/v1/luet.go
@@ -41,6 +41,7 @@ type Luet struct {
 	context           *context.Context
 	auth              *dockTypes.AuthConfig
 	fs                afero.Fs
+	plugins           []string
 	VerifyImageUnpack bool
 }
 
@@ -49,13 +50,7 @@ type LuetOptions func(l *Luet) error
 func WithLuetPlugins(plugins ...string) func(r *Luet) error {
 	return func(l *Luet) error {
 		if len(plugins) != 0 {
-			bus.Manager.Initialize(l.context, plugins...)
-			if l.log != nil {
-				l.log.Infof("Enabled plugins:")
-				for _, p := range bus.Manager.Plugins {
-					l.log.Infof("* %s (at %s)", p.Name, p.Executable)
-				}
-			}
+			l.plugins = plugins
 		}
 		return nil
 	}
@@ -118,6 +113,14 @@ func NewLuet(opts ...LuetOptions) *Luet {
 
 	if luet.auth == nil {
 		luet.auth = &dockTypes.AuthConfig{}
+	}
+
+	if len(luet.plugins) > 0 {
+		bus.Manager.Initialize(luet.context, luet.plugins...)
+		luet.log.Infof("Enabled plugins:")
+		for _, p := range bus.Manager.Plugins {
+			luet.log.Infof("* %s (at %s)", p.Name, p.Executable)
+		}
 	}
 
 	return luet

--- a/pkg/types/v1/luet_test.go
+++ b/pkg/types/v1/luet_test.go
@@ -125,7 +125,8 @@ var _ = Describe("Types", Label("luet", "types"), func() {
 				memLog := bytes.Buffer{}
 				log := v1.NewBufferLogger(&memLog)
 				log.SetLevel(logrus.DebugLevel)
-				v1.NewLuet(v1.WithLuetLogger(log))
+				fs := afero.NewMemMapFs()
+				v1.NewLuet(v1.WithLuetFs(fs), v1.WithLuetLogger(log))
 				// Check if the debug stuff was logged to the buffer
 				Expect(memLog.String()).To(ContainSubstring("Creating empty luet config"))
 			})


### PR DESCRIPTION
Problem 2fold, first its that if we changed context, the bus.manager
could get lost as we registered the plugins under one context but then
changed contexts. The second is that we need to set a luet logger now as
we create an empty context. as a side effect of that, it means that we
cna control the log level of luet actions, so we could even silence it
adn only show errors. Currently it sets at the same level as our logger

Signed-off-by: Itxaka <igarcia@suse.com>