### PR TITLE
Test the docker image install over loop device

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -46,13 +46,14 @@ jobs:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
-      - name: Build and push
+      - name: Build image
         uses: docker/build-push-action@v2
         with:
-          # push and load can't be used at the same time
-          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
-          load: ${{ github.event_name == 'pull_request' }} # loads it locally, so it can be used from docker client
+          load: true # loads it locally, so it can be used from docker client
+          # cache into GitHub actions cache, nice
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           target: elemental
           build-args: |
             ELEMENTAL_VERSION=${{ steps.export_tag.outputs.elemental_tag }}
@@ -77,3 +78,16 @@ jobs:
           docker run -v /dev/:/dev/ --privileged ${{ steps.meta.outputs.tags }} install --debug -d quay.io/costoolkit/releases-green:cos-system-0.8.6 $LOOP
           sudo losetup -D $LOOP
           rm disk.img
+      - name: Push image  # should be a free build as everything has been cached and loaded
+        uses: docker/build-push-action@v2
+        if: ${{ github.event_name != 'pull_request' }}
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          # cache into GitHub actions cache, nice
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          target: elemental
+          build-args: |
+            ELEMENTAL_VERSION=${{ steps.export_tag.outputs.elemental_tag }}
+            ELEMENTAL_COMMIT=${{ github.sha }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - Dockerfile
+      - .github/workflows/docker.yaml
   push:
     branches:
       - main
@@ -16,6 +17,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: Install qemu-tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-utils
       - name: Export tag
         id: export_tag
         run: |
@@ -52,12 +57,23 @@ jobs:
           build-args: |
             ELEMENTAL_VERSION=${{ steps.export_tag.outputs.elemental_tag }}
             ELEMENTAL_COMMIT=${{ github.sha }}
-      - name: Test docker image
+      - name: Test elemental image version
+        run: docker run ${{ steps.meta.outputs.tags }} version --long
+      - name: Test elemental image install with --force-efi
         run: |
           # create a 30Gb file
-          # qemu-img create -f raw disk.img 30G
+          qemu-img create -f raw disk-efi.img 30G
           # mount loop device and get the device
-          #LOOP=`sudo losetup -fP --show disk.img`
-          # unfortunately loop devices are not properly refreshed under a container :/
-          #docker run --privileged ${{ steps.meta.outputs.tags }} install --debug -d quay.io/costoolkit/releases-green:cos-system-0.8.6 $LOOP
-          docker run ${{ steps.meta.outputs.tags }} version --long
+          LOOP=`sudo losetup -fP --show disk-efi.img`
+          docker run -v /dev/:/dev/ --privileged ${{ steps.meta.outputs.tags }} install --force-efi --debug -d quay.io/costoolkit/releases-green:cos-system-0.8.6 $LOOP
+          sudo losetup -D $LOOP
+          rm disk-efi.img
+      - name: Test elemental image install
+        run: |
+          # create a 30Gb file
+          qemu-img create -f raw disk.img 30G
+          # mount loop device and get the device
+          LOOP=`sudo losetup -fP --show disk.img`
+          docker run -v /dev/:/dev/ --privileged ${{ steps.meta.outputs.tags }} install --debug -d quay.io/costoolkit/releases-green:cos-system-0.8.6 $LOOP
+          sudo losetup -D $LOOP
+          rm disk.img

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,7 @@ FROM quay.io/costoolkit/releases-green:cosign-toolchain-$COSIGN_VERSION AS cosig
 
 
 FROM golang:$GOLANG_IMAGE_VERSION as elemental-bin
-ARG ELEMENTAL_VERSION=0.0.1
-ARG ELEMENTAL_COMMIT=""
-
 ENV CGO_ENABLED=0
-ENV ELEMENTAL_VERSION=${ELEMENTAL_VERSION}
-ENV ELEMENTAL_COMMIT=${ELEMENTAL_COMMIT}
 WORKDIR /src/
 # Add specific dirs to the image so cache is not invalidated when modifying non go files
 ADD go.mod .
@@ -23,6 +18,11 @@ ADD internal internal
 ADD tests tests
 ADD pkg pkg
 ADD main.go .
+# Set arg/env after go mod download, otherwise we invalidate the cached layers due to the commit changing easily
+ARG ELEMENTAL_VERSION=0.0.1
+ARG ELEMENTAL_COMMIT=""
+ENV ELEMENTAL_VERSION=${ELEMENTAL_VERSION}
+ENV ELEMENTAL_COMMIT=${ELEMENTAL_COMMIT}
 RUN go build \
     -ldflags "-w -s \
     -X github.com/rancher-sandbox/elemental/internal/version.version=$ELEMENTAL_VERSION \


### PR DESCRIPTION
Some other improvements:

 - mv arg/env to after go mod download as to not ivalidate the steps
before
 - use gha cache for building
 - add elemental install test for docker image
 - add docker.yaml file to docker job
 - user qemu-img to create the empty disk image
 - only build the image before tests, do not push
 - push the image after tests if not on PR

Signed-off-by: Itxaka <igarcia@suse.com>