### PR TITLE
Bump yip to master

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/kevinburke/ssh_config v1.1.0 // indirect
 	github.com/mudler/go-pluggable v0.0.0-20211206135551-9263b05c562e
 	github.com/mudler/luet v0.0.0-20220127164253-6f77fa2b3a72
-	github.com/mudler/yip v0.0.0-20220127115532-dd6192ae26bf
+	github.com/mudler/yip v0.0.0-20220321143540-2617d71ea02a
 	github.com/onsi/ginkgo/v2 v2.1.3
 	github.com/onsi/gomega v1.18.0
 	github.com/packethost/packngo v0.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -845,8 +845,8 @@ github.com/mudler/luet v0.0.0-20220127164253-6f77fa2b3a72 h1:rYCpt//zBKWR65M7nAO
 github.com/mudler/luet v0.0.0-20220127164253-6f77fa2b3a72/go.mod h1:3zNs/Vlh0bkqCwrIE5XbwNvbYJ3mvmCL3ek2xh+0jN8=
 github.com/mudler/topsort v0.0.0-20201103161459-db5c7901c290 h1:426hFyXMpXeqIeGJn2cGAW9ogvM2Jf+Jv23gtVPvBLM=
 github.com/mudler/topsort v0.0.0-20201103161459-db5c7901c290/go.mod h1:uP5BBgFxq2wNWo7n1vnY5SSbgL0WDshVJrOO12tZ/lA=
-github.com/mudler/yip v0.0.0-20220127115532-dd6192ae26bf h1:KfJguk2AkPNA+yGc7PPgW9u4G7tQtP9xF5BcEf1r0K4=
-github.com/mudler/yip v0.0.0-20220127115532-dd6192ae26bf/go.mod h1:kMkNxi+1D644aNeWyEDMoMOTHdC8X0iBqD8wqLcPIXA=
+github.com/mudler/yip v0.0.0-20220321143540-2617d71ea02a h1:Mfw/jKrBW4KXMBfmFgJIWkvvCEqrv5o+c1nKZD8av3o=
+github.com/mudler/yip v0.0.0-20220321143540-2617d71ea02a/go.mod h1:kMkNxi+1D644aNeWyEDMoMOTHdC8X0iBqD8wqLcPIXA=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=


### PR DESCRIPTION
This commit is to bump yip library to include the latest user
creation patches (mudler/yip#37).

Related to rancher-sandbox/os2#13

Signed-off-by: David Cassany <dcassany@suse.com>