### PR TITLE
Increase shared flags between install, upgrade and reset

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -35,11 +35,15 @@ func addPowerFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolP("poweroff", "", false, "Shutdown the system after install")
 }
 
-// addSharedInstallUpgradeFlags add flags shared between install and upgrade
+// addSharedInstallUpgradeFlags add flags shared between install, upgrade and reset
 func addSharedInstallUpgradeFlags(cmd *cobra.Command) {
+	cmd.Flags().String("directory", "", "Use directory as source to install from")
 	cmd.Flags().StringP("docker-image", "d", "", "Install a specified container image")
 	cmd.Flags().BoolP("no-verify", "", false, "Disable mtree checksum verification (requires images manifests generated with mtree separately)")
 	cmd.Flags().BoolP("strict", "", false, "Enable strict check of hooks (They need to exit with 0)")
+
+	addCosignFlags(cmd)
+	addPowerFlags(cmd)
 }
 
 func validateCosignFlags(log v1.Logger) error {
@@ -53,7 +57,7 @@ func validateCosignFlags(log v1.Logger) error {
 	return nil
 }
 
-func validateUpgradeSourceFlags(log v1.Logger) error {
+func validateSourceFlags(log v1.Logger) error {
 	// docker-image and directory are mutually exclusive. Can't have your cake and eat it too.
 	if viper.GetString("docker-image") != "" && viper.GetString("directory") != "" {
 		msg := "flags docker-image and directory are mutually exclusive, please only set one of them"
@@ -70,21 +74,10 @@ func validatePowerFlags(log v1.Logger) error {
 }
 
 // validateUpgradeFlags is a helper call to check all the flags for the upgrade command
-func validateUpgradeFlags(log v1.Logger) error {
-	if err := validateUpgradeSourceFlags(log); err != nil {
+func validateInstallUpgradeFlags(log v1.Logger) error {
+	if err := validateSourceFlags(log); err != nil {
 		return err
 	}
-	if err := validateCosignFlags(log); err != nil {
-		return err
-	}
-	if err := validatePowerFlags(log); err != nil {
-		return err
-	}
-	return nil
-}
-
-// validateInstallFlags is a helper call to check all the flags for the upgrade command
-func validateInstallFlags(log v1.Logger) error {
 	if err := validateCosignFlags(log); err != nil {
 		return err
 	}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -48,7 +48,7 @@ var installCmd = &cobra.Command{
 			cfg.Logger.Errorf("Error reading config: %s\n", err)
 		}
 
-		if err := validateInstallFlags(cfg.Logger); err != nil {
+		if err := validateInstallUpgradeFlags(cfg.Logger); err != nil {
 			return err
 		}
 
@@ -89,6 +89,4 @@ func init() {
 	installCmd.Flags().BoolP("tty", "", false, "Add named tty to grub")
 	installCmd.Flags().BoolP("force", "", false, "Force install")
 	addSharedInstallUpgradeFlags(installCmd)
-	addCosignFlags(installCmd)
-	addPowerFlags(installCmd)
 }

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -62,4 +62,16 @@ var _ = Describe("Install", Label("install", "cmd", "systemctl"), func() {
 		Expect(buf.String()).To(ContainSubstring("Usage:"))
 		Expect(err.Error()).To(ContainSubstring("'cosign-key' requires 'cosign' option to be enabled"))
 	})
+	It("Errors out setting directory and docker-image at the same time", Label("flags"), func() {
+		buf := new(bytes.Buffer)
+		rootCmd.SetOut(buf)
+		rootCmd.SetErr(buf)
+		_, _, err := executeCommandC(rootCmd, "install", "--directory", "dir", "--docker-image", "image", "/dev/whatever")
+		// Restore cobra output
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		Expect(err).ToNot(BeNil())
+		Expect(buf.String()).To(ContainSubstring("Usage:"))
+		Expect(err.Error()).To(ContainSubstring("docker-image and directory are mutually exclusive"))
+	})
 })

--- a/cmd/reset_test.go
+++ b/cmd/reset_test.go
@@ -22,7 +22,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Install", Label("install", "cmd", "systemctl"), func() {
+var _ = Describe("Reset", Label("reset", "cmd", "systemctl"), func() {
 	It("Errors out setting reboot and poweroff at the same time", Label("flags"), func() {
 		buf := new(bytes.Buffer)
 		rootCmd.SetOut(buf)
@@ -32,8 +32,8 @@ var _ = Describe("Install", Label("install", "cmd", "systemctl"), func() {
 		rootCmd.SetOut(nil)
 		rootCmd.SetErr(nil)
 		Expect(err).ToNot(BeNil())
-		Expect(buf).To(ContainSubstring("Usage:"))
-		Expect(err.Error()).To(ContainSubstring("Invalid options"))
+		Expect(buf.String()).To(ContainSubstring("Usage:"))
+		Expect(err.Error()).To(ContainSubstring("'reboot' and 'poweroff' are mutually exclusive options"))
 	})
 	It("Errors out setting consign-key without setting cosign", Label("flags"), func() {
 		buf := new(bytes.Buffer)
@@ -44,7 +44,19 @@ var _ = Describe("Install", Label("install", "cmd", "systemctl"), func() {
 		rootCmd.SetOut(nil)
 		rootCmd.SetErr(nil)
 		Expect(err).ToNot(BeNil())
-		Expect(buf).To(ContainSubstring("Usage:"))
-		Expect(err.Error()).To(ContainSubstring("Invalid options"))
+		Expect(buf.String()).To(ContainSubstring("Usage:"))
+		Expect(err.Error()).To(ContainSubstring("'cosign-key' requires 'cosign' option to be enabled"))
+	})
+	It("Errors out setting directory and docker-image at the same time", Label("flags"), func() {
+		buf := new(bytes.Buffer)
+		rootCmd.SetOut(buf)
+		rootCmd.SetErr(buf)
+		_, _, err := executeCommandC(rootCmd, "reset", "--directory", "dir", "--docker-image", "image")
+		// Restore cobra output
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		Expect(err).ToNot(BeNil())
+		Expect(buf.String()).To(ContainSubstring("Usage:"))
+		Expect(err.Error()).To(ContainSubstring("docker-image and directory are mutually exclusive"))
 	})
 })

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -31,8 +31,6 @@ var upgradeCmd = &cobra.Command{
 	Short: "upgrade the system",
 	Args:  cobra.ExactArgs(0),
 	PreRun: func(cmd *cobra.Command, args []string) {
-		// We bind the --directory into the DirectoryUpgrade value directly to have a more explicit var in the config
-		viper.BindPFlag("DirectoryUpgrade", cmd.Flags().Lookup("directory"))
 		// We bind the --recovery flag into RecoveryUpgrade value to have a more explicit var in the config
 		viper.BindPFlag("RecoveryUpgrade", cmd.Flags().Lookup("recovery"))
 		// bind the rest of the flags into their direct values as they are mapped 1to1
@@ -52,11 +50,11 @@ var upgradeCmd = &cobra.Command{
 			cfg.Logger.Errorf("Error reading config: %s\n", err)
 		}
 
-		if err := validateUpgradeFlags(cfg.Logger); err != nil {
+		if err := validateInstallUpgradeFlags(cfg.Logger); err != nil {
 			return err
 		}
 
-		if cfg.DockerImg != "" || cfg.DirectoryUpgrade != "" {
+		if cfg.DockerImg != "" || cfg.Directory != "" {
 			// Force channel upgrades to be false, because as its loaded from the config files,
 			// it will probably always be set to true due to it being the default value
 			cfg.ChannelUpgrades = false
@@ -78,9 +76,6 @@ var upgradeCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(upgradeCmd)
-	upgradeCmd.Flags().String("directory", "", "Use directory as source to install from")
 	upgradeCmd.Flags().Bool("recovery", false, "Upgrade the recovery")
 	addSharedInstallUpgradeFlags(upgradeCmd)
-	addCosignFlags(upgradeCmd)
-	addPowerFlags(upgradeCmd)
 }

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -670,11 +670,11 @@ var _ = Describe("Actions", func() {
 				Expect(err).To(HaveOccurred())
 			})
 			It("Successfully upgrades from directory", Label("directory", "root"), func() {
-				config.DirectoryUpgrade, _ = os.MkdirTemp("", "elemental")
+				config.Directory, _ = os.MkdirTemp("", "elemental")
 				// Create the dir on real os as rsync works on the real os
-				defer os.RemoveAll(config.DirectoryUpgrade)
+				defer os.RemoveAll(config.Directory)
 				// create a random file on it
-				err := os.WriteFile(fmt.Sprintf("%s/file.file", config.DirectoryUpgrade), []byte("something"), os.ModePerm)
+				err := os.WriteFile(fmt.Sprintf("%s/file.file", config.Directory), []byte("something"), os.ModePerm)
 				Expect(err).ToNot(HaveOccurred())
 
 				upgrade = action.NewUpgradeAction(config)
@@ -936,11 +936,11 @@ var _ = Describe("Actions", func() {
 
 				})
 				It("Successfully upgrades recovery from directory", Label("directory", "root"), func() {
-					config.DirectoryUpgrade, _ = os.MkdirTemp("", "elemental")
+					config.Directory, _ = os.MkdirTemp("", "elemental")
 					// Create the dir on real os as rsync works on the real os
-					defer os.RemoveAll(config.DirectoryUpgrade)
+					defer os.RemoveAll(config.Directory)
 					// create a random file on it
-					_ = os.WriteFile(fmt.Sprintf("%s/file.file", config.DirectoryUpgrade), []byte("something"), os.ModePerm)
+					_ = os.WriteFile(fmt.Sprintf("%s/file.file", config.Directory), []byte("something"), os.ModePerm)
 
 					upgrade = action.NewUpgradeAction(config)
 					err := upgrade.Run()
@@ -1116,11 +1116,11 @@ var _ = Describe("Actions", func() {
 
 				})
 				It("Successfully upgrades recovery from directory", Label("directory", "root"), func() {
-					config.DirectoryUpgrade, _ = os.MkdirTemp("", "elemental")
+					config.Directory, _ = os.MkdirTemp("", "elemental")
 					// Create the dir on real os as rsync works on the real os
-					defer os.RemoveAll(config.DirectoryUpgrade)
+					defer os.RemoveAll(config.Directory)
 					// create a random file on it
-					_ = os.WriteFile(fmt.Sprintf("%s/file.file", config.DirectoryUpgrade), []byte("something"), os.ModePerm)
+					_ = os.WriteFile(fmt.Sprintf("%s/file.file", config.Directory), []byte("something"), os.ModePerm)
 
 					upgrade = action.NewUpgradeAction(config)
 					err := upgrade.Run()

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -463,9 +463,9 @@ func (u *UpgradeAction) getTargetAndSource() (string, v1.ImageSource) {
 			upgradeSource = v1.NewDockerSrc(u.Config.DockerImg)
 		}
 		// if directory -> upgrade from dir directly, ignores release_channel and uses the given directory
-		if u.Config.DirectoryUpgrade != "" {
-			u.Debug("Source is directory: %s", u.Config.DirectoryUpgrade)
-			upgradeSource = v1.NewDirSrc(u.Config.DirectoryUpgrade)
+		if u.Config.Directory != "" {
+			u.Debug("Source is directory: %s", u.Config.Directory)
+			upgradeSource = v1.NewDirSrc(u.Config.Directory)
 		}
 	}
 	u.Debug("Upgrade target: %s Upgrade source: %s", upgradeTarget, upgradeSource.Value())

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -92,40 +92,39 @@ func WithLuet(luet LuetInterface) func(r *RunConfig) error {
 // Basically everything needed to know for all operations in a running system, not related to builds
 type RunConfig struct {
 	// Can come from config, env var or flags
-	RecoveryLabel    string `yaml:"RECOVERY_LABEL,omitempty" mapstructure:"RECOVERY_LABEL"`
-	PersistentLabel  string `yaml:"PERSISTENT_LABEL,omitempty" mapstructure:"PERSISTENT_LABEL"`
-	StateLabel       string `yaml:"STATE_LABEL,omitempty" mapstructure:"STATE_LABEL"`
-	OEMLabel         string `yaml:"OEM_LABEL,omitempty" mapstructure:"OEM_LABEL"`
-	SystemLabel      string `yaml:"SYSTEM_LABEL,omitempty" mapstructure:"SYSTEM_LABEL"`
-	ActiveLabel      string `yaml:"ACTIVE_LABEL,omitempty" mapstructure:"ACTIVE_LABEL"`
-	PassiveLabel     string `yaml:"PASSIVE_LABEL,omitempty" mapstructure:"PASSIVE_LABEL"`
-	Target           string `yaml:"target,omitempty" mapstructure:"target"`
-	Source           string `yaml:"source,omitempty" mapstructure:"source"`
-	CloudInit        string `yaml:"cloud-init,omitempty" mapstructure:"cloud-init"`
-	ForceEfi         bool   `yaml:"force-efi,omitempty" mapstructure:"force-efi"`
-	ForceGpt         bool   `yaml:"force-gpt,omitempty" mapstructure:"force-gpt"`
-	PartLayout       string `yaml:"partition-layout,omitempty" mapstructure:"partition-layout"`
-	Tty              string `yaml:"tty,omitempty" mapstructure:"tty"`
-	NoFormat         bool   `yaml:"no-format,omitempty" mapstructure:"no-format"`
-	Force            bool   `yaml:"force,omitempty" mapstructure:"force"`
-	Strict           bool   `yaml:"strict,omitempty" mapstructure:"strict"`
-	Iso              string `yaml:"iso,omitempty" mapstructure:"iso"`
-	DockerImg        string `yaml:"docker-image,omitempty" mapstructure:"docker-image"`
-	Cosign           bool   `yaml:"cosign,omitempty" mapstructure:"cosign"`
-	CosignPubKey     string `yaml:"cosign-key,omitempty" mapstructure:"cosign-key"`
-	NoVerify         bool   `yaml:"no-verify,omitempty" mapstructure:"no-verify"`
-	CloudInitPaths   string `yaml:"CLOUD_INIT_PATHS,omitempty" mapstructure:"CLOUD_INIT_PATHS"`
-	GrubDefEntry     string `yaml:"GRUB_ENTRY_NAME,omitempty" mapstructure:"GRUB_ENTRY_NAME"`
-	Reboot           bool   `yaml:"reboot,omitempty" mapstructure:"reboot"`
-	PowerOff         bool   `yaml:"poweroff,omitempty" mapstructure:"poweroff"`
-	DirectoryUpgrade string // configured only via flag, no need to map it to any config
-	ChannelUpgrades  bool   `yaml:"CHANNEL_UPGRADES,omitempty" mapstructure:"CHANNEL_UPGRADES"`
-	UpgradeImage     string `yaml:"UPGRADE_IMAGE,omitempty" mapstructure:"UPGRADE_IMAGE"`
-	RecoveryImage    string `yaml:"RECOVERY_IMAGE,omitempty" mapstructure:"RECOVERY_IMAGE"`
-	RecoveryUpgrade  bool   // configured only via flag, no need to map it to any config
-	ImgSize          uint   `yaml:"DEFAULT_IMAGE_SIZE,omitempty" mapstructure:"DEFAULT_IMAGE_SIZE"`
-	Directory        string `yaml:"directory,omitempty" mapstructure:"directory"`
-	ResetPersistent  bool   `yaml:"reset-persistent,omitempty" mapstructure:"reset-persistent"`
+	RecoveryLabel   string `yaml:"RECOVERY_LABEL,omitempty" mapstructure:"RECOVERY_LABEL"`
+	PersistentLabel string `yaml:"PERSISTENT_LABEL,omitempty" mapstructure:"PERSISTENT_LABEL"`
+	StateLabel      string `yaml:"STATE_LABEL,omitempty" mapstructure:"STATE_LABEL"`
+	OEMLabel        string `yaml:"OEM_LABEL,omitempty" mapstructure:"OEM_LABEL"`
+	SystemLabel     string `yaml:"SYSTEM_LABEL,omitempty" mapstructure:"SYSTEM_LABEL"`
+	ActiveLabel     string `yaml:"ACTIVE_LABEL,omitempty" mapstructure:"ACTIVE_LABEL"`
+	PassiveLabel    string `yaml:"PASSIVE_LABEL,omitempty" mapstructure:"PASSIVE_LABEL"`
+	Target          string `yaml:"target,omitempty" mapstructure:"target"`
+	Source          string `yaml:"source,omitempty" mapstructure:"source"`
+	CloudInit       string `yaml:"cloud-init,omitempty" mapstructure:"cloud-init"`
+	ForceEfi        bool   `yaml:"force-efi,omitempty" mapstructure:"force-efi"`
+	ForceGpt        bool   `yaml:"force-gpt,omitempty" mapstructure:"force-gpt"`
+	PartLayout      string `yaml:"partition-layout,omitempty" mapstructure:"partition-layout"`
+	Tty             string `yaml:"tty,omitempty" mapstructure:"tty"`
+	NoFormat        bool   `yaml:"no-format,omitempty" mapstructure:"no-format"`
+	Force           bool   `yaml:"force,omitempty" mapstructure:"force"`
+	Strict          bool   `yaml:"strict,omitempty" mapstructure:"strict"`
+	Iso             string `yaml:"iso,omitempty" mapstructure:"iso"`
+	DockerImg       string `yaml:"docker-image,omitempty" mapstructure:"docker-image"`
+	Cosign          bool   `yaml:"cosign,omitempty" mapstructure:"cosign"`
+	CosignPubKey    string `yaml:"cosign-key,omitempty" mapstructure:"cosign-key"`
+	NoVerify        bool   `yaml:"no-verify,omitempty" mapstructure:"no-verify"`
+	CloudInitPaths  string `yaml:"CLOUD_INIT_PATHS,omitempty" mapstructure:"CLOUD_INIT_PATHS"`
+	GrubDefEntry    string `yaml:"GRUB_ENTRY_NAME,omitempty" mapstructure:"GRUB_ENTRY_NAME"`
+	Reboot          bool   `yaml:"reboot,omitempty" mapstructure:"reboot"`
+	PowerOff        bool   `yaml:"poweroff,omitempty" mapstructure:"poweroff"`
+	ChannelUpgrades bool   `yaml:"CHANNEL_UPGRADES,omitempty" mapstructure:"CHANNEL_UPGRADES"`
+	UpgradeImage    string `yaml:"UPGRADE_IMAGE,omitempty" mapstructure:"UPGRADE_IMAGE"`
+	RecoveryImage   string `yaml:"RECOVERY_IMAGE,omitempty" mapstructure:"RECOVERY_IMAGE"`
+	RecoveryUpgrade bool   // configured only via flag, no need to map it to any config
+	ImgSize         uint   `yaml:"DEFAULT_IMAGE_SIZE,omitempty" mapstructure:"DEFAULT_IMAGE_SIZE"`
+	Directory       string `yaml:"directory,omitempty" mapstructure:"directory"`
+	ResetPersistent bool   `yaml:"reset-persistent,omitempty" mapstructure:"reset-persistent"`
 	// Internally used to track stuff around
 	PartTable string
 	BootFlag  string


### PR DESCRIPTION
This ensures upgrade, reset and install share `--directory`, `--docker-image` and related flags.

Signed-off-by: David Cassany <dcassany@suse.com>