### PR TITLE
Fix docker building on tag

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
     tags:
-      - 'v*.*.*'
+      - 'v*'
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -44,7 +44,6 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
-          context: .
           # push and load can't be used at the same time
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
 - Remove path context and use github context so it can fetch the tag
properly and identify we are pushing a tag
 - Trigger on proper tags


While playing with this on my own repo I discovered that I mangled the version stuff and on tag it was not triggering a build and not identifying that the tag was created thus not creating the proper tags.

With this changes, when a tag is pushed it will identify it and create the following docker images:
 - elemental:TAG-SHORT_COMMIT
 - elemental:TAG
 - elemental:latest

Which works kind of nice, so latest will always point to the stable tag version, we get a tagged version for that tag and we also get a tag+commit like the rest of the images pushed from master.

Signed-off-by: Itxaka <igarcia@suse.com>