### PR TITLE
runstage: create cloudinitpaths before passing them to yip runner

### DIFF
--- a/pkg/utils/runstage.go
+++ b/pkg/utils/runstage.go
@@ -18,6 +18,7 @@ package utils
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -66,6 +67,12 @@ func RunStage(stage string, cfg *v1.RunConfig) error {
 		if err != nil {
 			errors = multierror.Append(errors, err)
 		}
+	}
+
+	// Blindly try to create the dir that we are gonna pass to yip to avoid yip trying to unmarshal a non.existing dir
+	for _, path := range CloudInitPaths {
+		// We dont care if it fails to create, thats a different issue altogether
+		_ = cfg.Fs.MkdirAll(path, os.ModeDir)
 	}
 
 	// Run all stages for each of the default cloud config paths + extra cloud config paths


### PR DESCRIPTION
So we avoid passing non.existing paths, which yip will try to parse as
a cloud-init config string and produce unmarshall error which are
indistinguishable from real unmarshall errors

Signed-off-by: Itxaka <igarcia@suse.com>