### PR TITLE
Dont run tests if only Dockerfile has changed

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,11 +10,22 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Check if only Dockerfile has changed
+        id: changed-docker-files
+        uses: tj-actions/changed-files@v18.2
+        with:
+          files: |
+            Dockerfile
+            .github/workflows/docker.yaml
       - name: Install Go
+        if: steps.changed-docker-files.outputs.only_changed == 'false'
         uses: actions/setup-go@v2
         with:
           go-version: '^1.16'
       - uses: actions/cache@v2
+        if: steps.changed-docker-files.outputs.only_changed == 'false'
         with:
           path: |
             ~/go/pkg/mod
@@ -25,15 +36,18 @@ jobs:
       - name: Deps
         run: make test_deps
       - name: Run tests
+        if: steps.changed-docker-files.outputs.only_changed == 'false'
         run: |
           make test
           sudo env PATH="$PATH" make test_root
       - name: Merge coverage
+        if: steps.changed-docker-files.outputs.only_changed == 'false'
         run: |
           echo "mode: atomic" > coverage.out
           grep -v "mode: atomic" coverage.txt >> coverage.out
           grep -v "mode: atomic" coverage_root.txt >> coverage.out
       - name: Codecov
+        if: steps.changed-docker-files.outputs.only_changed == 'false'
         uses: codecov/codecov-action@v2
         with:
           file: ./coverage.out


### PR DESCRIPTION
It doesnt make sense to run the tests when only changing the dockerfile
or the docker job as that wont touch the main elemental source

This allows us to always required the test job to pass and let the CI run or not the tests

Signed-off-by: Itxaka <igarcia@suse.com>