### PR TITLE
Use local context for docker building

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -49,6 +49,7 @@ jobs:
       - name: Build image
         uses: docker/build-push-action@v2
         with:
+          context: .
           tags: ${{ steps.meta.outputs.tags }}
           load: true # loads it locally, so it can be used from docker client
           # cache into GitHub actions cache, nice
@@ -82,6 +83,7 @@ jobs:
         uses: docker/build-push-action@v2
         if: ${{ github.event_name != 'pull_request' }}
         with:
+          context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           # cache into GitHub actions cache, nice


### PR DESCRIPTION
If we let it use the default context, it will checkout the whole repo
again to get all the repo info. Instead, because we already check it out
to obtain the latest tag, we can use the already existing context and
avoid uneeded checkouts

Signed-off-by: Itxaka <igarcia@suse.com>