### PR TITLE
Add a eject-cd flag for install

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -89,5 +89,6 @@ func init() {
 	installCmd.Flags().BoolP("force-gpt", "", false, "Forces a GPT partition table")
 	installCmd.Flags().BoolP("tty", "", false, "Add named tty to grub")
 	installCmd.Flags().BoolP("force", "", false, "Force install")
+	installCmd.Flags().BoolP("eject-cd", "", false, "Try to eject the cd on reboot, only valid if booting from iso")
 	addSharedInstallUpgradeFlags(installCmd)
 }

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -249,6 +249,15 @@ func InstallRun(config *v1.RunConfig) (err error) { //nolint:gocyclo
 		return err
 	}
 
+	// If we want to eject the cd, create the required executable so the cd is ejected at shutdown
+	if config.EjectCD && utils.BootedFrom(config.Runner, "cdroot") {
+		config.Logger.Infof("Writing eject script")
+		err = config.Fs.WriteFile("/usr/lib/systemd/system-shutdown/eject", []byte(cnst.EjectScript), 0744)
+		if err != nil {
+			config.Logger.Warnf("Could not write eject script, cdrom wont be ejected automatically: %s", err)
+		}
+	}
+
 	// Reboot, poweroff or nothing
 	if config.Reboot {
 		config.Logger.Infof("Rebooting in 5 seconds")

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -92,6 +92,9 @@ const (
 	// Default directory and file fileModes
 	DirPerm  = os.ModeDir | os.ModePerm
 	FilePerm = 0666
+
+	// Eject script
+	EjectScript = "#!/bin/sh\n/usr/bin/eject -rmF"
 )
 
 func GetCloudInitPaths() []string {

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -66,6 +66,7 @@ type RunConfig struct {
 	ImgSize         uint   `yaml:"DEFAULT_IMAGE_SIZE,omitempty" mapstructure:"DEFAULT_IMAGE_SIZE"`
 	Directory       string `yaml:"directory,omitempty" mapstructure:"directory"`
 	ResetPersistent bool   `yaml:"reset-persistent,omitempty" mapstructure:"reset-persistent"`
+	EjectCD         bool   `yaml:"eject-cd,omitempty" mapstructure:"eject-cd"`
 	// Internally used to track stuff around
 	PartTable string
 	BootFlag  string


### PR DESCRIPTION
Adds a flag available to the installer which will try to create a script
under /usr/lib/systemd/system-shutdown which gets executed at the total
end of the shutdown/reboot process which will try to eject the cd

First part of https://github.com/rancher-sandbox/os2/issues/31

Signed-off-by: Itxaka <igarcia@suse.com>