### PR TITLE
Add checkRoot helper for cmd and add it to root commands

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -17,20 +17,14 @@ limitations under the License.
 package cmd
 
 import (
-	"bytes"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"errors"
+	"os"
 )
 
-var _ = Describe("Upgrade", Label("upgrade", "cmd", "systemctl", "root"), func() {
-	It("Returns error if both --docker-image and --directory flags are used", Label("flags"), func() {
-		buf := new(bytes.Buffer)
-		rootCmd.SetOut(buf)
-		rootCmd.SetErr(buf)
-		_, _, err := executeCommandC(rootCmd, "upgrade", "--docker-image", "img", "--directory", "/tmp")
-		// Restore cobra output
-		rootCmd.SetOut(nil)
-		rootCmd.SetErr(nil)
-		Expect(err).To(HaveOccurred())
-	})
-})
+// CheckRoot is a helper to return on PreRunE, so we can add it to commands that require root
+func CheckRoot() error {
+	if os.Geteuid() != 0 {
+		return errors.New("this command requires root privileges")
+	}
+	return nil
+}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -32,9 +32,10 @@ var installCmd = &cobra.Command{
 	Use:   "install DEVICE",
 	Short: "elemental installer",
 	Args:  cobra.MaximumNArgs(1),
-	PreRun: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		_ = viper.BindEnv("target", "ELEMENTAL_TARGET")
 		_ = viper.BindPFlags(cmd.Flags())
+		return CheckRoot()
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		path, err := exec.LookPath("mount")

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -23,7 +23,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Install", Label("install", "cmd", "systemctl"), func() {
+var _ = Describe("Install", Label("install", "cmd", "systemctl", "root"), func() {
 	It("outputs usage if no DEVICE param", Label("args"), func() {
 		buf := new(bytes.Buffer)
 		rootCmd.SetOut(buf)

--- a/cmd/pull-image.go
+++ b/cmd/pull-image.go
@@ -29,11 +29,12 @@ import (
 
 // pullImage represents the pull-image command
 var pullImage = &cobra.Command{
-	Use:           "pull-image IMAGE DESTINATION",
-	Short:         "elemental pull-image",
-	Args:          cobra.ExactArgs(2),
-	SilenceUsage:  true, // Do not show usage on error
-	SilenceErrors: true, // Do not propagate errors down the line, we control them
+	Use:   "pull-image IMAGE DESTINATION",
+	Short: "elemental pull-image",
+	Args:  cobra.ExactArgs(2),
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		return CheckRoot()
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg, err := config.ReadConfigRun(viper.GetString("config-dir"), &mount.FakeMounter{})
 
@@ -47,6 +48,10 @@ var pullImage = &cobra.Command{
 			cfg.Logger.Errorf("Invalid path %s", destination)
 			return err
 		}
+
+		// Set this after parsing of the flags, so it fails on parsing and prints usage properly
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true // Do not propagate errors down the line, we control them
 
 		verify, _ := cmd.Flags().GetBool("verify")
 		user, _ := cmd.Flags().GetString("auth-username")

--- a/cmd/pull-image_test.go
+++ b/cmd/pull-image_test.go
@@ -22,9 +22,9 @@ import (
 	"os"
 )
 
-var _ = Describe("pull-image", Label("pull-image", "cmd"), func() {
+var _ = Describe("pull-image", Label("pull-image", "cmd", "root"), func() {
 	Describe("execution", func() {
-		It("executes command correctly", Label("root"), func() {
+		It("executes command correctly", func() {
 			d, err := os.MkdirTemp("", "elemental")
 			Expect(err).ToNot(HaveOccurred())
 			defer os.RemoveAll(d)
@@ -44,28 +44,11 @@ var _ = Describe("pull-image", Label("pull-image", "cmd"), func() {
 			)
 			Expect(err).To(HaveOccurred())
 		})
-		It("fails when destination is missing", Label("args"), func() {
-			_, _, err := executeCommandC(
-				rootCmd,
-				"pull-image",
-				"fakeImage",
-			)
-			Expect(err).To(HaveOccurred())
-		})
 		It("fails when image is not an image", Label("args"), func() {
 			_, _, err := executeCommandC(
 				rootCmd,
 				"pull-image",
 				"fakeImage",
-				"fakeDest",
-			)
-			Expect(err).To(HaveOccurred())
-		})
-		It("fails when destination does not exists", Label("args"), func() {
-			_, _, err := executeCommandC(
-				rootCmd,
-				"pull-image",
-				"alpine",
 				"fakeDest",
 			)
 			Expect(err).To(HaveOccurred())

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -31,8 +31,9 @@ var resetCmd = &cobra.Command{
 	Use:   "reset",
 	Short: "elemental reset OS",
 	Args:  cobra.ExactArgs(0),
-	PreRun: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		_ = viper.BindPFlags(cmd.Flags())
+		return CheckRoot()
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		path, err := exec.LookPath("mount")

--- a/cmd/reset_test.go
+++ b/cmd/reset_test.go
@@ -22,7 +22,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Reset", Label("reset", "cmd", "systemctl"), func() {
+var _ = Describe("Reset", Label("reset", "cmd", "systemctl", "root"), func() {
 	It("Errors out setting reboot and poweroff at the same time", Label("flags"), func() {
 		buf := new(bytes.Buffer)
 		rootCmd.SetOut(buf)

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -31,11 +31,12 @@ var upgradeCmd = &cobra.Command{
 	Use:   "upgrade",
 	Short: "upgrade the system",
 	Args:  cobra.ExactArgs(0),
-	PreRun: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// We bind the --recovery flag into RecoveryUpgrade value to have a more explicit var in the config
 		_ = viper.BindPFlag("RecoveryUpgrade", cmd.Flags().Lookup("recovery"))
 		// bind the rest of the flags into their direct values as they are mapped 1to1
 		_ = viper.BindPFlags(cmd.Flags())
+		return CheckRoot()
 	},
 
 	RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Some of the commands require root privs to run but currently they are
run without which could cause issues during the middle of the command
leaving the target system broken.

Now the commands that require root are checked on PreRun and fail if
they require privs and they are running without

Signed-off-by: Itxaka <igarcia@suse.com>