### PR TITLE
Dockerfile changes

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -48,4 +48,4 @@ jobs:
           # mount loop device and get the device
           LOOP=`sudo losetup -fP --show loopbackfile.img`
           # run the install tot he loop device as a small test
-          docker run --privileged ${{ steps.meta.outputs.tags }} install --debug $LOOP
+          docker run --privileged ${{ steps.meta.outputs.tags }} install --debug -d quay.io/costoolkit/releases-green:cos-system-0.8.6 $LOOP

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -14,6 +14,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Export tag
+        id: export_tag
+        run: |
+          TAG=`git describe --tags 2>/dev/null || echo "v0.0.1"`
+          echo "::set-output name=elemental_tag::$TAG"
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v3
@@ -41,13 +46,15 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           load: true # loads it locally, so it can be used from docker client
           target: elemental
-      - name: Install qemu-utils
-        run: sudo apt-get install qemu-utils
+          build-args: |
+            ELEMENTAL_VERSION=${{ steps.export_tag.outputs.elemental_tag }}
+            ELEMENTAL_COMMIT=${{ github.sha }}
       - name: Test docker image
         run: |
           # create a 30Gb file
-          qemu-img create -f raw disk.img 30G
+          # qemu-img create -f raw disk.img 30G
           # mount loop device and get the device
-          LOOP=`sudo losetup -fP --show disk.img`
-          # run the install tot he loop device as a small test
-          docker run --privileged ${{ steps.meta.outputs.tags }} install --debug -d quay.io/costoolkit/releases-green:cos-system-0.8.6 $LOOP
+          #LOOP=`sudo losetup -fP --show disk.img`
+          # unfortunately loop devices are not properly refreshed under a container :/
+          #docker run --privileged ${{ steps.meta.outputs.tags }} install --debug -d quay.io/costoolkit/releases-green:cos-system-0.8.6 $LOOP
+          docker run ${{ steps.meta.outputs.tags }} version --long

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -14,10 +14,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Export tag
         id: export_tag
         run: |
-          TAG=`git describe --tags 2>/dev/null || echo "v0.0.1"`
+          git describe --abbrev=0 --tags
+          TAG=`git describe --abbrev=0 --tags 2>/dev/null || echo "v0.0.1"`
           echo "::set-output name=elemental_tag::$TAG"
       - name: Docker meta
         id: meta
@@ -27,7 +30,7 @@ jobs:
             quay.io/costoolkit/elemental
           tags: |
             type=semver,pattern=v{{version}}
-            type=sha,format=long
+            type=sha,format=short,prefix=${{ steps.export_tag.outputs.elemental_tag }}-
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -39,4 +39,13 @@ jobs:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
+          load: true # loads it locally, so it can be used from docker client
           target: elemental
+      - name: Test docker image
+        run: |
+          # create a 30Gb file
+          dd if=/dev/zero of=loopbackfile.img bs=3000M count=10
+          # mount loop device and get the device
+          LOOP=`sudo losetup -fP --show loopbackfile.img`
+          # run the install tot he loop device as a small test
+          docker run --privileged ${{ steps.meta.outputs.tags }} install --debug $LOOP

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,6 +1,8 @@
 name: Docker build and push
 on:
   pull_request:
+    paths:
+      - Dockerfile
   push:
     branches:
       - main

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -41,11 +41,13 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           load: true # loads it locally, so it can be used from docker client
           target: elemental
+      - name: Install qemu-utils
+        run: sudo apt-get install qemu-utils
       - name: Test docker image
         run: |
           # create a 30Gb file
-          dd if=/dev/zero of=loopbackfile.img bs=3000M count=10
+          qemu-img create -f raw disk.img 30G
           # mount loop device and get the device
-          LOOP=`sudo losetup -fP --show loopbackfile.img`
+          LOOP=`sudo losetup -fP --show disk.img`
           # run the install tot he loop device as a small test
           docker run --privileged ${{ steps.meta.outputs.tags }} install --debug -d quay.io/costoolkit/releases-green:cos-system-0.8.6 $LOOP

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN go build -o /usr/bin/elemental
 
 FROM opensuse/leap:$LEAP_VERSION AS elemental
 RUN zypper ref
-RUN zypper in -y xfsprogs parted util-linux-systemd e2fsprogs util-linux udev rsync grub2
+RUN zypper in -y xfsprogs parted util-linux-systemd e2fsprogs util-linux udev rsync grub2 dosfstools
 COPY --from=elemental-bin /usr/bin/elemental /usr/bin/elemental
 COPY --from=cosign-bin /usr/bin/cosign /usr/bin/cosign
 # Fix for blkid only using udev on opensuse

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
 ARG GOLANG_IMAGE_VERSION=1.17-alpine
 ARG COSIGN_VERSION=1.4.1-5
 ARG LEAP_VERSION=15.4
-ARG ELEMENTAL_VERSION=0.0.1
-ARG ELEMENTAL_COMMIT=""
 
 FROM quay.io/costoolkit/releases-green:cosign-toolchain-$COSIGN_VERSION AS cosign-bin
 
 
+
 FROM golang:$GOLANG_IMAGE_VERSION as elemental-bin
+ARG ELEMENTAL_VERSION=0.0.1
+ARG ELEMENTAL_COMMIT=""
+
 ENV CGO_ENABLED=0
 ENV ELEMENTAL_VERSION=${ELEMENTAL_VERSION}
 ENV ELEMENTAL_COMMIT=${ELEMENTAL_COMMIT}
@@ -23,8 +25,8 @@ ADD pkg pkg
 ADD main.go .
 RUN go build \
     -ldflags "-w -s \
-    -X github.com/rancher-sandbox/elemental/internal/version.version=${ELEMENTAL_VERSION} \
-    -X github.com/rancher-sandbox/elemental/internal/version.gitCommit=${ELEMENTAL_COMMIT}" \
+    -X github.com/rancher-sandbox/elemental/internal/version.version=$ELEMENTAL_VERSION \
+    -X github.com/rancher-sandbox/elemental/internal/version.gitCommit=$ELEMENTAL_COMMIT" \
     -o /usr/bin/elemental
 
 FROM opensuse/leap:$LEAP_VERSION AS elemental

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,16 @@
 ARG GOLANG_IMAGE_VERSION=1.17-alpine
 ARG COSIGN_VERSION=1.4.1-5
 ARG LEAP_VERSION=15.4
+ARG ELEMENTAL_VERSION=0.0.1
+ARG ELEMENTAL_COMMIT=""
 
 FROM quay.io/costoolkit/releases-green:cosign-toolchain-$COSIGN_VERSION AS cosign-bin
 
 
 FROM golang:$GOLANG_IMAGE_VERSION as elemental-bin
 ENV CGO_ENABLED=0
+ENV ELEMENTAL_VERSION=${ELEMENTAL_VERSION}
+ENV ELEMENTAL_COMMIT=${ELEMENTAL_COMMIT}
 WORKDIR /src/
 # Add specific dirs to the image so cache is not invalidated when modifying non go files
 ADD go.mod .
@@ -17,7 +21,11 @@ ADD internal internal
 ADD tests tests
 ADD pkg pkg
 ADD main.go .
-RUN go build -o /usr/bin/elemental
+RUN go build \
+    -ldflags "-w -s \
+    -X github.com/rancher-sandbox/elemental/internal/version.version=${ELEMENTAL_VERSION} \
+    -X github.com/rancher-sandbox/elemental/internal/version.gitCommit=${ELEMENTAL_COMMIT}" \
+    -o /usr/bin/elemental
 
 FROM opensuse/leap:$LEAP_VERSION AS elemental
 RUN zypper ref

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 GIT_COMMIT ?= $(shell git rev-parse HEAD)
-GIT_TAG ?= $(shell git describe --tags 2>/dev/null || echo "v0.0.1" )
+GIT_TAG ?= $(shell git describe --abbrev=0 --tags 2>/dev/null || echo "v0.0.1" )
 
 PKG        := ./...
 LDFLAGS    := -w -s
@@ -20,7 +20,7 @@ build:
 	go build -ldflags '$(LDFLAGS)' -o bin/
 
 docker_build:
-	DOCKER_BUILDKIT=1 docker build --build-arg ELEMENTAL_VERSION=${GIT_TAG} --build-arg ELEMENTAL_COMMIT=${GIT_COMMIT} --target elemental -t elemental:${GIT_TAG} .
+	DOCKER_BUILDKIT=1 docker build --build-arg ELEMENTAL_VERSION=${GIT_TAG} --build-arg ELEMENTAL_COMMIT=${GIT_COMMIT} --target elemental -t elemental:${GIT_TAG}-${GIT_COMMIT} .
 
 vet:
 	go vet ${PKG}

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ $(GINKGO):
 build:
 	go build -ldflags '$(LDFLAGS)' -o bin/
 
+docker_build:
+	DOCKER_BUILDKIT=1 docker build --build-arg ELEMENTAL_VERSION=${GIT_TAG} --build-arg ELEMENTAL_COMMIT=${GIT_COMMIT} --target elemental -t elemental:${GIT_TAG} .
+
 vet:
 	go vet ${PKG}
 


### PR DESCRIPTION
 - Build dockerfile on PR only when the file is changed. Does not affect master/tag building
 - Add a target to the Makefile to build docker image locally
 - Use version and commit while building docker image elemental
 - Use version and commit for image tags on docker image
 - Fix version on makefile getting the long version (tag+commit) instead of the short version (tag)
 - Master merged docker images are now pushed with a tag+short_commit instead of `sha-long_commit` as its easier to differentiate
 - Built image is now locally pushed in the worker so it can be reused in the job

Signed-off-by: Itxaka <igarcia@suse.com>