### PR TITLE
Remove blkid dependency and limit lsblk usage

### DIFF
--- a/pkg/action/reset.go
+++ b/pkg/action/reset.go
@@ -64,7 +64,7 @@ func ResetSetup(config *v1.RunConfig) error {
 			partEfi.MountPoint = cnst.EfiDir
 		}
 		partEfi.Name = cnst.EfiPartName
-		config.Partitions = append(config.Partitions, &partEfi)
+		config.Partitions = append(config.Partitions, partEfi)
 	}
 
 	// Only add it if it exists, not a hard requirement
@@ -74,7 +74,7 @@ func ResetSetup(config *v1.RunConfig) error {
 			partOEM.MountPoint = cnst.OEMDir
 		}
 		partOEM.Name = cnst.OEMPartName
-		config.Partitions = append(config.Partitions, &partOEM)
+		config.Partitions = append(config.Partitions, partOEM)
 	} else {
 		config.Logger.Warnf("No OEM partition found")
 	}
@@ -88,7 +88,7 @@ func ResetSetup(config *v1.RunConfig) error {
 		partState.MountPoint = cnst.StateDir
 	}
 	partState.Name = cnst.StatePartName
-	config.Partitions = append(config.Partitions, &partState)
+	config.Partitions = append(config.Partitions, partState)
 	config.Target = partState.Disk
 
 	// Only add it if it exists, not a hard requirement
@@ -98,7 +98,7 @@ func ResetSetup(config *v1.RunConfig) error {
 			partPersistent.MountPoint = cnst.PersistentDir
 		}
 		partPersistent.Name = cnst.PersistentPartName
-		config.Partitions = append(config.Partitions, &partPersistent)
+		config.Partitions = append(config.Partitions, partPersistent)
 	} else {
 		config.Logger.Warnf("No Persistent partition found")
 	}

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -144,7 +144,7 @@ func (u *UpgradeAction) Run() (err error) { // nolint:gocyclo
 		//  We are updating recovery
 		if u.Config.RecoveryUpgrade {
 			// Try to mount SYSTEM partition, only exists if recovery is squash
-			var recoveryPart v1.Partition
+			var recoveryPart *v1.Partition
 			recoveryPart, err = utils.GetFullDeviceByLabel(u.Config.Runner, u.Config.SystemLabel, 2)
 			if err != nil {
 				// Failure to get the system label, fallback tor recovery label

--- a/pkg/cloudinit/layout_plugin.go
+++ b/pkg/cloudinit/layout_plugin.go
@@ -55,9 +55,19 @@ func layoutPlugin(l logger.Interface, s schema.Stage, fs vfs.FS, console plugins
 			l.Errorf("Exiting, disk not found:\n %s", err.Error())
 			return err
 		}
-		dev = partitioner.NewDisk(partDevice.Disk, partitioner.WithRunner(runner), partitioner.WithLogger(log))
+		dev = partitioner.NewDisk(
+			partDevice.Disk,
+			partitioner.WithRunner(runner),
+			partitioner.WithLogger(log),
+			partitioner.WithFS(fs),
+		)
 	} else if len(strings.TrimSpace(s.Layout.Device.Path)) > 0 {
-		dev = partitioner.NewDisk(s.Layout.Device.Path, partitioner.WithRunner(runner), partitioner.WithLogger(log))
+		dev = partitioner.NewDisk(
+			s.Layout.Device.Path,
+			partitioner.WithRunner(runner),
+			partitioner.WithLogger(log),
+			partitioner.WithFS(fs),
+		)
 	} else {
 		l.Warnf("No target device defined, nothing to do")
 		return nil

--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -528,7 +528,7 @@ func (c Elemental) SetDefaultGrubEntry() error {
 		} else if p.MountPoint == "" {
 			return errors.New("state partition not mounted. Cannot set grub env file")
 		} else {
-			part = &p
+			part = p
 		}
 	}
 	grub := utils.NewGrub(c.config)

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -143,14 +143,14 @@ type RunConfig struct {
 
 // Partition struct represents a partition with its commonly configurable values, size in MiB
 type Partition struct {
-	Label      string `json:"label,omitempty"`
+	Label      string
 	Size       uint
 	Name       string
-	FS         string `json:"fstype,omitempty"`
+	FS         string
 	Flags      []string
-	MountPoint string `json:"mountpoint,omitempty"`
-	Path       string `json:"path,omitempty"`
-	Disk       string `json:"pkname,omitempty"`
+	MountPoint string
+	Path       string
+	Disk       string
 }
 
 type PartitionList []*Partition

--- a/pkg/types/v1/fs.go
+++ b/pkg/types/v1/fs.go
@@ -29,6 +29,7 @@ type FS interface {
 	Stat(name string) (os.FileInfo, error)
 	RemoveAll(path string) error
 	ReadFile(filename string) ([]byte, error)
+	Readlink(name string) (string, error)
 	RawPath(name string) (string, error)
 	Remove(name string) error
 	OpenFile(name string, flag int, perm fs.FileMode) (*os.File, error)

--- a/pkg/utils/lsblk.go
+++ b/pkg/utils/lsblk.go
@@ -1,0 +1,109 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"encoding/json"
+	"errors"
+
+	v1 "github.com/rancher-sandbox/elemental/pkg/types/v1"
+)
+
+type jPart struct {
+	Label      string `json:"label,omitempty"`
+	Size       uint64 `json:"size,omitempty"`
+	FS         string `json:"fstype,omitempty"`
+	MountPoint string `json:"mountpoint,omitempty"`
+	Path       string `json:"path,omitempty"`
+	Disk       string `json:"pkname,omitempty"`
+	Type       string `json:"type,omitempty"`
+}
+
+type jParts []*v1.Partition
+
+func (p jPart) Partition() *v1.Partition {
+	// Converts B to MB
+	return &v1.Partition{
+		Label:      p.Label,
+		Size:       uint(p.Size / (1024 * 1024)),
+		FS:         p.FS,
+		Flags:      []string{},
+		MountPoint: p.MountPoint,
+		Path:       p.Path,
+		Disk:       p.Disk,
+	}
+}
+
+func (p *jParts) UnmarshalJSON(data []byte) error {
+	var parts []jPart
+
+	if err := json.Unmarshal(data, &parts); err != nil {
+		return err
+	}
+
+	var partitions jParts
+	for _, part := range parts {
+		// filter only partition or loop devices
+		if part.Type == "part" || part.Type == "loop" {
+			partitions = append(partitions, part.Partition())
+		}
+	}
+	*p = partitions
+	return nil
+}
+
+func unmarshalLsblk(lsblkOut []byte) ([]*v1.Partition, error) {
+	var objmap map[string]*json.RawMessage
+	err := json.Unmarshal(lsblkOut, &objmap)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, ok := objmap["blockdevices"]; !ok {
+		return nil, errors.New("Invalid json object, no 'blockdevices' key found")
+	}
+
+	var parts jParts
+	err = json.Unmarshal(*objmap["blockdevices"], &parts)
+	if err != nil {
+		return nil, err
+	}
+
+	return parts, nil
+}
+
+// GetAllPartitions gets an array of partition devices mapped into v1.Partition
+// objects.
+func GetAllPartitions(runner v1.Runner) (v1.PartitionList, error) {
+	out, err := runner.Run("lsblk", "-p", "-b", "-n", "-J", "--output", "LABEL,SIZE,FSTYPE,MOUNTPOINT,PATH,PKNAME,TYPE")
+	if err != nil {
+		return nil, err
+	}
+
+	return unmarshalLsblk(out)
+}
+
+// GetDevicePartitions gets an array of partition devices mapped into v1.Partition
+// objects.
+func GetDevicePartitions(runner v1.Runner, device string) (v1.PartitionList, error) {
+	out, err := runner.Run("lsblk", "-p", "-b", "-n", "-J", "--output", "LABEL,SIZE,FSTYPE,MOUNTPOINT,PATH,PKNAME,TYPE", device)
+	if err != nil {
+		return nil, err
+	}
+
+	return unmarshalLsblk(out)
+}

--- a/pkg/utils/lsblk.go
+++ b/pkg/utils/lsblk.go
@@ -86,8 +86,8 @@ func unmarshalLsblk(lsblkOut []byte) ([]*v1.Partition, error) {
 	return parts, nil
 }
 
-// GetAllPartitions gets an array of partition devices mapped into v1.Partition
-// objects.
+// GetAllPartitions gets a slice of all partition devices found in the host
+// mapped into a v1.PartitionList object.
 func GetAllPartitions(runner v1.Runner) (v1.PartitionList, error) {
 	out, err := runner.Run("lsblk", "-p", "-b", "-n", "-J", "--output", "LABEL,SIZE,FSTYPE,MOUNTPOINT,PATH,PKNAME,TYPE")
 	if err != nil {
@@ -97,8 +97,9 @@ func GetAllPartitions(runner v1.Runner) (v1.PartitionList, error) {
 	return unmarshalLsblk(out)
 }
 
-// GetDevicePartitions gets an array of partition devices mapped into v1.Partition
-// objects.
+// GetDevicePartitions gets a slice of partitions found in the given device mapped
+// into a v1.PartitionList object. If the device is a disk it will list all disk
+// partitions, if the device is already a partition it will simply list a single partition.
 func GetDevicePartitions(runner v1.Runner, device string) (v1.PartitionList, error) {
 	out, err := runner.Run("lsblk", "-p", "-b", "-n", "-J", "--output", "LABEL,SIZE,FSTYPE,MOUNTPOINT,PATH,PKNAME,TYPE", device)
 	if err != nil {

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -171,7 +171,7 @@ var _ = Describe("Utils", Label("utils"), func() {
 			Expect(utils.BootedFrom(runner, "FAKELABEL")).To(BeTrue())
 		})
 	})
-	Describe("GetDeviceByLabel", Label("GetDeviceByLabel"), func() {
+	Describe("GetDeviceByLabel", Label("lsblk", "partitions"), func() {
 		var cmds [][]string
 		BeforeEach(func() {
 			cmds = [][]string{
@@ -197,6 +197,109 @@ var _ = Describe("Utils", Label("utils"), func() {
 			_, err := utils.GetDeviceByLabel(runner, "FAKE", 2)
 			Expect(err).NotTo(BeNil())
 			Expect(runner.CmdsMatch(append(cmds, cmds...))).To(BeNil())
+		})
+	})
+	Describe("GetAllPartitions", Label("lsblk", "partitions"), func() {
+		var cmds [][]string
+		BeforeEach(func() {
+			cmds = [][]string{
+				{"lsblk", "-p", "-b", "-n", "-J", "--output", "LABEL,SIZE,FSTYPE,MOUNTPOINT,PATH,PKNAME,TYPE"},
+			}
+		})
+		It("returns all found partitions", func() {
+			runner.ReturnValue = []byte(`{
+"blockdevices":
+    [
+        {"label": "COS_ACTIVE", "type": "loop", "path": "/some/loop0"},
+        {"label": "COS_OEM", "type": "part", "path": "/some/device1"},
+        {"label": "COS_RECOVERY", "type": "part", "path": "/some/device2"},
+        {"label": "COS_STATE", "type": "part", "path": "/some/device3"},
+        {"label": "COS_PERSISTENT", "type": "part", "path": "/some/device4"}
+    ]
+}`)
+			parts, err := utils.GetAllPartitions(runner)
+			Expect(err).To(BeNil())
+			Expect(len(parts)).To(Equal(5))
+			Expect(runner.CmdsMatch(cmds)).To(BeNil())
+		})
+		It("fails to run lsblk", func() {
+			runner.ReturnError = errors.New("failed running lsblk")
+			_, err := utils.GetAllPartitions(runner)
+			Expect(err).NotTo(BeNil())
+			Expect(runner.CmdsMatch(cmds)).To(BeNil())
+		})
+		It("fails on invalid lsblk output", func() {
+			runner.ReturnValue = []byte("invalid")
+			_, err := utils.GetAllPartitions(runner)
+			Expect(err).NotTo(BeNil())
+			Expect(runner.CmdsMatch(cmds)).To(BeNil())
+
+			runner.ClearCmds()
+			runner.ReturnValue = []byte(`{"invalidjson": []}`)
+			_, err = utils.GetAllPartitions(runner)
+			Expect(err).NotTo(BeNil())
+			Expect(runner.CmdsMatch(cmds)).To(BeNil())
+
+			runner.ClearCmds()
+			runner.ReturnValue = []byte(`{"blockdevices": "invalidlist"}`)
+			_, err = utils.GetAllPartitions(runner)
+			Expect(err).NotTo(BeNil())
+			Expect(runner.CmdsMatch(cmds)).To(BeNil())
+		})
+	})
+	Describe("GetDevicePartitions", Label("lsblk", "partitions"), func() {
+		var cmds [][]string
+		BeforeEach(func() {
+			cmds = [][]string{
+				{"lsblk", "-p", "-b", "-n", "-J", "--output", "LABEL,SIZE,FSTYPE,MOUNTPOINT,PATH,PKNAME,TYPE", "/some/disk"},
+			}
+		})
+		It("returns all found partitions", func() {
+			runner.ReturnValue = []byte(`{
+"blockdevices":
+    [
+        {"type": "disk", "path": "/some/disk"},
+        {"label": "COS_OEM", "type": "part", "path": "/some/disk1"},
+        {"label": "COS_RECOVERY", "type": "part", "path": "/some/disk2"}
+    ]
+}`)
+			parts, err := utils.GetDevicePartitions(runner, "/some/disk")
+			Expect(err).To(BeNil())
+			Expect(len(parts)).To(Equal(2))
+			Expect(runner.CmdsMatch(cmds)).To(BeNil())
+		})
+	})
+	Describe("GetPartitionFS", Label("lsblk", "partitions"), func() {
+		var cmds [][]string
+		BeforeEach(func() {
+			cmds = [][]string{
+				{"lsblk", "-p", "-b", "-n", "-J", "--output", "LABEL,SIZE,FSTYPE,MOUNTPOINT,PATH,PKNAME,TYPE", "/some/device"},
+			}
+		})
+		It("returns found device", func() {
+			runner.ReturnValue = []byte(`{"blockdevices": [{"fstype": "xfs", "type": "part"}]}`)
+			pFS, err := utils.GetPartitionFS(runner, "/some/device")
+			Expect(err).To(BeNil())
+			Expect(pFS).To(Equal("xfs"))
+			Expect(runner.CmdsMatch(cmds)).To(BeNil())
+		})
+		It("fails to run lsblk", func() {
+			runner.ReturnError = errors.New("failed running lsblk")
+			_, err := utils.GetPartitionFS(runner, "/some/device")
+			Expect(err).NotTo(BeNil())
+			Expect(runner.CmdsMatch(cmds)).To(BeNil())
+		})
+		It("fails if more than one partition is found", func() {
+			runner.ReturnValue = []byte(`{"blockdevices": [{"fstype": "xfs", "type": "part"}, {"fstype": "ext4", "type": "part"}]}`)
+			_, err := utils.GetPartitionFS(runner, "/some/device")
+			Expect(err).NotTo(BeNil())
+			Expect(runner.CmdsMatch(cmds)).To(BeNil())
+		})
+		It("fails if no partition is found", func() {
+			runner.ReturnValue = []byte(`{"blockdevices": []}`)
+			_, err := utils.GetPartitionFS(runner, "/some/device")
+			Expect(err).NotTo(BeNil())
+			Expect(runner.CmdsMatch(cmds)).To(BeNil())
 		})
 	})
 	Describe("CosignVerify", Label("cosign"), func() {
@@ -233,7 +336,7 @@ var _ = Describe("Utils", Label("utils"), func() {
 			Expect(duration.Seconds() >= 3).To(BeTrue())
 		})
 	})
-	Describe("GetFullDeviceByLabel", Label("GetFullDeviceByLabel", "partition", "types"), func() {
+	Describe("GetFullDeviceByLabel", Label("lsblk", "partitions"), func() {
 		var cmds [][]string
 		BeforeEach(func() {
 			cmds = [][]string{


### PR DESCRIPTION
This commit removes all blkid calls and wraps lsblk in a more
normalized and generic way. lsblk is only called in two methods:

* GetDevicePartitions: returns a v1.PartitionList with all the
partitions or loop devices for the given device path.

* GetAllPartitions: returns a v1.PartitionList with all the partitions
and loop devices of the host.

Signed-off-by: David Cassany <dcassany@suse.com>