### PR TITLE
codecov: split cmd from pkg coverage

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,2 +1,15 @@
 github_checks:
   annotations: false
+coverage:
+  status:
+    project:
+      default: false
+      cli:
+        paths:
+         - "cmd/"
+        target: 75%
+        informational: true
+      pkg:
+        paths:
+          - "pkg/"
+        target: 75%


### PR DESCRIPTION
This will split the reported coverage of the pkg code from the cmd code,
making the cmd treshold much lower as its not only difficult to cover
but also difficult to test properly

Also sets the cmd to inform only mode, which means that if coverage goes below what is expected (75% currently) it doesnt fail the PR.

This also means we can now enforce the coverage test of the pkg to be required so we never go down in coverage unless...reasons.

Signed-off-by: Itxaka <igarcia@suse.com>