### PR TITLE
Relocate GPT headers for expanded disks

### DIFF
--- a/pkg/partitioner/disk.go
+++ b/pkg/partitioner/disk.go
@@ -118,6 +118,19 @@ func (dev *Disk) Reload() error {
 		return err
 	}
 
+	if pc.HasUnallocatedSpace(prnt) {
+		// Parted has not a proper way to doing it in non interactive mode,
+		// because of that we use sgdisk for that...
+		_, err = dev.runner.Run("sgdisk", "-e", dev.device)
+		if err != nil {
+			return err
+		}
+		prnt, err = pc.Print()
+		if err != nil {
+			return err
+		}
+	}
+
 	sectorS, err := pc.GetSectorSize(prnt)
 	if err != nil {
 		return err

--- a/pkg/partitioner/disk.go
+++ b/pkg/partitioner/disk.go
@@ -31,7 +31,11 @@ import (
 
 const (
 	partitionTries = 10
+	// Parted warning substring for expanded disks without fixing GPT headers
+	partedWarn = "Not all of the space available"
 )
+
+var unallocatedRegexp = regexp.MustCompile(partedWarn)
 
 type Disk struct {
 	device  string
@@ -118,13 +122,20 @@ func (dev *Disk) Reload() error {
 		return err
 	}
 
-	if pc.HasUnallocatedSpace(prnt) {
+	// if the unallocated space warning is found it is assumed GPT headers
+	// are not properly located to match disk size, so we use sgdisk
+	// to expand the partition table to fully match disk size.
+	// It is expected that in upcoming parted releases (>3.4) there will be
+	// --fix flag to solve this issue transparently on the fly on any parted call.
+	// However this option is not yet present in all major distros.
+	if unallocatedRegexp.Match([]byte(prnt)) {
 		// Parted has not a proper way to doing it in non interactive mode,
 		// because of that we use sgdisk for that...
 		_, err = dev.runner.Run("sgdisk", "-e", dev.device)
 		if err != nil {
 			return err
 		}
+		// Reload disk data with fixed headers
 		prnt, err = pc.Print()
 		if err != nil {
 			return err

--- a/pkg/partitioner/parted.go
+++ b/pkg/partitioner/parted.go
@@ -155,17 +155,6 @@ func (pc PartedCall) Print() (string, error) {
 	return string(out), err
 }
 
-// HasUnallocatedSpace parses a parted print command output and checks for a
-// warning within the output complaining about wrong GPT end header. If
-// the warning is found it assumes the GPT end header is not at the end of
-// the disk, hence it needs to be adapted to get valid sizes from parted
-// print. Parted has no proper command to verify GPT headers neither a
-// proper command to fix them whenever is possible in a non interactive mode.
-func (pc PartedCall) HasUnallocatedSpace(printOut string) bool {
-	unallocated, _ := regexp.MatchString("Not all of the space available", printOut)
-	return unallocated
-}
-
 // Parses the output of a PartedCall.Print call
 func (pc PartedCall) parseHeaderFields(printOut string, field int) (string, error) {
 	re := regexp.MustCompile(`^(.*):(\d+)s:(.*):(\d+):(\d+):(.*):(.*):(.*);$`)

--- a/pkg/partitioner/parted.go
+++ b/pkg/partitioner/parted.go
@@ -155,6 +155,17 @@ func (pc PartedCall) Print() (string, error) {
 	return string(out), err
 }
 
+// HasUnallocatedSpace parses a parted print command output and checks for a
+// warning within the output complaining about wrong GPT end header. If
+// the warning is found it assumes the GPT end header is not at the end of
+// the disk, hence it needs to be adapted to get valid sizes from parted
+// print. Parted has no proper command to verify GPT headers neither a
+// proper command to fix them whenever is possible in a non interactive mode.
+func (pc PartedCall) HasUnallocatedSpace(printOut string) bool {
+	unallocated, _ := regexp.MatchString("Not all of the space available", printOut)
+	return unallocated
+}
+
 // Parses the output of a PartedCall.Print call
 func (pc PartedCall) parseHeaderFields(printOut string, field int) (string, error) {
 	re := regexp.MustCompile(`^(.*):(\d+)s:(.*):(\d+):(\d+):(.*):(.*):(.*);$`)

--- a/pkg/partitioner/partitioner_test.go
+++ b/pkg/partitioner/partitioner_test.go
@@ -253,6 +253,15 @@ var _ = Describe("Partitioner", Label("disk", "partition", "partitioner"), func(
 				dev.Reload()
 				Expect(dev.GetLabel()).To(Equal("msdos"))
 			})
+			It("It fixes GPT headers if the disk was expanded", func() {
+				runner.ReturnValue = []byte("Warning: Not all of the space available to /dev/loop0...\n" + printOutput)
+				Expect(dev.Reload()).To(BeNil())
+				Expect(runner.MatchMilestones([][]string{
+					{"parted", "--script", "--machine", "--", "/some/device", "unit", "s", "print"},
+					{"sgdisk", "-e", "/some/device"},
+					{"parted", "--script", "--machine", "--", "/some/device", "unit", "s", "print"},
+				})).To(BeNil())
+			})
 		})
 		Describe("Modify disk", func() {
 			It("Format an already existing partition", func() {


### PR DESCRIPTION
This commit ensure the partitioner module run 'sgdisk -e /dev/disk' to
fix GPT headers in case the disk was expanded or some smaller image was
dumped into the disk.

Fixes rancher-sandbox/cOS-toolkit#1201

Signed-off-by: David Cassany <dcassany@suse.com>