### PR TITLE
Move config options into the config package

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -54,8 +54,8 @@ func ReadConfigBuild(configDir string) (*v1.BuildConfig, error) {
 
 func ReadConfigRun(configDir string, mounter mount.Interface) (*v1.RunConfig, error) {
 	cfg := config.NewRunConfig(
-		v1.WithLogger(v1.NewLogger()),
-		v1.WithMounter(mounter),
+		config.WithLogger(v1.NewLogger()),
+		config.WithMounter(mounter),
 	)
 
 	// Set debug level

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -73,13 +73,13 @@ var _ = Describe("Actions", func() {
 
 		cloudInit = &v1mock.FakeCloudInitRunner{}
 		config = conf.NewRunConfig(
-			v1.WithFs(fs),
-			v1.WithRunner(runner),
-			v1.WithLogger(logger),
-			v1.WithMounter(mounter),
-			v1.WithSyscall(syscall),
-			v1.WithClient(client),
-			v1.WithCloudInitRunner(cloudInit),
+			conf.WithFs(fs),
+			conf.WithRunner(runner),
+			conf.WithLogger(logger),
+			conf.WithMounter(mounter),
+			conf.WithSyscall(syscall),
+			conf.WithClient(client),
+			conf.WithCloudInitRunner(cloudInit),
 		)
 	})
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,7 +25,65 @@ import (
 	"k8s.io/mount-utils"
 )
 
-func NewRunConfig(opts ...v1.RunConfigOptions) *v1.RunConfig {
+type RunConfigOptions func(a *v1.RunConfig) error
+
+func WithFs(fs v1.FS) func(r *v1.RunConfig) error {
+	return func(r *v1.RunConfig) error {
+		r.Fs = fs
+		return nil
+	}
+}
+
+func WithLogger(logger v1.Logger) func(r *v1.RunConfig) error {
+	return func(r *v1.RunConfig) error {
+		r.Logger = logger
+		return nil
+	}
+}
+
+func WithSyscall(syscall v1.SyscallInterface) func(r *v1.RunConfig) error {
+	return func(r *v1.RunConfig) error {
+		r.Syscall = syscall
+		return nil
+	}
+}
+
+func WithMounter(mounter mount.Interface) func(r *v1.RunConfig) error {
+	return func(r *v1.RunConfig) error {
+		r.Mounter = mounter
+		return nil
+	}
+}
+
+func WithRunner(runner v1.Runner) func(r *v1.RunConfig) error {
+	return func(r *v1.RunConfig) error {
+		r.Runner = runner
+		return nil
+	}
+}
+
+func WithClient(client v1.HTTPClient) func(r *v1.RunConfig) error {
+	return func(r *v1.RunConfig) error {
+		r.Client = client
+		return nil
+	}
+}
+
+func WithCloudInitRunner(ci v1.CloudInitRunner) func(r *v1.RunConfig) error {
+	return func(r *v1.RunConfig) error {
+		r.CloudInitRunner = ci
+		return nil
+	}
+}
+
+func WithLuet(luet v1.LuetInterface) func(r *v1.RunConfig) error {
+	return func(r *v1.RunConfig) error {
+		r.Luet = luet
+		return nil
+	}
+}
+
+func NewRunConfig(opts ...RunConfigOptions) *v1.RunConfig {
 	log := v1.NewLogger()
 	r := &v1.RunConfig{
 		Fs:      vfs.OSFS,

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -40,12 +40,12 @@ var _ = Describe("Types", Label("types", "config"), func() {
 				logger := v1.NewNullLogger()
 				ci := &v1mock.FakeCloudInitRunner{}
 				c := config.NewRunConfig(
-					v1.WithFs(fs),
-					v1.WithMounter(mounter),
-					v1.WithRunner(runner),
-					v1.WithSyscall(sysc),
-					v1.WithLogger(logger),
-					v1.WithCloudInitRunner(ci),
+					config.WithFs(fs),
+					config.WithMounter(mounter),
+					config.WithRunner(runner),
+					config.WithSyscall(sysc),
+					config.WithLogger(logger),
+					config.WithCloudInitRunner(ci),
 				)
 				Expect(c.Fs).To(Equal(fs))
 				Expect(c.Mounter).To(Equal(mounter))
@@ -61,9 +61,9 @@ var _ = Describe("Types", Label("types", "config"), func() {
 				sysc := &v1mock.FakeSyscall{}
 				logger := v1.NewNullLogger()
 				c := config.NewRunConfig(
-					v1.WithRunner(runner),
-					v1.WithSyscall(sysc),
-					v1.WithLogger(logger),
+					config.WithRunner(runner),
+					config.WithSyscall(sysc),
+					config.WithLogger(logger),
 				)
 				Expect(c.Mounter).To(Equal(mount.New(constants.MountBinary)))
 			})
@@ -79,10 +79,10 @@ var _ = Describe("Types", Label("types", "config"), func() {
 				_, _ = fs.Create(constants.EfiDevice)
 
 				c = config.NewRunConfig(
-					v1.WithFs(fs),
-					v1.WithMounter(&mount.FakeMounter{}),
-					v1.WithRunner(v1mock.NewFakeRunner()),
-					v1.WithSyscall(&v1mock.FakeSyscall{}))
+					config.WithFs(fs),
+					config.WithMounter(&mount.FakeMounter{}),
+					config.WithRunner(v1mock.NewFakeRunner()),
+					config.WithSyscall(&v1mock.FakeSyscall{}))
 				c.Partitions = []*v1.Partition{
 					{
 						Label:      constants.StateLabel,

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -36,9 +36,11 @@ var _ = Describe("Types", Label("types", "config"), func() {
 				Expect(err).ToNot(HaveOccurred())
 				mounter := mount.NewFakeMounter([]mount.MountPoint{})
 				runner := v1mock.NewFakeRunner()
+				client := &v1mock.FakeHTTPClient{}
 				sysc := &v1mock.FakeSyscall{}
 				logger := v1.NewNullLogger()
 				ci := &v1mock.FakeCloudInitRunner{}
+				luet := &v1mock.FakeLuet{}
 				c := config.NewRunConfig(
 					config.WithFs(fs),
 					config.WithMounter(mounter),
@@ -46,6 +48,8 @@ var _ = Describe("Types", Label("types", "config"), func() {
 					config.WithSyscall(sysc),
 					config.WithLogger(logger),
 					config.WithCloudInitRunner(ci),
+					config.WithClient(client),
+					config.WithLuet(luet),
 				)
 				Expect(c.Fs).To(Equal(fs))
 				Expect(c.Mounter).To(Equal(mounter))
@@ -53,6 +57,21 @@ var _ = Describe("Types", Label("types", "config"), func() {
 				Expect(c.Syscall).To(Equal(sysc))
 				Expect(c.Logger).To(Equal(logger))
 				Expect(c.CloudInitRunner).To(Equal(ci))
+				Expect(c.Client).To(Equal(client))
+				Expect(c.Luet).To(Equal(luet))
+			})
+			It("Sets the runner if we dont pass one", func() {
+				fs, cleanup, err := vfst.NewTestFS(nil)
+				defer cleanup()
+				Expect(err).ToNot(HaveOccurred())
+				mounter := mount.NewFakeMounter([]mount.MountPoint{})
+				c := config.NewRunConfig(
+					config.WithFs(fs),
+					config.WithMounter(mounter),
+				)
+				Expect(c.Fs).To(Equal(fs))
+				Expect(c.Mounter).To(Equal(mounter))
+				Expect(c.Runner).ToNot(BeNil())
 			})
 		})
 		Describe("ConfigOptions no mounter specified", Label("mount", "mounter"), func() {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -68,40 +68,6 @@ var _ = Describe("Types", Label("types", "config"), func() {
 				Expect(c.Mounter).To(Equal(mount.New(constants.MountBinary)))
 			})
 		})
-		Describe("PartitionList.GetByName", Label("partition"), func() {
-			var c *v1.RunConfig
-
-			BeforeEach(func() {
-				fs, cleanup, err := vfst.NewTestFS(nil)
-				defer cleanup()
-				Expect(err).ToNot(HaveOccurred())
-
-				_, _ = fs.Create(constants.EfiDevice)
-
-				c = config.NewRunConfig(
-					config.WithFs(fs),
-					config.WithMounter(&mount.FakeMounter{}),
-					config.WithRunner(v1mock.NewFakeRunner()),
-					config.WithSyscall(&v1mock.FakeSyscall{}))
-				c.Partitions = []*v1.Partition{
-					{
-						Label:      constants.StateLabel,
-						Size:       constants.StateSize,
-						Name:       constants.StatePartName,
-						FS:         constants.LinuxFs,
-						MountPoint: constants.StateDir,
-						Flags:      []string{},
-					},
-				}
-			})
-			It("Finds a partition given a partition label", func() {
-				part := c.Partitions.GetByName(constants.StatePartName)
-				Expect(part.Name).To(Equal(constants.StatePartName))
-			})
-			It("Returns nil if requested partition label is not found", func() {
-				Expect(c.Partitions.GetByName("whatever")).To(BeNil())
-			})
-		})
 	})
 
 })

--- a/pkg/elemental/elemental_test.go
+++ b/pkg/elemental/elemental_test.go
@@ -65,12 +65,12 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 		logger = v1.NewNullLogger()
 		fs, cleanup, _ = vfst.NewTestFS(nil)
 		config = conf.NewRunConfig(
-			v1.WithFs(fs),
-			v1.WithRunner(runner),
-			v1.WithLogger(logger),
-			v1.WithMounter(mounter),
-			v1.WithSyscall(syscall),
-			v1.WithClient(client),
+			conf.WithFs(fs),
+			conf.WithRunner(runner),
+			conf.WithLogger(logger),
+			conf.WithMounter(mounter),
+			conf.WithSyscall(syscall),
+			conf.WithClient(client),
 		)
 	})
 	AfterEach(func() { cleanup() })

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -29,64 +29,6 @@ const (
 	BOOT  = "boot"
 )
 
-type RunConfigOptions func(a *RunConfig) error
-
-func WithFs(fs FS) func(r *RunConfig) error {
-	return func(r *RunConfig) error {
-		r.Fs = fs
-		return nil
-	}
-}
-
-func WithLogger(logger Logger) func(r *RunConfig) error {
-	return func(r *RunConfig) error {
-		r.Logger = logger
-		return nil
-	}
-}
-
-func WithSyscall(syscall SyscallInterface) func(r *RunConfig) error {
-	return func(r *RunConfig) error {
-		r.Syscall = syscall
-		return nil
-	}
-}
-
-func WithMounter(mounter mount.Interface) func(r *RunConfig) error {
-	return func(r *RunConfig) error {
-		r.Mounter = mounter
-		return nil
-	}
-}
-
-func WithRunner(runner Runner) func(r *RunConfig) error {
-	return func(r *RunConfig) error {
-		r.Runner = runner
-		return nil
-	}
-}
-
-func WithClient(client HTTPClient) func(r *RunConfig) error {
-	return func(r *RunConfig) error {
-		r.Client = client
-		return nil
-	}
-}
-
-func WithCloudInitRunner(ci CloudInitRunner) func(r *RunConfig) error {
-	return func(r *RunConfig) error {
-		r.CloudInitRunner = ci
-		return nil
-	}
-}
-
-func WithLuet(luet LuetInterface) func(r *RunConfig) error {
-	return func(r *RunConfig) error {
-		r.Luet = luet
-		return nil
-	}
-}
-
 // RunConfig is the struct that represents the full configuration needed for install, upgrade, reset, rebrand.
 // Basically everything needed to know for all operations in a running system, not related to builds
 type RunConfig struct {

--- a/pkg/types/v1/config_test.go
+++ b/pkg/types/v1/config_test.go
@@ -42,5 +42,47 @@ var _ = Describe("Types", Label("types", "config"), func() {
 
 		})
 	})
+	Describe("Partitionlist", func() {
+		var p v1.PartitionList
+		BeforeEach(func() {
+			p = v1.PartitionList{
+				&v1.Partition{
+					Label:      "",
+					Size:       0,
+					Name:       "one",
+					FS:         "",
+					Flags:      nil,
+					MountPoint: "",
+					Path:       "",
+					Disk:       "",
+				},
+				&v1.Partition{
+					Label:      "",
+					Size:       0,
+					Name:       "two",
+					FS:         "",
+					Flags:      nil,
+					MountPoint: "",
+					Path:       "",
+					Disk:       "",
+				},
+			}
+		})
+		It("returns partitions by name", func() {
+			Expect(p.GetByName("two")).To(Equal(&v1.Partition{
+				Label:      "",
+				Size:       0,
+				Name:       "two",
+				FS:         "",
+				Flags:      nil,
+				MountPoint: "",
+				Path:       "",
+				Disk:       "",
+			}))
+		})
+		It("returns nil if partiton not found", func() {
+			Expect(p.GetByName("nonexistent")).To(BeNil())
+		})
+	})
 
 })

--- a/pkg/types/v1/runner_test.go
+++ b/pkg/types/v1/runner_test.go
@@ -17,10 +17,12 @@ limitations under the License.
 package v1_test
 
 import (
+	"bytes"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "github.com/rancher-sandbox/elemental/pkg/types/v1"
 	v1mock "github.com/rancher-sandbox/elemental/tests/mocks"
+	"github.com/sirupsen/logrus"
 )
 
 var _ = Describe("Runner", Label("types", "runner"), func() {
@@ -33,5 +35,30 @@ var _ = Describe("Runner", Label("types", "runner"), func() {
 		r := v1mock.NewFakeRunner()
 		_, err := r.Run("pwd")
 		Expect(err).To(BeNil())
+	})
+	It("Sets and gets the logger on the fake runner", func() {
+		r := v1mock.NewFakeRunner()
+		Expect(r.GetLogger()).To(BeNil())
+		logger := v1.NewNullLogger()
+		r.SetLogger(logger)
+		Expect(r.GetLogger()).To(Equal(logger))
+	})
+	It("Sets and gets the logger on the real runner", func() {
+		r := v1.RealRunner{}
+		Expect(r.GetLogger()).To(BeNil())
+		logger := v1.NewNullLogger()
+		r.SetLogger(logger)
+		Expect(r.GetLogger()).To(Equal(logger))
+	})
+
+	It("logs the command when on debug", func() {
+
+		memLog := &bytes.Buffer{}
+		logger := v1.NewBufferLogger(memLog)
+		logger.SetLevel(logrus.DebugLevel)
+		r := v1.RealRunner{Logger: logger}
+		_, err := r.Run("command", "with", "args")
+		Expect(err).ToNot(BeNil()) // Command will fail
+		Expect(memLog.String()).To(ContainSubstring("command with args"))
 	})
 })

--- a/pkg/utils/runstage_test.go
+++ b/pkg/utils/runstage_test.go
@@ -61,12 +61,12 @@ var _ = Describe("run stage", Label("RunStage", "root"), func() {
 		fs, cleanup, _ = vfst.NewTestFS(nil)
 
 		config = conf.NewRunConfig(
-			v1.WithFs(fs),
-			v1.WithRunner(runner),
-			v1.WithLogger(logger),
-			v1.WithMounter(mounter),
-			v1.WithSyscall(syscall),
-			v1.WithClient(client),
+			conf.WithFs(fs),
+			conf.WithRunner(runner),
+			conf.WithLogger(logger),
+			conf.WithMounter(mounter),
+			conf.WithSyscall(syscall),
+			conf.WithClient(client),
 		)
 
 		config.CloudInitRunner = cloudinit.NewYipCloudInitRunner(config.Logger, config.Runner, fs)

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -69,12 +69,12 @@ var _ = Describe("Utils", Label("utils"), func() {
 		fs.Mkdir("/etc", constants.DirPerm)
 
 		config = conf.NewRunConfig(
-			v1.WithFs(fs),
-			v1.WithRunner(runner),
-			v1.WithLogger(logger),
-			v1.WithMounter(mounter),
-			v1.WithSyscall(syscall),
-			v1.WithClient(client),
+			conf.WithFs(fs),
+			conf.WithRunner(runner),
+			conf.WithLogger(logger),
+			conf.WithMounter(mounter),
+			conf.WithSyscall(syscall),
+			conf.WithClient(client),
 		)
 	})
 	AfterEach(func() { cleanup() })


### PR DESCRIPTION
It makes no sense to have the config options under types, lets move it
to the config package instead

Also adds some missing tests

Signed-off-by: Itxaka <igarcia@suse.com>