### PR TITLE
CLI fixups

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -33,6 +33,7 @@ var installCmd = &cobra.Command{
 	Short: "elemental installer",
 	Args:  cobra.MaximumNArgs(1),
 	PreRun: func(cmd *cobra.Command, args []string) {
+		viper.BindEnv("target", "ELEMENTAL_TARGET")
 		viper.BindPFlags(cmd.Flags())
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -118,7 +118,7 @@ type RunConfig struct {
 	Reboot           bool   `yaml:"reboot,omitempty" mapstructure:"reboot"`
 	PowerOff         bool   `yaml:"poweroff,omitempty" mapstructure:"poweroff"`
 	DirectoryUpgrade string // configured only via flag, no need to map it to any config
-	ChannelUpgrades  bool   `yaml:"CHANNEL_UPGRADES, omitempty" mapstructure:"CHANNEL_UPGRADES"`
+	ChannelUpgrades  bool   `yaml:"CHANNEL_UPGRADES,omitempty" mapstructure:"CHANNEL_UPGRADES"`
 	UpgradeImage     string `yaml:"UPGRADE_IMAGE,omitempty" mapstructure:"UPGRADE_IMAGE"`
 	RecoveryImage    string `yaml:"RECOVERY_IMAGE,omitempty" mapstructure:"RECOVERY_IMAGE"`
 	RecoveryUpgrade  bool   // configured only via flag, no need to map it to any config


### PR DESCRIPTION
This is a couple of small fixup. The target was not bind to any env as it is not exposed in any flags so it adds it on cmd install.

Aside I noticed the omitempty whitespace, which makes any marshaller to go crazy when trying to marshal config (which currently isn't still possible):

```
~/_git/elemental-cli main* ⇣ 27s                                                                                                                                                                                
❯ ./elemental install                                                                                                                                                                                           
panic: Unsupported flag " omitempty" in tag "CHANNEL_UPGRADES, omitempty" of type v1.RunConfig [recovered]                                                                                                      
        panic: Unsupported flag " omitempty" in tag "CHANNEL_UPGRADES, omitempty" of type v1.RunConfig  
                                                                                                        
goroutine 1 [running]:                                                                                  
gopkg.in/yaml%2ev2.handleErr(0xc00083fb18)                                                                                                                                                                      
        /home/ettore/go/pkg/mod/gopkg.in/yaml.v2@v2.4.0/yaml.go:249 +0x6d                                                                                                                                       
panic({0x11af040, 0xc000710990})                                                                                                                                                                                
        /usr/lib64/go/1.17/src/runtime/panic.go:1038 +0x215                                                                                                                                                     
gopkg.in/yaml%2ev2.(*encoder).structv(0xc0002e2580, {0x0, 0x0}, {0x13655a0, 0xc0001a4600, 0x270})                                                                                                               
        /home/ettore/go/pkg/mod/gopkg.in/yaml.v2@v2.4.0/encode.go:211 +0xe9                             
gopkg.in/yaml%2ev2.(*encoder).marshal(0x1138ba0, {0x0, 0x0}, {0x13655a0, 0xc0001a4600, 0x0})            
        /home/ettore/go/pkg/mod/gopkg.in/yaml.v2@v2.4.0/encode.go:160 +0x9a5                            
gopkg.in/yaml%2ev2.(*encoder).marshal(0xc0002e2580, {0x0, 0x0}, {0x1138ba0, 0xc0001a4600, 0x4})                                                                                                                 
        /home/ettore/go/pkg/mod/gopkg.in/yaml.v2@v2.4.0/encode.go:154 +0x7f9                                                                                                                                    
gopkg.in/yaml%2ev2.(*encoder).marshalDoc(0xc0002e2580, {0x0, 0x0}, {0x1138ba0, 0xc0001a4600, 0x11d47c0})                                                                                                        
        /home/ettore/go/pkg/mod/gopkg.in/yaml.v2@v2.4.0/encode.go:93 +0x125                                                                                                                                     
gopkg.in/yaml%2ev2.Marshal({0x1138ba0, 0xc0001a4600})                                                                                                                                                           
        /home/ettore/go/pkg/mod/gopkg.in/yaml.v2@v2.4.0/yaml.go:203 +0x37e                              
github.com/rancher-sandbox/elemental/cmd.glob..func4(0x1eb2e40, {0x1ef9210, 0x0, 0x0})                  
        /home/ettore/_git/elemental-cli/cmd/install.go:63 +0x1e5                                                                                                                                                
github.com/spf13/cobra.(*Command).execute(0x1eb2e40, {0x1ef9210, 0x0, 0x0})                                                                                                                                     
        /home/ettore/go/pkg/mod/github.com/spf13/cobra@v1.3.0/command.go:856 +0x60e                                                                                                                             
github.com/spf13/cobra.(*Command).ExecuteC(0x1eb3840)                                                                                                                                                           
        /home/ettore/go/pkg/mod/github.com/spf13/cobra@v1.3.0/command.go:974 +0x3bc                                                                                                                             
github.com/spf13/cobra.(*Command).Execute(...)                                                                                                                                                                  
        /home/ettore/go/pkg/mod/github.com/spf13/cobra@v1.3.0/command.go:902                            
github.com/rancher-sandbox/elemental/cmd.Execute()                                                      
        /home/ettore/_git/elemental-cli/cmd/root.go:34 +0x25                                                                                                                                                    
main.main()                                                                                                                                                                                                     
        /home/ettore/_git/elemental-cli/main.go:21 +0x17      
```