### PR TITLE
Keep partition device path after creating a new partition

### DIFF
--- a/pkg/partitioner/disk.go
+++ b/pkg/partitioner/disk.go
@@ -262,11 +262,6 @@ func (dev Disk) FormatPartition(partNum int, fileSystem string, label string) (s
 }
 
 func (dev Disk) WipeFsOnPartition(device string) error {
-	/*pDev, err := dev.FindPartitionDevice(partNum)
-	if err != nil {
-		return err
-	}*/
-
 	_, err := dev.runner.Run("wipefs", "--all", device)
 	return err
 }

--- a/pkg/partitioner/disk.go
+++ b/pkg/partitioner/disk.go
@@ -261,13 +261,13 @@ func (dev Disk) FormatPartition(partNum int, fileSystem string, label string) (s
 	return mkfs.Apply()
 }
 
-func (dev Disk) WipeFsOnPartition(partNum int) error {
-	pDev, err := dev.FindPartitionDevice(partNum)
+func (dev Disk) WipeFsOnPartition(device string) error {
+	/*pDev, err := dev.FindPartitionDevice(partNum)
 	if err != nil {
 		return err
-	}
+	}*/
 
-	_, err = dev.runner.Run("wipefs", "--all", pDev)
+	_, err := dev.runner.Run("wipefs", "--all", device)
 	return err
 }
 

--- a/pkg/partitioner/partitioner_test.go
+++ b/pkg/partitioner/partitioner_test.go
@@ -334,18 +334,15 @@ var _ = Describe("Partitioner", Label("disk", "partition", "partitioner"), func(
 			})
 			It("Clears filesystem header from a partition", func() {
 				cmds = [][]string{
-					{"udevadm", "settle"},
-					{"lsblk", "-ltnpo", "name,type", "/some/device"},
 					{"wipefs", "--all", "/some/device1"},
 				}
 				runner.ReturnValue = []byte("/some/device1 part")
-				Expect(dev.WipeFsOnPartition(1)).To(BeNil())
+				Expect(dev.WipeFsOnPartition("/some/device1")).To(BeNil())
 				Expect(runner.CmdsMatch(cmds)).To(BeNil())
 			})
 			It("Fails while removing file system header", func() {
-				runner.ReturnValue = []byte("/some/device1 part")
 				runner.ReturnError = errors.New("some error")
-				Expect(dev.WipeFsOnPartition(1)).NotTo(BeNil())
+				Expect(dev.WipeFsOnPartition("/some/device1")).NotTo(BeNil())
 			})
 			Describe("Expanding partitions", func() {
 				var fileSystem string


### PR DESCRIPTION
This commit stores the device path of a partition after creating it.
This is helpful to reduce the amount of calls to tools such as `blkid`
or `lsblk` during the installation.

Signed-off-by: David Cassany <dcassany@suse.com>