### PR TITLE
Add logger to runner and log commands on debug

### DIFF
--- a/pkg/types/v1/runner.go
+++ b/pkg/types/v1/runner.go
@@ -18,15 +18,20 @@ package v1
 
 import (
 	"os/exec"
+	"strings"
 )
 
 type Runner interface {
 	InitCmd(string, ...string) *exec.Cmd
 	Run(string, ...string) ([]byte, error)
 	RunCmd(cmd *exec.Cmd) ([]byte, error)
+	GetLogger() Logger
+	SetLogger(logger Logger)
 }
 
-type RealRunner struct{}
+type RealRunner struct {
+	Logger Logger
+}
 
 func (r RealRunner) InitCmd(command string, args ...string) *exec.Cmd {
 	return exec.Command(command, args...)
@@ -38,5 +43,16 @@ func (r RealRunner) RunCmd(cmd *exec.Cmd) ([]byte, error) {
 
 func (r RealRunner) Run(command string, args ...string) ([]byte, error) {
 	cmd := r.InitCmd(command, args...)
+	if r.Logger != nil {
+		r.Logger.Debugf("Running cmd: '%s %s'", command, strings.Join(args, " "))
+	}
 	return r.RunCmd(cmd)
+}
+
+func (r RealRunner) GetLogger() Logger {
+	return r.Logger
+}
+
+func (r RealRunner) SetLogger(logger Logger) {
+	r.Logger = logger
 }

--- a/pkg/types/v1/runner.go
+++ b/pkg/types/v1/runner.go
@@ -53,6 +53,6 @@ func (r RealRunner) GetLogger() Logger {
 	return r.Logger
 }
 
-func (r RealRunner) SetLogger(logger Logger) {
+func (r *RealRunner) SetLogger(logger Logger) {
 	r.Logger = logger
 }

--- a/tests/mocks/runner_mock.go
+++ b/tests/mocks/runner_mock.go
@@ -18,6 +18,7 @@ package mocks
 
 import (
 	"fmt"
+	v1 "github.com/rancher-sandbox/elemental/pkg/types/v1"
 	"os/exec"
 	"strings"
 )
@@ -27,6 +28,7 @@ type FakeRunner struct {
 	ReturnValue []byte
 	SideEffect  func(command string, args ...string) ([]byte, error)
 	ReturnError error
+	Logger      v1.Logger
 }
 
 func NewFakeRunner() *FakeRunner {
@@ -116,4 +118,12 @@ func (r FakeRunner) MatchMilestones(cmdList [][]string) error {
 	}
 
 	return nil
+}
+
+func (r FakeRunner) GetLogger() v1.Logger {
+	return r.Logger
+}
+
+func (r FakeRunner) SetLogger(logger v1.Logger) {
+	r.Logger = logger
 }

--- a/tests/mocks/runner_mock.go
+++ b/tests/mocks/runner_mock.go
@@ -18,9 +18,10 @@ package mocks
 
 import (
 	"fmt"
-	v1 "github.com/rancher-sandbox/elemental/pkg/types/v1"
 	"os/exec"
 	"strings"
+
+	v1 "github.com/rancher-sandbox/elemental/pkg/types/v1"
 )
 
 type FakeRunner struct {
@@ -124,6 +125,6 @@ func (r FakeRunner) GetLogger() v1.Logger {
 	return r.Logger
 }
 
-func (r FakeRunner) SetLogger(logger v1.Logger) {
+func (r *FakeRunner) SetLogger(logger v1.Logger) {
 	r.Logger = logger
 }


### PR DESCRIPTION
Adds a logger to the runner and logs commands on debug calls.
Takes care of trying to use a nil Logger and doesnt force a logger to
exists


Side effect of checking some commands locally, I implemented this real quick to see the commands being executed :)

Signed-off-by: Itxaka <igarcia@suse.com>