### PR TITLE
Sync locally build docker names with remote

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 GIT_COMMIT ?= $(shell git rev-parse HEAD)
+GIT_COMMIT_SHORT ?= $(shell git rev-parse --short HEAD)
 GIT_TAG ?= $(shell git describe --abbrev=0 --tags 2>/dev/null || echo "v0.0.1" )
 
 PKG        := ./...
@@ -20,7 +21,7 @@ build:
 	go build -ldflags '$(LDFLAGS)' -o bin/
 
 docker_build:
-	DOCKER_BUILDKIT=1 docker build --build-arg ELEMENTAL_VERSION=${GIT_TAG} --build-arg ELEMENTAL_COMMIT=${GIT_COMMIT} --target elemental -t elemental:${GIT_TAG}-${GIT_COMMIT} .
+	DOCKER_BUILDKIT=1 docker build --build-arg ELEMENTAL_VERSION=${GIT_TAG} --build-arg ELEMENTAL_COMMIT=${GIT_COMMIT} --target elemental -t elemental:${GIT_TAG}-${GIT_COMMIT_SHORT} .
 
 vet:
 	go vet ${PKG}


### PR DESCRIPTION
Remote docker images have a TAG-SHORT_COMMIT format but we were building
the local images with TAG-LONG_COMMIT which is a bit confusing. Sync the
names so locally build images have the same name as remote ones

Signed-off-by: Itxaka <igarcia@suse.com>