### PR TITLE
build-iso command first round implementation

### DIFF
--- a/cmd/build-iso.go
+++ b/cmd/build-iso.go
@@ -52,7 +52,10 @@ var buildISO = &cobra.Command{
 			cfg.ISO.RootFS = []string{args[0]}
 		}
 
-		validateCosignFlags(cfg.Logger)
+		err = validateCosignFlags(cfg.Logger)
+		if err != nil {
+			return err
+		}
 
 		// Set this after parsing of the flags, so it fails on parsing and prints usage properly
 		cmd.SilenceUsage = true
@@ -74,7 +77,7 @@ var buildISO = &cobra.Command{
 			if ok, err := utils.Exists(cfg.Fs, oUEFI); ok {
 				cfg.ISO.UEFI = append(cfg.ISO.UEFI, oUEFI)
 			} else {
-				cfg.Logger.Errorf("Invalid value for overlay-rootfs")
+				cfg.Logger.Errorf("Invalid value for overlay-uefi")
 				return fmt.Errorf("Invalid path '%s': %v", oUEFI, err)
 			}
 		}
@@ -82,7 +85,7 @@ var buildISO = &cobra.Command{
 			if ok, err := utils.Exists(cfg.Fs, oISO); ok {
 				cfg.ISO.Image = append(cfg.ISO.Image, oISO)
 			} else {
-				cfg.Logger.Errorf("Invalid value for overlay-rootfs")
+				cfg.Logger.Errorf("Invalid value for overlay-iso")
 				return fmt.Errorf("Invalid path '%s': %v", oISO, err)
 			}
 		}
@@ -104,7 +107,7 @@ func init() {
 	buildISO.Flags().String("overlay-rootfs", "", "Path of the overlayed rootfs data")
 	buildISO.Flags().String("overlay-uefi", "", "Path of the overlayed uefi data")
 	buildISO.Flags().String("overlay-iso", "", "Path of the overlayed iso data")
-	// TODO find away to specify or guess source types
+	// TBC expose rootfs as flags?
 	//buildISO.Flags().StringArray("rootfs", []string{}, "A list of sources for the rootfs image. Can be repeated to add more than one source.")
 	buildISO.Flags().StringArray("isoimage", []string{}, "A list of sources for the ISO image. Can be repeated to add more than one source.")
 	buildISO.Flags().StringArray("uefi", []string{}, "A list of sources for the UEFI image. Can be repeated to add more than one source.")

--- a/cmd/build-iso.go
+++ b/cmd/build-iso.go
@@ -1,0 +1,112 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"os/exec"
+
+	"github.com/rancher-sandbox/elemental/cmd/config"
+	"github.com/rancher-sandbox/elemental/pkg/action"
+	"github.com/rancher-sandbox/elemental/pkg/utils"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"k8s.io/mount-utils"
+)
+
+// buildISO represents the build-iso command
+var buildISO = &cobra.Command{
+	Use:   "build-iso IMAGE",
+	Short: "elemental build-iso IMAGE",
+	Args:  cobra.MaximumNArgs(1),
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		return CheckRoot()
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		path, err := exec.LookPath("mount")
+		if err != nil {
+			return err
+		}
+		mounter := mount.New(path)
+
+		cfg, err := config.ReadConfigBuild(viper.GetString("config-dir"), mounter)
+		if err != nil {
+			cfg.Logger.Errorf("Error reading config: %s\n", err)
+		}
+
+		if len(args) == 1 {
+			cfg.ISO.RootFS = []string{args[0]}
+		}
+
+		validateCosignFlags(cfg.Logger)
+
+		// Set this after parsing of the flags, so it fails on parsing and prints usage properly
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true // Do not propagate errors down the line, we control them
+
+		oRootfs, _ := cmd.Flags().GetString("overlay-rootfs")
+		oUEFI, _ := cmd.Flags().GetString("overlay-uefi")
+		oISO, _ := cmd.Flags().GetString("overlay-iso")
+
+		if oRootfs != "" {
+			if ok, err := utils.Exists(cfg.Fs, oRootfs); ok {
+				cfg.ISO.RootFS = append(cfg.ISO.RootFS, oRootfs)
+			} else {
+				cfg.Logger.Errorf("Invalid value for overlay-rootfs")
+				return fmt.Errorf("Invalid path '%s': %v", oRootfs, err)
+			}
+		}
+		if oUEFI != "" {
+			if ok, err := utils.Exists(cfg.Fs, oUEFI); ok {
+				cfg.ISO.UEFI = append(cfg.ISO.UEFI, oUEFI)
+			} else {
+				cfg.Logger.Errorf("Invalid value for overlay-rootfs")
+				return fmt.Errorf("Invalid path '%s': %v", oUEFI, err)
+			}
+		}
+		if oISO != "" {
+			if ok, err := utils.Exists(cfg.Fs, oISO); ok {
+				cfg.ISO.Image = append(cfg.ISO.Image, oISO)
+			} else {
+				cfg.Logger.Errorf("Invalid value for overlay-rootfs")
+				return fmt.Errorf("Invalid path '%s': %v", oISO, err)
+			}
+		}
+
+		err = action.BuildISORun(cfg)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(buildISO)
+	buildISO.Flags().String("label", "", "Label of the ISO volume")
+	buildISO.Flags().StringP("name", "n", "", "Basename of the generated ISO file")
+	buildISO.Flags().Bool("date", true, "Adds a date suffix into the generated ISO file")
+	buildISO.Flags().String("overlay-rootfs", "", "Path of the overlayed rootfs data")
+	buildISO.Flags().String("overlay-uefi", "", "Path of the overlayed uefi data")
+	buildISO.Flags().String("overlay-iso", "", "Path of the overlayed iso data")
+	// TODO find away to specify or guess source types
+	//buildISO.Flags().StringArray("rootfs", []string{}, "A list of sources for the rootfs image. Can be repeated to add more than one source.")
+	buildISO.Flags().StringArray("isoimage", []string{}, "A list of sources for the ISO image. Can be repeated to add more than one source.")
+	buildISO.Flags().StringArray("uefi", []string{}, "A list of sources for the UEFI image. Can be repeated to add more than one source.")
+	addCosignFlags(buildISO)
+}

--- a/cmd/build-iso.go
+++ b/cmd/build-iso.go
@@ -57,6 +57,8 @@ var buildISO = &cobra.Command{
 			return err
 		}
 
+		//TODO validate there is, at least some source for rootfs, uefi and isoimage
+
 		// Set this after parsing of the flags, so it fails on parsing and prints usage properly
 		cmd.SilenceUsage = true
 		cmd.SilenceErrors = true // Do not propagate errors down the line, we control them

--- a/cmd/config/config/manifest.yaml
+++ b/cmd/config/config/manifest.yaml
@@ -1,4 +1,4 @@
-packages:
+iso:
   rootfs:
     - system/cos
   uefi:
@@ -7,6 +7,7 @@ packages:
     - live/grub2
     - live/grub2-efi-image
     - recovery/cos-img
+  label: "COS_LIVE"
 
 # Raw disk creation values start
 
@@ -49,26 +50,5 @@ raw_disk:
 
 # Raw disk creation values end
 
-boot_file: "boot/x86_64/loader/eltorito.img"
-boot_catalog: "boot/x86_64/boot.catalog"
-isohybrid_mbr: "boot/x86_64/loader/boot_hybrid.img"
-
-initramfs:
-  kernel_file: "vmlinuz"
-  rootfs_file: "initrd"
-
-
-image_prefix: "cOS-0."
-image_date: true
-label: "COS_LIVE"
-
-# Additional packages to build
-build:
-  - utils/nerdctl
-  - utils/k9s
-  - utils/jq
-  - selinux/rancher
-  - selinux/k3s
-  - recovery/cos
-  - system/grub2-artifacts
-  - system/grub2-efi-image
+name: "cOS-0"
+date: true

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.2 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20220113124808-70ae35bab23f // indirect
 	github.com/cavaliergopher/grab/v3 v3.0.1
+	github.com/distribution/distribution v2.8.1+incompatible
 	github.com/docker/docker v20.10.12+incompatible
 	github.com/docker/go-units v0.4.0
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -359,6 +359,8 @@ github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8
 github.com/diskfs/go-diskfs v1.1.1/go.mod h1:afUPxxu+x1snp4aCY2bKR0CoZ/YFJewV3X2UEr2nPZE=
 github.com/diskfs/go-diskfs v1.2.1-0.20211109185859-9509735ba7a4 h1:r3v6uGKwhBghjhxkUPa/T+YuARVY8dDc2tdpLwUfWc0=
 github.com/diskfs/go-diskfs v1.2.1-0.20211109185859-9509735ba7a4/go.mod h1:IoDpuEbpS+D+yCGdoOm6GNfyTeEws77ALvcMQFxmenw=
+github.com/distribution/distribution v2.8.1+incompatible h1:8iXUoOqRPx30bhzIEPUmNIqlmBlWdrieW1bqr6LrX30=
+github.com/distribution/distribution v2.8.1+incompatible/go.mod h1:EgLm2NgWtdKgzF9NpMzUKgzmR7AMmb0VQi2B+ZzDRjc=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/docker/cli v20.10.10+incompatible h1:kcbwdgWbrBOH8QwQzaJmyriHwF7XIl4HT1qh0HTRys4=
 github.com/docker/cli v20.10.10+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=

--- a/pkg/action/action_suite_test.go
+++ b/pkg/action/action_suite_test.go
@@ -1,0 +1,28 @@
+/*
+   Copyright © 2022 SUSE LLC
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package action_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestElementalSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Actions test suite")
+}

--- a/pkg/action/build-iso.go
+++ b/pkg/action/build-iso.go
@@ -1,0 +1,331 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package action
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/rancher-sandbox/elemental/pkg/constants"
+	"github.com/rancher-sandbox/elemental/pkg/partitioner"
+	v1 "github.com/rancher-sandbox/elemental/pkg/types/v1"
+	"github.com/rancher-sandbox/elemental/pkg/utils"
+)
+
+// BuildISORun will install the system from a given configuration
+func BuildISORun(cfg *v1.BuildConfig) (err error) {
+	cleanup := utils.NewCleanStack()
+	defer func() { err = cleanup.Cleanup(err) }()
+
+	rootDir, err := utils.TempDir(cfg.Fs, "", "elemental-iso-rootfs")
+	if err != nil {
+		return err
+	}
+	cleanup.Push(func() error { return cfg.Fs.RemoveAll(rootDir) })
+
+	uefiDir, err := utils.TempDir(cfg.Fs, "", "elemental-iso-uefi")
+	if err != nil {
+		return err
+	}
+	cleanup.Push(func() error { return cfg.Fs.RemoveAll(uefiDir) })
+
+	isoDir, err := utils.TempDir(cfg.Fs, "", "elemental-iso")
+	if err != nil {
+		return err
+	}
+	cleanup.Push(func() error { return cfg.Fs.RemoveAll(isoDir) })
+
+	err = applySources(cfg.Config, rootDir, cfg.ISO.RootFS...)
+	if err != nil {
+		cfg.Logger.Errorf("Failed installing OS packages: %v", err)
+		return err
+	}
+
+	err = applySources(cfg.Config, uefiDir, cfg.ISO.UEFI...)
+	if err != nil {
+		cfg.Logger.Errorf("Failed installing EFI packages: %v", err)
+		return err
+	}
+
+	err = applySources(cfg.Config, isoDir, cfg.ISO.Image...)
+	if err != nil {
+		cfg.Logger.Errorf("Failed installing ISO image packages: %v", err)
+		return err
+	}
+
+	err = prepareISORoot(cfg.Config, isoDir, rootDir, uefiDir) // mksquashfs, mkfs.fat copy kernel and initrd
+	if err != nil {
+		cfg.Logger.Errorf("Failed preparing ISO's root tree: %v", err)
+		return err
+	}
+
+	err = burnISO(cfg, isoDir)
+	if err != nil {
+		cfg.Logger.Errorf("Failed preparing ISO's root tree: %v", err)
+		return err
+	}
+
+	return err
+}
+
+func prepareISORoot(c v1.Config, isoDir string, rootDir string, uefiDir string) error {
+	kernel, initrd, err := findKernelInitrd(c, rootDir)
+	if err != nil {
+		c.Logger.Error("Could not find kernel and/or initrd")
+		return err
+	}
+	err = utils.MkdirAll(c.Fs, filepath.Join(isoDir, "boot"), constants.DirPerm)
+	if err != nil {
+		return err
+	}
+	//TODO document boot/kernel and boot/initrd expectation in bootloader config
+	c.Logger.Debugf("Copying Kernel file %s to iso root tree", kernel)
+	err = utils.CopyFile(c.Fs, kernel, filepath.Join(isoDir, constants.IsoKernelPath))
+	if err != nil {
+		return err
+	}
+
+	c.Logger.Debugf("Copying initrd file %s to iso root tree", initrd)
+	err = utils.CopyFile(c.Fs, initrd, filepath.Join(isoDir, constants.IsoInitrdPath))
+	if err != nil {
+		return err
+	}
+
+	c.Logger.Info("Creating squashfs...")
+	err = utils.CreateSquashFS(c.Runner, c.Logger, rootDir, filepath.Join(isoDir, constants.IsoRootFile), constants.GetDefaultSquashfsOptions())
+	if err != nil {
+		return err
+	}
+
+	c.Logger.Info("Creating EFI image...")
+	err = createEFI(c, uefiDir, filepath.Join(isoDir, constants.IsoEFIPath))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func findFileWithPrefix(fs v1.FS, path string, prefixes ...string) (string, error) {
+	files, err := fs.ReadDir(path)
+	if err != nil {
+		return "", err
+	}
+	for _, f := range files {
+		for _, p := range prefixes {
+			if !f.IsDir() && strings.HasPrefix(f.Name(), p) {
+				found, err := fs.Readlink(filepath.Join(path, f.Name()))
+				if err == nil {
+					return filepath.Join(path, found), nil
+				}
+			}
+		}
+	}
+	return "", fmt.Errorf("No file found with prefixes: %v", prefixes)
+}
+
+func findKernelInitrd(c v1.Config, rootDir string) (kernel string, initrd string, err error) {
+	kernelNames := []string{"uImage", "Image", "zImage", "vmlinuz", "image", "vmlinux"}
+	initrdNames := []string{"initrd", "initramfs"}
+	kernel, err = findFileWithPrefix(c.Fs, filepath.Join(rootDir, "boot"), kernelNames...)
+	if err != nil {
+		c.Logger.Errorf("No Kernel file found")
+		return "", "", err
+	}
+	initrd, err = findFileWithPrefix(c.Fs, filepath.Join(rootDir, "boot"), initrdNames...)
+	if err != nil {
+		c.Logger.Errorf("No initrd file found")
+		return "", "", err
+	}
+	return kernel, initrd, nil
+}
+
+func createEFI(c v1.Config, root string, img string) error {
+	efiSize, err := utils.DirSize(c.Fs, root)
+	if err != nil {
+		return err
+	}
+
+	// align efiSize to the next 4MB slot
+	align := int64(4 * 1024 * 1024)
+	efiSize = efiSize/align*align + align
+
+	// TODO this is a copy of Elemental's CreateFilesystemImage, Elemental should not be tied to RunConfig
+	err = utils.MkdirAll(c.Fs, filepath.Dir(img), constants.DirPerm)
+	if err != nil {
+		return err
+	}
+	actImg, err := c.Fs.Create(img)
+	if err != nil {
+		return err
+	}
+
+	err = actImg.Truncate(efiSize)
+	if err != nil {
+		actImg.Close()
+		_ = c.Fs.RemoveAll(img)
+		return err
+	}
+	err = actImg.Close()
+	if err != nil {
+		_ = c.Fs.RemoveAll(img)
+		return err
+	}
+
+	mkfs := partitioner.NewMkfsCall(img, constants.EfiFs, constants.EfiLabel, c.Runner)
+	_, err = mkfs.Apply()
+	if err != nil {
+		_ = c.Fs.RemoveAll(img)
+		return err
+	}
+	// End of CreateFileSystemImage copy
+
+	files, err := c.Fs.ReadDir(root)
+	if err != nil {
+		return err
+	}
+
+	for _, f := range files {
+		_, err = c.Runner.Run("mcopy", "-s", "-i", img, filepath.Join(root, f.Name()), "::")
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func burnISO(c *v1.BuildConfig, root string) error {
+	cmd := "xorriso"
+	var outputFile string
+
+	if c.Date {
+		currTime := time.Now()
+		outputFile = fmt.Sprintf("%s.%s.iso", c.Name, currTime.Format("20060102"))
+	} else {
+		outputFile = fmt.Sprintf("%s.iso", c.Name)
+	}
+
+	if exists, _ := utils.Exists(c.Fs, outputFile); exists {
+		c.Logger.Warnf("Overwriting already existing %s", outputFile)
+		err := c.Fs.Remove(outputFile)
+		if err != nil {
+			return err
+		}
+	}
+
+	args := []string{
+		"-volid", c.ISO.Label, "-joliet", "on", "-padding", "0",
+		"-outdev", outputFile, "-map", root, "/", "-chmod", "0755", "--",
+	}
+
+	// TODO: make this detection more robust
+	// Assume ISOLINUX bootloader is used if boot file is includes 'isolinux'
+	// in its name, otherwise assume an eltorito based grub2 setup
+	if strings.Contains(c.ISO.BootFile, "isolinux") {
+		args = append(args, []string{
+			"-boot_image", "isolinux", fmt.Sprintf("bin_path=%s", c.ISO.BootFile),
+			"-boot_image", "isolinux", fmt.Sprintf("system_area=%s/%s", root, c.ISO.HybridMBR),
+			"-boot_image", "isolinux", "partition_table=on",
+		}...)
+	} else {
+		args = append(args, []string{
+			"-boot_image", "grub", fmt.Sprintf("bin_path=%s", c.ISO.BootFile),
+			"-boot_image", "grub", fmt.Sprintf("grub2_mbr=%s/%s", root, c.ISO.HybridMBR),
+			"-boot_image", "grub", "grub2_boot_info=on",
+		}...)
+	}
+
+	args = append(args, []string{
+		"-boot_image", "any", "partition_offset=16",
+		"-boot_image", "any", fmt.Sprintf("cat_path=%s", c.ISO.BootCatalog),
+		"-boot_image", "any", "cat_hidden=on",
+		"-boot_image", "any", "boot_info_table=on",
+		"-boot_image", "any", "platform_id=0x00",
+		"-boot_image", "any", "emul_type=no_emulation",
+		"-boot_image", "any", "load_size=2048",
+		"-append_partition", "2", "0xef", fmt.Sprintf("%s/boot/uefi.img", root),
+		"-boot_image", "any", "next",
+		"-boot_image", "any", "efi_path=--interval:appended_partition_2:all::",
+		"-boot_image", "any", "platform_id=0xef",
+		"-boot_image", "any", "emul_type=no_emulation",
+	}...)
+	out, err := c.Runner.Run(cmd, args...)
+	c.Logger.Debugf("Xorriso: %s", string(out))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func applySources(c v1.Config, target string, sources ...string) error {
+	var err error
+	for _, src := range sources {
+		err = applySource(c, target, utils.NewSrcGuessingType(c, src))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// TODO this method should be part of Elemental (almost the same code as in CopyImage) however Elemental
+// is tied to RunConfig while it shouldn't, related to issue #33
+func applySource(c v1.Config, target string, src v1.ImageSource) error {
+	c.Logger.Debugf("Applying source %s to target %s", src.Value(), target)
+	if src.IsDocker() {
+		if c.Cosign {
+			c.Logger.Infof("Running cosing verification for %s", src.Value())
+			out, err := utils.CosignVerify(
+				c.Fs, c.Runner, src.Value(),
+				c.CosignPubKey, v1.IsDebugLevel(c.Logger),
+			)
+			if err != nil {
+				c.Logger.Errorf("Cosign verification failed: %s", out)
+				return err
+			}
+		}
+		err := c.Luet.Unpack(target, src.Value(), false)
+		if err != nil {
+			return err
+		}
+	} else if src.IsDir() {
+		excludes := []string{"mnt", "proc", "sys", "dev", "tmp", "host", "run"}
+		err := utils.SyncData(c.Fs, src.Value(), target, excludes...)
+		if err != nil {
+			return err
+		}
+	} else if src.IsChannel() {
+		err := c.Luet.UnpackFromChannel(target, src.Value())
+		if err != nil {
+			return err
+		}
+	} else if src.IsFile() {
+		err := utils.MkdirAll(c.Fs, filepath.Dir(target), constants.DirPerm)
+		if err != nil {
+			return err
+		}
+		err = utils.CopyFile(c.Fs, src.Value(), target)
+		if err != nil {
+			return err
+		}
+	} else {
+		return fmt.Errorf("Unknown image source type for %s", src.Value())
+	}
+	return nil
+}

--- a/pkg/action/build_test.go
+++ b/pkg/action/build_test.go
@@ -1,0 +1,188 @@
+/*
+   Copyright © 2022 SUSE LLC
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package action_test
+
+import (
+	"errors"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rancher-sandbox/elemental/pkg/action"
+	"github.com/rancher-sandbox/elemental/pkg/config"
+	"github.com/rancher-sandbox/elemental/pkg/constants"
+	v1 "github.com/rancher-sandbox/elemental/pkg/types/v1"
+	"github.com/rancher-sandbox/elemental/pkg/utils"
+	v1mock "github.com/rancher-sandbox/elemental/tests/mocks"
+	"github.com/twpayne/go-vfs"
+	"github.com/twpayne/go-vfs/vfst"
+)
+
+var _ = Describe("Runtime Actions", func() {
+	var cfg *v1.BuildConfig
+	var runner *v1mock.FakeRunner
+	var fs vfs.FS
+	var logger v1.Logger
+	var mounter *v1mock.ErrorMounter
+	var syscall *v1mock.FakeSyscall
+	var client *v1mock.FakeHTTPClient
+	var cloudInit *v1mock.FakeCloudInitRunner
+	var luet *v1mock.FakeLuet
+	var cleanup func()
+	BeforeEach(func() {
+		runner = v1mock.NewFakeRunner()
+		syscall = &v1mock.FakeSyscall{}
+		mounter = v1mock.NewErrorMounter()
+		client = &v1mock.FakeHTTPClient{}
+		logger = v1.NewNullLogger()
+		cloudInit = &v1mock.FakeCloudInitRunner{}
+		luet = &v1mock.FakeLuet{}
+		fs, cleanup, _ = vfst.NewTestFS(map[string]interface{}{})
+		cfg = config.NewBuildConfig(
+			config.WithFs(fs),
+			config.WithRunner(runner),
+			config.WithLogger(logger),
+			config.WithMounter(mounter),
+			config.WithSyscall(syscall),
+			config.WithClient(client),
+			config.WithCloudInitRunner(cloudInit),
+			config.WithLuet(luet),
+		)
+	})
+	AfterEach(func() {
+		cleanup()
+	})
+	Describe("Build ISO", Label("iso"), func() {
+		It("Successfully builds an ISO from a Docker image", func() {
+			cfg.Date = true
+			cfg.ISO.RootFS = []string{"elementalos:latest"}
+			cfg.ISO.UEFI = []string{"live/efi"}
+			cfg.ISO.Image = []string{"live/bootloader"}
+
+			luet.UnpackSideEffect = func(target string, image string, local bool) error {
+				bootDir := filepath.Join(target, "boot")
+				err := utils.MkdirAll(fs, bootDir, constants.DirPerm)
+				if err != nil {
+					return err
+				}
+				_, err = fs.Create(filepath.Join(bootDir, "vmlinuz"))
+				if err != nil {
+					return err
+				}
+				_, err = fs.Create(filepath.Join(bootDir, "initrd"))
+				if err != nil {
+					return err
+				}
+				return nil
+			}
+
+			err := action.BuildISORun(cfg)
+
+			Expect(luet.UnpackCalled()).To(BeTrue())
+			Expect(luet.UnpackChannelCalled()).To(BeTrue())
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+		It("Successfully builds an ISO from a luet channel including overlayed files", func() {
+			cfg.ISO.RootFS = []string{"system/elemental", "/overlay/dir"}
+			cfg.ISO.UEFI = []string{"live/efi"}
+			cfg.ISO.Image = []string{"live/bootloader"}
+
+			err := utils.MkdirAll(fs, "/overlay/dir/boot", constants.DirPerm)
+			Expect(err).ShouldNot(HaveOccurred())
+			_, err = fs.Create("/overlay/dir/boot/vmlinuz")
+			Expect(err).ShouldNot(HaveOccurred())
+			_, err = fs.Create("/overlay/dir/boot/initrd")
+			Expect(err).ShouldNot(HaveOccurred())
+
+			err = action.BuildISORun(cfg)
+
+			Expect(luet.UnpackChannelCalled()).To(BeTrue())
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+		It("Fails if kernel or initrd is not found in rootfs", func() {
+			cfg.ISO.RootFS = []string{"/local/dir"}
+			cfg.ISO.UEFI = []string{"live/efi"}
+			cfg.ISO.Image = []string{"live/bootloader"}
+
+			err := utils.MkdirAll(fs, "/local/dir/boot", constants.DirPerm)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			By("fails without kernel")
+			err = action.BuildISORun(cfg)
+			Expect(err).Should(HaveOccurred())
+
+			By("fails without initrd")
+			_, err = fs.Create("/local/dir/boot/vmlinuz")
+			Expect(err).ShouldNot(HaveOccurred())
+			err = action.BuildISORun(cfg)
+			Expect(err).Should(HaveOccurred())
+		})
+		It("Fails installing rootfs sources", func() {
+			cfg.ISO.RootFS = []string{"system/elemental"}
+			luet.OnUnpackFromChannelError = true
+
+			err := action.BuildISORun(cfg)
+			Expect(err).Should(HaveOccurred())
+			Expect(luet.UnpackChannelCalled()).To(BeTrue())
+		})
+		It("Fails installing uefi sources", func() {
+			cfg.ISO.RootFS = []string{"elemental:latest"}
+			cfg.ISO.UEFI = []string{"live/efi"}
+			luet.OnUnpackFromChannelError = true
+
+			err := action.BuildISORun(cfg)
+			Expect(err).Should(HaveOccurred())
+			Expect(luet.UnpackCalled()).To(BeTrue())
+			Expect(luet.UnpackChannelCalled()).To(BeTrue())
+		})
+		It("Fails installing image sources", func() {
+			cfg.ISO.RootFS = []string{"elemental:latest"}
+			cfg.ISO.UEFI = []string{"registry.suse.com/custom-uefi:v0.1"}
+			cfg.ISO.Image = []string{"live/bootloader"}
+			luet.OnUnpackFromChannelError = true
+
+			err := action.BuildISORun(cfg)
+			Expect(err).Should(HaveOccurred())
+			Expect(luet.UnpackCalled()).To(BeTrue())
+			Expect(luet.UnpackChannelCalled()).To(BeTrue())
+		})
+		It("Fails on ISO filesystem creation", func() {
+			cfg.ISO.RootFS = []string{"/local/dir"}
+			cfg.ISO.UEFI = []string{"live/efi"}
+			cfg.ISO.Image = []string{"live/bootloader"}
+
+			err := utils.MkdirAll(fs, "/local/dir/boot", constants.DirPerm)
+			Expect(err).ShouldNot(HaveOccurred())
+			_, err = fs.Create("/local/dir/boot/vmlinuz")
+			Expect(err).ShouldNot(HaveOccurred())
+			_, err = fs.Create("/local/dir/boot/initrd")
+			Expect(err).ShouldNot(HaveOccurred())
+
+			runner.SideEffect = func(command string, args ...string) ([]byte, error) {
+				if command == "xorriso" {
+					return []byte{}, errors.New("Burn ISO error")
+				}
+				return []byte{}, nil
+			}
+
+			err = action.BuildISORun(cfg)
+
+			Expect(luet.UnpackChannelCalled()).To(BeTrue())
+			Expect(err).Should(HaveOccurred())
+		})
+	})
+})

--- a/pkg/action/runtime_test.go
+++ b/pkg/action/runtime_test.go
@@ -20,11 +20,11 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/jaypipes/ghw/pkg/block"
 	"os"
 	"path/filepath"
 	"runtime"
-	"testing"
+
+	"github.com/jaypipes/ghw/pkg/block"
 
 	luetTypes "github.com/mudler/luet/pkg/api/core/types"
 	. "github.com/onsi/ginkgo/v2"
@@ -46,12 +46,7 @@ const printOutput = `BYT;
 const partTmpl = `
 %d:%ss:%ss:2048s:ext4::type=83;`
 
-func TestElementalSuite(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Actions test suite")
-}
-
-var _ = Describe("Actions", func() {
+var _ = Describe("Runtime Actions", func() {
 	var config *v1.RunConfig
 	var runner *v1mock.FakeRunner
 	var fs vfs.FS

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -172,9 +172,19 @@ func NewRunConfig(opts ...GenericOptions) *v1.RunConfig {
 	return r
 }
 
+func NewISO() *v1.LiveISO {
+	return &v1.LiveISO{
+		HybridMBR:   cnst.IsoHybridMBR,
+		BootFile:    cnst.IsoBootFile,
+		BootCatalog: cnst.IsoBootCatalog,
+	}
+}
+
 func NewBuildConfig(opts ...GenericOptions) *v1.BuildConfig {
 	b := &v1.BuildConfig{
 		Config: *NewConfig(opts...),
+		ISO:    NewISO(),
+		Name:   cnst.BuildImgName,
 	}
 	return b
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -87,6 +87,11 @@ var _ = Describe("Types", Label("types", "config"), func() {
 				Expect(c.Mounter).To(Equal(mount.New(constants.MountBinary)))
 			})
 		})
+		Describe("BuildConfig", func() {
+			build := config.NewBuildConfig()
+			Expect(build.Name).To(Equal(constants.BuildImgName))
+			Expect(build.ISO.BootCatalog).To(Equal(constants.IsoBootCatalog))
+		})
 	})
 
 })

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -64,6 +64,7 @@ const (
 	EfiDir                 = "/run/cos/efi"
 	RecoverySquashFile     = "recovery.squashfs"
 	IsoRootFile            = "rootfs.squashfs"
+	IsoEFIPath             = "/boot/uefi.img"
 	ActiveImgFile          = "active.img"
 	PassiveImgFile         = "passive.img"
 	RecoveryImgFile        = "recovery.img"
@@ -88,6 +89,18 @@ const (
 	PassiveImgName         = "passive"
 	RecoveryImgName        = "recovery"
 	GPT                    = "gpt"
+	BuildImgName           = "elemental"
+
+	//TODO these paths are abitrary, coupled to package live/grub2 and assuming xz
+	// I'd suggest using `/boot/kernel` and `/boot/initrd`
+	IsoKernelPath = "/boot/kernel.xz"
+	IsoInitrdPath = "/boot/rootfs.xz"
+
+	// TODO would be nice to discover these ISO loader values instead of hardcoding them
+	// These values are coupled with package live/grub2
+	IsoHybridMBR   = "/boot/x86_64/loader/boot_hybrid.img"
+	IsoBootCatalog = "/boot/x86_64/boot.catalog"
+	IsoBootFile    = "/boot/x86_64/loader/eltorito.img"
 
 	// Default directory and file fileModes
 	DirPerm  = os.ModeDir | os.ModePerm

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -40,6 +40,8 @@ type Config struct {
 	CloudInitRunner CloudInitRunner
 	Luet            LuetInterface
 	Client          HTTPClient
+	Cosign          bool   `yaml:"cosign,omitempty" mapstructure:"cosign"`
+	CosignPubKey    string `yaml:"cosign-key,omitempty" mapstructure:"cosign-key"`
 }
 
 // RunConfig is the struct that represents the full configuration needed for install, upgrade, reset, rebrand.
@@ -65,8 +67,6 @@ type RunConfig struct {
 	Strict          bool   `yaml:"strict,omitempty" mapstructure:"strict"`
 	Iso             string `yaml:"iso,omitempty" mapstructure:"iso"`
 	DockerImg       string `yaml:"docker-image,omitempty" mapstructure:"docker-image"`
-	Cosign          bool   `yaml:"cosign,omitempty" mapstructure:"cosign"`
-	CosignPubKey    string `yaml:"cosign-key,omitempty" mapstructure:"cosign-key"`
 	NoVerify        bool   `yaml:"no-verify,omitempty" mapstructure:"no-verify"`
 	CloudInitPaths  string `yaml:"CLOUD_INIT_PATHS,omitempty" mapstructure:"CLOUD_INIT_PATHS"`
 	GrubDefEntry    string `yaml:"GRUB_ENTRY_NAME,omitempty" mapstructure:"GRUB_ENTRY_NAME"`
@@ -152,9 +152,22 @@ func (pl PartitionList) GetByName(name string) *Partition {
 	return nil
 }
 
+// LiveISO represents the configurations needed for a live ISO image
+type LiveISO struct {
+	RootFS      []string `yaml:"rootfs,omitempty" mapstructure:"rootfs"`
+	UEFI        []string `yaml:"uefi,omitempty" mapstructure:"uefi"`
+	Image       []string `yaml:"isoimage,omitempty" mapstructure:"isoimage"`
+	Label       string   `yaml:"label,omitempty" mapstructure:"label"`
+	BootCatalog string   `yaml:"boot_catalog,omitempty" mapstructure:"boot_catalog"`
+	BootFile    string   `yaml:"boot_file,omitempty" mapstructure:"boot_file"`
+	HybridMBR   string   `yaml:"hybrid_mbr,omitempty" mapstructure:"hybrid_mbr,omitempty"`
+}
+
 // BuildConfig represents the config we need for building isos, raw images, artifacts
 type BuildConfig struct {
-	Label string `yaml:"label,omitempty" mapstructure:"label"`
+	ISO  *LiveISO `yaml:"iso,omitempty" mapstructure:"iso"`
+	Date bool     `yaml:"date,omitempty" mapstructure:"date"`
+	Name string   `yaml:"name,omitempty" mapstructure:"name"`
 	// Generic runtime configuration
 	Config
 }

--- a/pkg/types/v1/fs.go
+++ b/pkg/types/v1/fs.go
@@ -27,10 +27,12 @@ type FS interface {
 	Create(name string) (*os.File, error)
 	Mkdir(name string, perm os.FileMode) error
 	Stat(name string) (os.FileInfo, error)
+	Lstat(name string) (os.FileInfo, error)
 	RemoveAll(path string) error
 	ReadFile(filename string) ([]byte, error)
 	Readlink(name string) (string, error)
 	RawPath(name string) (string, error)
+	ReadDir(dirname string) ([]os.FileInfo, error)
 	Remove(name string) error
 	OpenFile(name string, flag int, perm fs.FileMode) (*os.File, error)
 	WriteFile(filename string, data []byte, perm os.FileMode) error

--- a/pkg/types/v1/luet.go
+++ b/pkg/types/v1/luet.go
@@ -211,7 +211,6 @@ func (l Luet) createLuetConfig() *luetTypes.LuetConfig {
 	// if there is a luet.yaml file, load the data from there
 	if _, err := l.fs.Stat("/etc/luet/luet.yaml"); err == nil {
 		l.log.Debugf("Loading luet config from /etc/luet/luet.yaml")
-		config = &luetTypes.LuetConfig{}
 		f, err := l.fs.ReadFile("/etc/luet/luet.yaml")
 		if err != nil {
 			l.log.Errorf("Error reading luet.yaml file: %s", err)

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/distribution/distribution/reference"
 	"github.com/joho/godotenv"
 	cnst "github.com/rancher-sandbox/elemental/pkg/constants"
 	v1 "github.com/rancher-sandbox/elemental/pkg/types/v1"
@@ -75,8 +76,12 @@ func GetFullDeviceByLabel(runner v1.Runner, label string, attempts int) (*v1.Par
 	return nil, errors.New("no device found")
 }
 
-// CopyFile Copies source file to target file using Fs interface
+// CopyFile Copies source file to target file using Fs interface. If target
+// is  directory source is copied into that directory using source name file.
 func CopyFile(fs v1.FS, source string, target string) (err error) {
+	if dir, _ := IsDir(fs, target); dir {
+		target = filepath.Join(target, filepath.Base(source))
+	}
 	sourceFile, err := fs.Open(source)
 	if err != nil {
 		return err
@@ -206,7 +211,6 @@ func CreateSquashFS(runner v1.Runner, logger v1.Logger, source string, destinati
 	args := []string{source, destination}
 	// append options passed to args in order to have the correct order
 	args = append(args, options...)
-	logger.Debug("Running command: mksquashfs with args: %s", args)
 	out, err := runner.Run("mksquashfs", args...)
 	if err != nil {
 		logger.Debugf("Error running squashfs creation, stdout: %s", out)
@@ -291,4 +295,45 @@ func GetSource(config *v1.RunConfig, source string, destination string) error {
 		}
 	}
 	return nil
+}
+
+// ValidContainerReferece returns true if the given string matches
+// a container registry reference, false otherwise
+func ValidContainerReference(ref string) bool {
+	if _, err := reference.ParseNormalizedNamed(ref); err != nil {
+		return false
+	}
+	return true
+}
+
+// ValidTaggedContainerReferece returns true if the given string matches
+// a container registry reference including a tag, false otherwise.
+func ValidTaggedContainerReference(ref string) bool {
+	n, err := reference.ParseNormalizedNamed(ref)
+	if err != nil {
+		return false
+	}
+	if reference.IsNameOnly(n) {
+		return false
+	}
+	return true
+}
+
+// NewSrcGuessingType returns new v1.ImageSource instance guessing its type
+// applying somne heuristic techniques (by order of preference):
+//   1. Assume it is Dir/File if value is found as a path in host
+//	 2. Assume it is a container registry reference if it matches [<domain>/]<repositry>:<tag>
+//      (only domain is optional)
+//	 3. Fallback to a channel source
+func NewSrcGuessingType(c v1.Config, value string) v1.ImageSource {
+	if exists, _ := Exists(c.Fs, value); exists {
+		if dir, _ := IsDir(c.Fs, value); dir {
+			return v1.NewDirSrc(value)
+		} else {
+			return v1.NewFileSrc(value)
+		}
+	} else if ValidTaggedContainerReference(value) {
+		return v1.NewDockerSrc(value)
+	}
+	return v1.NewChannelSrc(value)
 }

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -120,14 +120,6 @@ func CreateDirStructure(fs v1.FS, target string) error {
 // SyncData rsync's source folder contents to a target folder content,
 // both are expected to exist before hand.
 func SyncData(fs v1.FS, source string, target string, excludes ...string) error {
-	if !strings.HasSuffix(source, "/") {
-		source = fmt.Sprintf("%s/", source)
-	}
-
-	if !strings.HasSuffix(target, "/") {
-		target = fmt.Sprintf("%s/", target)
-	}
-
 	if fs != nil {
 		if s, err := fs.RawPath(source); err == nil {
 			source = s
@@ -135,6 +127,14 @@ func SyncData(fs v1.FS, source string, target string, excludes ...string) error 
 		if t, err := fs.RawPath(target); err == nil {
 			target = t
 		}
+	}
+
+	if !strings.HasSuffix(source, "/") {
+		source = fmt.Sprintf("%s/", source)
+	}
+
+	if !strings.HasSuffix(target, "/") {
+		target = fmt.Sprintf("%s/", target)
 	}
 
 	task := grsync.NewTask(

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -329,9 +329,8 @@ func NewSrcGuessingType(c v1.Config, value string) v1.ImageSource {
 	if exists, _ := Exists(c.Fs, value); exists {
 		if dir, _ := IsDir(c.Fs, value); dir {
 			return v1.NewDirSrc(value)
-		} else {
-			return v1.NewFileSrc(value)
 		}
+		return v1.NewFileSrc(value)
 	} else if ValidTaggedContainerReference(value) {
 		return v1.NewDockerSrc(value)
 	}

--- a/pkg/utils/fs.go
+++ b/pkg/utils/fs.go
@@ -32,6 +32,21 @@ import (
 	"github.com/twpayne/go-vfs"
 )
 
+// DirSize returns the accumulated size of all files in folder
+func DirSize(fs v1.FS, path string) (int64, error) {
+	var size int64
+	err := vfs.Walk(fs, path, func(_ string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			size += info.Size()
+		}
+		return err
+	})
+	return size, err
+}
+
 // Check if a file or directory exists.
 func Exists(fs v1.FS, path string) (bool, error) {
 	_, err := fs.Stat(path)

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -423,24 +422,22 @@ var _ = Describe("Utils", Label("utils"), func() {
 	})
 	Describe("SyncData", Label("SyncData"), func() {
 		It("Copies all files from source to target", func() {
-			sourceDir, err := os.MkdirTemp("", "elemental")
-			Expect(err).To(BeNil())
-			defer os.RemoveAll(sourceDir)
-			destDir, err := os.MkdirTemp("", "elemental")
-			Expect(err).To(BeNil())
-			defer os.RemoveAll(destDir)
+			sourceDir, err := utils.TempDir(fs, "", "elemental")
+			Expect(err).ShouldNot(HaveOccurred())
+			destDir, err := utils.TempDir(fs, "", "elemental")
+			Expect(err).ShouldNot(HaveOccurred())
 
 			for i := 0; i < 5; i++ {
-				_, _ = os.CreateTemp(sourceDir, "file*")
+				_, _ = utils.TempFile(fs, sourceDir, "file*")
 			}
 
-			Expect(utils.SyncData(nil, sourceDir, destDir)).To(BeNil())
+			Expect(utils.SyncData(fs, sourceDir, destDir)).To(BeNil())
 
-			filesDest, err := ioutil.ReadDir(destDir)
+			filesDest, err := fs.ReadDir(destDir)
 			Expect(err).To(BeNil())
 
 			destNames := getNamesFromListFiles(filesDest)
-			filesSource, err := ioutil.ReadDir(sourceDir)
+			filesSource, err := fs.ReadDir(sourceDir)
 			Expect(err).To(BeNil())
 
 			SourceNames := getNamesFromListFiles(filesSource)
@@ -450,27 +447,26 @@ var _ = Describe("Utils", Label("utils"), func() {
 		})
 
 		It("Copies all files from source to target respecting excludes", func() {
-			sourceDir, err := os.MkdirTemp("", "elemental")
-			Expect(err).To(BeNil())
-			defer os.RemoveAll(sourceDir)
-			destDir, err := os.MkdirTemp("", "elemental")
-			Expect(err).To(BeNil())
-			defer os.RemoveAll(destDir)
+			sourceDir, err := utils.TempDir(fs, "", "elemental")
+			Expect(err).ShouldNot(HaveOccurred())
+			destDir, err := utils.TempDir(fs, "", "elemental")
+			Expect(err).ShouldNot(HaveOccurred())
 
-			os.MkdirAll(filepath.Join(sourceDir, "host"), constants.DirPerm)
-			os.MkdirAll(filepath.Join(sourceDir, "run"), constants.DirPerm)
+			utils.MkdirAll(fs, filepath.Join(sourceDir, "host"), constants.DirPerm)
+			utils.MkdirAll(fs, filepath.Join(sourceDir, "run"), constants.DirPerm)
+
 			for i := 0; i < 5; i++ {
-				_, _ = os.CreateTemp(sourceDir, "file*")
+				_, _ = utils.TempFile(fs, sourceDir, "file*")
 			}
 
-			Expect(utils.SyncData(nil, sourceDir, destDir, "host", "run")).To(BeNil())
+			Expect(utils.SyncData(fs, sourceDir, destDir, "host", "run")).To(BeNil())
 
-			filesDest, err := ioutil.ReadDir(destDir)
+			filesDest, err := fs.ReadDir(destDir)
 			Expect(err).To(BeNil())
 
 			destNames := getNamesFromListFiles(filesDest)
 
-			filesSource, err := ioutil.ReadDir(sourceDir)
+			filesSource, err := fs.ReadDir(sourceDir)
 			Expect(err).To(BeNil())
 
 			SourceNames := getNamesFromListFiles(filesSource)
@@ -488,13 +484,11 @@ var _ = Describe("Utils", Label("utils"), func() {
 		})
 
 		It("should not fail if dirs are empty", func() {
-			sourceDir, err := os.MkdirTemp("", "elemental")
-			Expect(err).To(BeNil())
-			defer os.RemoveAll(sourceDir)
-			destDir, err := os.MkdirTemp("", "elemental")
-			Expect(err).To(BeNil())
-			defer os.RemoveAll(destDir)
-			Expect(utils.SyncData(nil, sourceDir, destDir)).To(BeNil())
+			sourceDir, err := utils.TempDir(fs, "", "elemental")
+			Expect(err).ShouldNot(HaveOccurred())
+			destDir, err := utils.TempDir(fs, "", "elemental")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(utils.SyncData(fs, sourceDir, destDir)).To(BeNil())
 		})
 		It("should fail if destination does not exist", func() {
 			sourceDir, err := os.MkdirTemp("", "elemental")

--- a/tests/mocks/luet_mock.go
+++ b/tests/mocks/luet_mock.go
@@ -23,10 +23,12 @@ import (
 )
 
 type FakeLuet struct {
-	OnUnpackError            bool
-	OnUnpackFromChannelError bool
-	unpackCalled             bool
-	unpackFromChannelCalled  bool
+	OnUnpackError               bool
+	OnUnpackFromChannelError    bool
+	UnpackSideEffect            func(string, string, bool) error
+	UnpackFromChannelSideEffect func(string, string) error
+	unpackCalled                bool
+	unpackFromChannelCalled     bool
 }
 
 func NewFakeLuet() *FakeLuet {
@@ -38,6 +40,9 @@ func (l *FakeLuet) Unpack(target string, image string, local bool) error {
 	if l.OnUnpackError {
 		return errors.New("Luet install error")
 	}
+	if l.UnpackSideEffect != nil {
+		return l.UnpackSideEffect(target, image, local)
+	}
 	return nil
 }
 
@@ -45,6 +50,9 @@ func (l *FakeLuet) UnpackFromChannel(target string, pkg string) error {
 	l.unpackFromChannelCalled = true
 	if l.OnUnpackFromChannelError {
 		return errors.New("Luet install error")
+	}
+	if l.UnpackFromChannelSideEffect != nil {
+		return l.UnpackFromChannelSideEffect(target, pkg)
 	}
 	return nil
 }


### PR DESCRIPTION
This commit includes a first round of the 'build-iso' subcommand
implementation. It is functional enough to create a hybrid ISO bootable
for both, BIOS and EFI firmwares.

Related with rancher-sandbox/cOS-Toolkit#1217

Signed-off-by: David Cassany <dcassany@suse.com>