### PR TITLE
Fix variables initialization in tests

### DIFF
--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -80,6 +80,8 @@ var _ = Describe("Actions", func() {
 	Describe("Reset Setup", Label("resetsetup"), func() {
 		var lsblkTmpl, bootedFrom, blkidOut, label, cmdFail string
 		BeforeEach(func() {
+			label = ""
+			cmdFail = ""
 			fs.Create(constants.EfiDevice)
 			bootedFrom = constants.RecoverySquashFile
 			blkidOut = "/dev/device1"
@@ -142,6 +144,7 @@ var _ = Describe("Actions", func() {
 		var cmdFail, activeTree, activeMount string
 		var err error
 		BeforeEach(func() {
+			cmdFail = ""
 			activeTree, err = os.MkdirTemp("", "elemental")
 			Expect(err).To(BeNil())
 			activeMount, err = os.MkdirTemp("", "elemental")
@@ -201,7 +204,7 @@ var _ = Describe("Actions", func() {
 			config.ResetPersistent = true
 			Expect(action.ResetRun(config)).To(BeNil())
 		})
-		It("Successfully resets on squashfs recovery", func() {
+		It("Successfully resets on squashfs recovery", Label("squashfs"), func() {
 			config.PowerOff = true
 			config.Images.GetActive().Source = v1.NewDirSrc(activeTree)
 			Expect(action.ResetRun(config)).To(BeNil())
@@ -210,7 +213,7 @@ var _ = Describe("Actions", func() {
 			cloudInit.Error = true
 			Expect(action.ResetRun(config)).To(BeNil())
 		})
-		It("Successfully resets from a docker image", func() {
+		It("Successfully resets from a docker image", Label("docker"), func() {
 			config.Images.GetActive().Source = v1.NewDockerSrc("my/image:latest")
 			luet := v1mock.NewFakeLuet()
 			config.Luet = luet

--- a/pkg/elemental/elemental_test.go
+++ b/pkg/elemental/elemental_test.go
@@ -437,6 +437,7 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 			Expect(err).To(BeNil())
 			destDir, err := os.MkdirTemp("", "elemental")
 			Expect(err).To(BeNil())
+			cmdFail = ""
 			el = elemental.NewElemental(config)
 			img = &v1.Image{
 				FS:         "ext2",

--- a/pkg/partitioner/partitioner_test.go
+++ b/pkg/partitioner/partitioner_test.go
@@ -199,19 +199,19 @@ var _ = Describe("Partitioner", Label("disk", "partition", "partitioner"), func(
 		var dev *part.Disk
 		var cmds [][]string
 		var printCmd []string
-		It("Creates a default disk", func() {
-			dev = part.NewDisk("/some/device")
-		})
 		BeforeEach(func() {
 			dev = part.NewDisk("/some/device", part.WithRunner(runner), part.WithFS(afero.NewMemMapFs()))
 			printCmd = []string{
 				"parted", "--script", "--machine", "--", "/some/device",
 				"unit", "s", "print",
 			}
+			cmds = [][]string{printCmd}
+		})
+		It("Creates a default disk", func() {
+			dev = part.NewDisk("/some/device")
 		})
 		Describe("Load data without changes", func() {
 			BeforeEach(func() {
-				cmds = [][]string{printCmd}
 				runner.ReturnValue = []byte(printOutput)
 			})
 			It("Loads disk layout data", func() {

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -59,7 +59,6 @@ var _ = Describe("Utils", Label("utils"), func() {
 	var client *v1mock.FakeHTTPClient
 	var mounter *v1mock.ErrorMounter
 	var fs afero.Fs
-	var memLog *bytes.Buffer
 
 	BeforeEach(func() {
 		runner = v1mock.NewFakeRunner()
@@ -621,6 +620,7 @@ var _ = Describe("Utils", Label("utils"), func() {
 		})
 	})
 	Describe("RunStage", Label("RunStage"), func() {
+		var memLog *bytes.Buffer
 		BeforeEach(func() {
 			// Use a different config with a buffer for logger, so we can check the output
 			// We also use the real fs

--- a/tests/mocks/luet_mock.go
+++ b/tests/mocks/luet_mock.go
@@ -30,10 +30,7 @@ type FakeLuet struct {
 }
 
 func NewFakeLuet() *FakeLuet {
-	return &FakeLuet{
-		OnUnpackError: false,
-		unpackCalled:  false,
-	}
+	return &FakeLuet{}
 }
 
 func (l *FakeLuet) Unpack(target string, image string, local bool) error {


### PR DESCRIPTION
This commit makes explicit initialization of the variables declared
in `Describe` sections of test specs. I realized that non initialized
variables in `BeforeEach` or explicitly in each tests might be shared
across tests causing erratic behaviors depending on how concurrency
is applied over the suite.

Signed-off-by: David Cassany <dcassany@suse.com>