### PR TITLE
Allow to set GIT_TAG and GIT_COMMIT when calling make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-GIT_COMMIT = $(shell git rev-parse HEAD)
-GIT_TAG = $(shell git describe --tags 2>/dev/null || echo "v0.0.1" )
+GIT_COMMIT ?= $(shell git rev-parse HEAD)
+GIT_TAG ?= $(shell git describe --tags 2>/dev/null || echo "v0.0.1" )
 
 PKG        := ./...
 LDFLAGS    := -w -s


### PR DESCRIPTION
This enables rpm builds for a source tarball, where .git isn't present

Signed-off-by: Klaus Kämpf <kkaempf@suse.de>