### PR TITLE
Add build-disk command

### DIFF
--- a/cmd/build-disk.go
+++ b/cmd/build-disk.go
@@ -59,6 +59,8 @@ func NewBuildDisk(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 			imgType, _ := cmd.Flags().GetString("type")
 			archType, _ := cmd.Flags().GetString("arch")
 			output, _ := cmd.Flags().GetString("arch")
+			oemLabel, _ := cmd.Flags().GetString("oem_label")
+			recoveryLabel, _ := cmd.Flags().GetString("recovery_label")
 
 			// Set the repo depending on the arch we are building for
 			var repos []v1.Repository
@@ -67,7 +69,7 @@ func NewBuildDisk(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 			}
 			cfg.Config.Repos = repos
 
-			err = action.BuildDiskRun(cfg, imgType, archType, output)
+			err = action.BuildDiskRun(cfg, imgType, archType, oemLabel, recoveryLabel, output)
 			if err != nil {
 				return err
 			}
@@ -77,10 +79,12 @@ func NewBuildDisk(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 	}
 	root.AddCommand(c)
 	imgType := newEnumFlag([]string{"raw"}, "raw")
-	archType := newEnumFlag([]string{"x86_64", "aarch64"}, "x86_64")
+	archType := newEnumFlag([]string{"x86_64", "aarch64", "odroid_c2"}, "x86_64")
 	c.Flags().VarP(imgType, "type", "t", "Type of image to create")
 	c.Flags().VarP(archType, "arch", "a", "Arch to build the image for")
 	c.Flags().StringP("output", "o", "disk.raw", "Arch to build the image for")
+	c.Flags().String("oem_label", "COS_OEM", "Oem partition label")
+	c.Flags().String("recovery_label", "COS_RECOVERY", "Recovery partition label")
 	addCosignFlags(c)
 	return c
 }

--- a/cmd/build-disk.go
+++ b/cmd/build-disk.go
@@ -58,7 +58,7 @@ func NewBuildDisk(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 			cmd.SilenceErrors = true // Do not propagate errors down the line, we control them
 			imgType, _ := cmd.Flags().GetString("type")
 			archType, _ := cmd.Flags().GetString("arch")
-			output, _ := cmd.Flags().GetString("arch")
+			output, _ := cmd.Flags().GetString("output")
 			oemLabel, _ := cmd.Flags().GetString("oem_label")
 			recoveryLabel, _ := cmd.Flags().GetString("recovery_label")
 

--- a/cmd/build-disk.go
+++ b/cmd/build-disk.go
@@ -1,0 +1,89 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/rancher-sandbox/elemental/cmd/config"
+	"github.com/rancher-sandbox/elemental/pkg/action"
+	v1 "github.com/rancher-sandbox/elemental/pkg/types/v1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	mountUtils "k8s.io/mount-utils"
+)
+
+// NewBuildDisk returns a new instance of the build-disk subcommand and appends it to
+// the root command. requireRoot is to initiate it with or without the CheckRoot
+// pre-run check. This method is mostly used for testing purposes.
+func NewBuildDisk(root *cobra.Command, addCheckRoot bool) *cobra.Command {
+	c := &cobra.Command{
+		Use:   "build-disk",
+		Short: "elemental build-disk",
+		Args:  cobra.NoArgs,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			_ = viper.BindPFlags(cmd.Flags())
+			if addCheckRoot {
+				return CheckRoot()
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			mounter := &mountUtils.FakeMounter{}
+
+			cfg, err := config.ReadConfigBuild(viper.GetString("config-dir"), mounter)
+			if err != nil {
+				cfg.Logger.Errorf("Error reading config: %s\n", err)
+			}
+
+			err = validateCosignFlags(cfg.Logger)
+			if err != nil {
+				return err
+			}
+
+			// Set this after parsing of the flags, so it fails on parsing and prints usage properly
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true // Do not propagate errors down the line, we control them
+			imgType, _ := cmd.Flags().GetString("type")
+			archType, _ := cmd.Flags().GetString("arch")
+			output, _ := cmd.Flags().GetString("arch")
+
+			// Set the repo depending on the arch we are building for
+			var repos []v1.Repository
+			for _, u := range cfg.RawDisk[archType].Repositories {
+				repos = append(repos, v1.Repository{URI: u.URI})
+			}
+			cfg.Config.Repos = repos
+
+			err = action.BuildDiskRun(cfg, imgType, archType, output)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+	root.AddCommand(c)
+	imgType := newEnumFlag([]string{"raw"}, "raw")
+	archType := newEnumFlag([]string{"x86_64", "aarch64"}, "x86_64")
+	c.Flags().VarP(imgType, "type", "t", "Type of image to create")
+	c.Flags().VarP(archType, "arch", "a", "Arch to build the image for")
+	c.Flags().StringP("output", "o", "disk.raw", "Arch to build the image for")
+	addCosignFlags(c)
+	return c
+}
+
+// register the subcommand into rootCmd
+var _ = NewBuildDisk(rootCmd, true)

--- a/cmd/build-disk.go
+++ b/cmd/build-disk.go
@@ -43,9 +43,15 @@ func NewBuildDisk(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			mounter := &mountUtils.FakeMounter{}
 
-			cfg, err := config.ReadConfigBuild(viper.GetString("config-dir"), mounter)
+			// If configDir is empty try to get the manifest from current dir
+			configDir := viper.GetString("config-dir")
+			if configDir == "" {
+				configDir = "."
+			}
+
+			cfg, err := config.ReadConfigBuild(configDir, mounter, true)
 			if err != nil {
-				cfg.Logger.Errorf("Error reading config: %s\n", err)
+				return err
 			}
 
 			err = validateCosignFlags(cfg.Logger)

--- a/cmd/build-disk_test.go
+++ b/cmd/build-disk_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"bytes"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("BuildDisk", Label("disk", "raw", "cmd"), func() {
+	var buf *bytes.Buffer
+	BeforeEach(func() {
+		rootCmd = NewRootCmd()
+		_ = NewBuildDisk(rootCmd, false)
+		buf = new(bytes.Buffer)
+		rootCmd.SetOut(buf)
+		rootCmd.SetErr(buf)
+	})
+	It("Errors out setting consign-key without setting cosign", Label("flags"), func() {
+		_, _, err := executeCommandC(rootCmd, "build-disk", "--cosign-key", "pubKey.url")
+		Expect(err).ToNot(BeNil())
+		Expect(buf.String()).To(ContainSubstring("Usage:"))
+		Expect(err.Error()).To(ContainSubstring("'cosign-key' requires 'cosign' option to be enabled"))
+	})
+})

--- a/cmd/build-disk_test.go
+++ b/cmd/build-disk_test.go
@@ -33,7 +33,7 @@ var _ = Describe("BuildDisk", Label("disk", "raw", "cmd"), func() {
 		rootCmd.SetErr(buf)
 	})
 	It("Errors out setting consign-key without setting cosign", Label("flags"), func() {
-		_, _, err := executeCommandC(rootCmd, "build-disk", "--cosign-key", "pubKey.url")
+		_, _, err := executeCommandC(rootCmd, "--config-dir", "config/config", "build-disk", "--cosign-key", "pubKey.url")
 		Expect(err).ToNot(BeNil())
 		Expect(buf.String()).To(ContainSubstring("Usage:"))
 		Expect(err.Error()).To(ContainSubstring("'cosign-key' requires 'cosign' option to be enabled"))

--- a/cmd/build-iso.go
+++ b/cmd/build-iso.go
@@ -56,7 +56,7 @@ func NewBuildISO(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 				cfg.Logger.Errorf("Error reading config: %s\n", err)
 			}
 
-			if len(args) == 1 {
+			if len(args) >= 1 {
 				cfg.ISO.RootFS = []string{args[0]}
 			}
 

--- a/cmd/build-iso.go
+++ b/cmd/build-iso.go
@@ -51,7 +51,7 @@ func NewBuildISO(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 			}
 			mounter := mount.New(path)
 
-			cfg, err := config.ReadConfigBuild(viper.GetString("config-dir"), mounter)
+			cfg, err := config.ReadConfigBuild(viper.GetString("config-dir"), mounter, false)
 			if err != nil {
 				cfg.Logger.Errorf("Error reading config: %s\n", err)
 			}

--- a/cmd/config/config/manifest.yaml
+++ b/cmd/config/config/manifest.yaml
@@ -14,8 +14,8 @@ iso:
 
 raw_disk:
   x86_64:
-    # Where to get the packages from if the local build doesn't have the needed packages
-    repo: quay.io/costoolkit/releases-green
+    repositories:
+     - uri: quay.io/costoolkit/releases-green
     # which packages to install and the target to install them at
     packages:
       - name: system/grub2-efi-image
@@ -27,7 +27,8 @@ raw_disk:
       - name: recovery/cos-img
         target: root/cOS
   aarch64:
-    repo: quay.io/costoolkit/releases-green-arm64
+    repositories:
+     - uri: quay.io/costoolkit/releases-green-arm64
     packages:
       - name: system/grub2-efi-image
         target: efi
@@ -38,7 +39,8 @@ raw_disk:
       - name: recovery/cos-img
         target: root/cOS
   odroid_c2:
-    repo: quay.io/costoolkit/releases-green-arm64
+    repositories:
+     - uri: quay.io/costoolkit/releases-green-arm64
     packages:
       - name: system/grub2-efi-image
         target: efi

--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -44,13 +44,13 @@ var _ = Describe("Config", func() {
 	})
 	Describe("Build config", Label("config", "build"), func() {
 		It("values empty if config path not valid", Label("path", "values"), func() {
-			cfg, err := ReadConfigBuild("/none/", mounter)
+			cfg, err := ReadConfigBuild("/none/", mounter, false)
 			Expect(err).To(BeNil())
 			Expect(viper.GetString("name")).To(Equal(""))
 			Expect(cfg.Name).To(Equal("elemental"))
 		})
 		It("values filled if config path valid", Label("path", "values"), func() {
-			cfg, err := ReadConfigBuild("config/", mounter)
+			cfg, err := ReadConfigBuild("config/", mounter, false)
 			Expect(err).To(BeNil())
 			Expect(viper.GetString("name")).To(Equal("cOS-0"))
 			Expect(cfg.Name).To(Equal("cOS-0"))
@@ -59,7 +59,7 @@ var _ = Describe("Config", func() {
 		})
 		It("overrides values with env values", Label("env", "values"), func() {
 			_ = os.Setenv("ELEMENTAL_NAME", "environment")
-			cfg, err := ReadConfigBuild("config/", mounter)
+			cfg, err := ReadConfigBuild("config/", mounter, false)
 			Expect(err).To(BeNil())
 			source := viper.GetString("name")
 			// check that the final value comes from the env var

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -18,6 +18,8 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 
 	v1 "github.com/rancher-sandbox/elemental/pkg/types/v1"
 	"github.com/spf13/cobra"
@@ -86,4 +88,41 @@ func validateInstallUpgradeFlags(log v1.Logger) error {
 		return err
 	}
 	return nil
+}
+
+type enum struct {
+	Allowed []string
+	Value   string
+}
+
+// newEnum give a list of allowed flag parameters, where the second argument is the default
+func newEnumFlag(allowed []string, d string) *enum {
+	return &enum{
+		Allowed: allowed,
+		Value:   d,
+	}
+}
+
+func (a enum) String() string {
+	return a.Value
+}
+
+func (a *enum) Set(p string) error {
+	isIncluded := func(opts []string, val string) bool {
+		for _, opt := range opts {
+			if val == opt {
+				return true
+			}
+		}
+		return false
+	}
+	if !isIncluded(a.Allowed, p) {
+		return fmt.Errorf("%s is not included in %s", p, strings.Join(a.Allowed, ","))
+	}
+	a.Value = p
+	return nil
+}
+
+func (a *enum) Type() string {
+	return "string"
 }

--- a/pkg/action/build-disk.go
+++ b/pkg/action/build-disk.go
@@ -32,6 +32,14 @@ var MB = int64(1024 * 1024)
 func BuildDiskRun(cfg *v1.BuildConfig, imgType string, arch string, oemLabel string, recoveryLabel string, output string) (err error) {
 	cfg.Logger.Infof("Building disk image type %s for arch %s", imgType, arch)
 
+	if oemLabel == "" {
+		oemLabel = constants.OEMLabel
+	}
+
+	if recoveryLabel == "" {
+		recoveryLabel = constants.RecoveryLabel
+	}
+
 	cleanup := utils.NewCleanStack()
 	defer func() { err = cleanup.Cleanup(err) }()
 
@@ -147,11 +155,11 @@ func CreateFinalImage(c *v1.BuildConfig, img string, parts ...string) error {
 		_ = c.Fs.RemoveAll(img)
 		return err
 	}
-	// Seek to the end of the file so we start copying the files at the end of those 3Mb that we truncated before
+	// Seek to the end of the file, so we start copying the files at the end of those 3Mb that we truncated before
 	_, _ = actImg.Seek(0, io.SeekEnd)
 	for _, p := range parts {
 		c.Logger.Debugf("Copying %s", p)
-		toRead, _ := os.Open(p)
+		toRead, _ := c.Fs.Open(p)
 		_, err = io.Copy(actImg, toRead)
 		if err != nil {
 			return err

--- a/pkg/action/build-disk.go
+++ b/pkg/action/build-disk.go
@@ -29,7 +29,7 @@ import (
 
 var MB = int64(1024 * 1024)
 
-func BuildDiskRun(cfg *v1.BuildConfig, imgType string, arch string, output string) (err error) {
+func BuildDiskRun(cfg *v1.BuildConfig, imgType string, arch string, oemLabel string, recoveryLabel string, output string) (err error) {
 	cfg.Logger.Infof("Building disk image type %s for arch %s", imgType, arch)
 
 	cleanup := utils.NewCleanStack()
@@ -70,7 +70,7 @@ func BuildDiskRun(cfg *v1.BuildConfig, imgType string, arch string, output strin
 		cfg,
 		rootfsPart,
 		filepath.Join(baseDir, "root"),
-		constants.RecoveryLabel,
+		recoveryLabel,
 		constants.LinuxImgFs,
 		2048*MB,
 	)
@@ -109,7 +109,7 @@ func BuildDiskRun(cfg *v1.BuildConfig, imgType string, arch string, output strin
 		cfg,
 		oemPart,
 		filepath.Join(baseDir, "oem"),
-		constants.OEMLabel,
+		oemLabel,
 		constants.LinuxImgFs,
 		64*MB,
 	)

--- a/pkg/action/build-disk.go
+++ b/pkg/action/build-disk.go
@@ -1,0 +1,246 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package action
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/rancher-sandbox/elemental/pkg/constants"
+	"github.com/rancher-sandbox/elemental/pkg/partitioner"
+	v1 "github.com/rancher-sandbox/elemental/pkg/types/v1"
+	"github.com/rancher-sandbox/elemental/pkg/utils"
+)
+
+var MB = int64(1024 * 1024)
+
+func BuildDiskRun(cfg *v1.BuildConfig, imgType string, arch string, output string) (err error) {
+	cfg.Logger.Infof("Building disk image type %s for arch %s", imgType, arch)
+
+	cleanup := utils.NewCleanStack()
+	defer func() { err = cleanup.Cleanup(err) }()
+
+	// baseDir is where we are going install all packages
+	baseDir, err := utils.TempDir(cfg.Fs, "", "elemental-build-disk-files")
+	if err != nil {
+		return err
+	}
+	cleanup.Push(func() error { return cfg.Fs.RemoveAll(baseDir) })
+
+	// diskTempDir is where we are going to create all the disk parts
+	diskTempDir, err := utils.TempDir(cfg.Fs, "", "elemental-build-disk-parts")
+	if err != nil {
+		return err
+	}
+	cleanup.Push(func() error { return cfg.Fs.RemoveAll(diskTempDir) })
+
+	rootfsPart := filepath.Join(diskTempDir, "rootfs.part")
+	oemPart := filepath.Join(diskTempDir, "oem.part")
+	efiPart := filepath.Join(diskTempDir, "efi.part")
+
+	// Extract required packages to basedir
+	for _, pkg := range cfg.RawDisk[arch].Packages {
+		err = os.MkdirAll(filepath.Join(baseDir, pkg.Target), constants.DirPerm)
+		if err != nil {
+			return err
+		}
+		err = applySources(cfg.Config, filepath.Join(baseDir, pkg.Target), pkg.Name)
+		if err != nil {
+			cfg.Logger.Error(err)
+		}
+	}
+
+	// Create rootfs.part
+	err = CreatePart(
+		cfg,
+		rootfsPart,
+		filepath.Join(baseDir, "root"),
+		constants.RecoveryLabel,
+		constants.LinuxImgFs,
+		2048*MB,
+	)
+	if err != nil {
+		cfg.Logger.Error(err)
+		return err
+	}
+
+	// create EFI part
+	err = CreatePart(
+		cfg,
+		efiPart,
+		"",
+		constants.EfiLabel,
+		constants.EfiFs,
+		20*MB,
+	)
+	if err != nil {
+		cfg.Logger.Error(err)
+		return err
+	}
+	// copy files to efi with mcopy
+	_, err = cfg.Runner.Run("mcopy", "-s", "-i", efiPart, filepath.Join(baseDir, "efi", "EFI"), "::EFI")
+	if err != nil {
+		return err
+	}
+
+	// Create the oem part
+	// Create the grubenv forcing first boot to be on recovery system
+	_ = cfg.Fs.Mkdir(filepath.Join(baseDir, "oem"), constants.DirPerm)
+	err = utils.CopyFile(cfg.Fs, filepath.Join(baseDir, "root", "etc", "cos", "grubenv_firstboot"), filepath.Join(baseDir, "oem", "grubenv"))
+	if err != nil {
+		return err
+	}
+	err = CreatePart(
+		cfg,
+		oemPart,
+		filepath.Join(baseDir, "oem"),
+		constants.OEMLabel,
+		constants.LinuxImgFs,
+		64*MB,
+	)
+	if err != nil {
+		cfg.Logger.Error(err)
+		return err
+	}
+
+	// Create final image
+	err = CreateFinalImage(cfg, output, efiPart, oemPart, rootfsPart)
+	if err != nil {
+		cfg.Logger.Error(err)
+		return err
+	}
+
+	return err
+}
+
+// CreateFinalImage creates the final image by truncating the image with the proper sizes, concatenating the contents of the
+// given parts and creating the partition table on the image
+func CreateFinalImage(c *v1.BuildConfig, img string, parts ...string) error {
+	err := utils.MkdirAll(c.Fs, filepath.Dir(img), constants.DirPerm)
+	if err != nil {
+		return err
+	}
+	actImg, err := c.Fs.Create(img)
+	if err != nil {
+		return err
+	}
+
+	// add 3MB of initial free space to disk, 1MB is for proper alignment, 2MB are for the hybrid legacy boot.
+	err = actImg.Truncate(3 * MB)
+	if err != nil {
+		actImg.Close()
+		_ = c.Fs.RemoveAll(img)
+		return err
+	}
+	// Seek to the end of the file so we start copying the files at the end of those 3Mb that we truncated before
+	_, _ = actImg.Seek(0, io.SeekEnd)
+	for _, p := range parts {
+		c.Logger.Debugf("Copying %s", p)
+		toRead, _ := os.Open(p)
+		_, err = io.Copy(actImg, toRead)
+		if err != nil {
+			return err
+		}
+	}
+
+	info, _ := actImg.Stat()
+	finalSize := info.Size() + (1 * MB)
+	err = actImg.Truncate(finalSize)
+	if err != nil {
+		actImg.Close()
+		_ = c.Fs.RemoveAll(img)
+		return err
+	}
+
+	err = actImg.Close()
+	if err != nil {
+		_ = c.Fs.RemoveAll(img)
+		return err
+	}
+
+	// Partition table
+	/*
+		Where:
+		  -c indicates change the name of the partition in partnum:name format
+		  -n new partition in partnum:start:end format
+		  -t type of the partition (EF02 bios, EF00 efi and 8300 linux)
+	*/
+	out, err := c.Runner.Run("sgdisk", "-n", "1:2048:+2M", "-c", "1:legacy", "-t", "1:EF02", img)
+	if err != nil {
+		c.Logger.Errorf("Error from sgdisk: %s", out)
+		return err
+	}
+	_, err = c.Runner.Run("sgdisk", "-n", "2:0:+20M", "-c", "2:UEFI", "-t", "2:EF00", img)
+	if err != nil {
+		c.Logger.Errorf("Error from sgdisk: %s", out)
+		return err
+	}
+	_, err = c.Runner.Run("sgdisk", "-n", "3:0:+64M", "-c", "3:oem", "-t", "3:8300", img)
+	if err != nil {
+		c.Logger.Errorf("Error from sgdisk: %s", out)
+		return err
+	}
+	_, err = c.Runner.Run("sgdisk", "-n", "4:0:+2048M", "-c", "4:root", "-t", "4:8300", img)
+	if err != nil {
+		c.Logger.Errorf("Error from sgdisk: %s", out)
+		return err
+	}
+
+	return err
+}
+
+// CreatePart creates, truncates, and formats an img.part file. if rootDir is passed it will use that as the rootdir for
+// the part creation, thus copying the contents into the newly created part file
+func CreatePart(c *v1.BuildConfig, img string, rootDir string, label string, fs string, size int64) error {
+	err := utils.MkdirAll(c.Fs, filepath.Dir(img), constants.DirPerm)
+	if err != nil {
+		return err
+	}
+	actImg, err := c.Fs.Create(img)
+	if err != nil {
+		return err
+	}
+
+	err = actImg.Truncate(size)
+	if err != nil {
+		actImg.Close()
+		_ = c.Fs.RemoveAll(img)
+		return err
+	}
+	err = actImg.Close()
+	if err != nil {
+		_ = c.Fs.RemoveAll(img)
+		return err
+	}
+
+	var extraOpts []string
+
+	// Only add the rootDir if it's not empty
+	if rootDir != "" {
+		extraOpts = []string{"-d", rootDir}
+	}
+
+	mkfs := partitioner.NewMkfsCall(img, fs, label, c.Runner, extraOpts...)
+	out, err := mkfs.Apply()
+	if err != nil {
+		_ = c.Fs.RemoveAll(img)
+		c.Logger.Errorf("Error applying mkfs call: %s", out)
+		return err
+	}
+	return err
+}

--- a/pkg/action/build_test.go
+++ b/pkg/action/build_test.go
@@ -17,7 +17,10 @@
 package action_test
 
 import (
+	"bytes"
 	"errors"
+	"github.com/sirupsen/logrus"
+	"os"
 	"path/filepath"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -43,12 +46,15 @@ var _ = Describe("Runtime Actions", func() {
 	var cloudInit *v1mock.FakeCloudInitRunner
 	var luet *v1mock.FakeLuet
 	var cleanup func()
+	var memLog *bytes.Buffer
 	BeforeEach(func() {
 		runner = v1mock.NewFakeRunner()
 		syscall = &v1mock.FakeSyscall{}
 		mounter = v1mock.NewErrorMounter()
 		client = &v1mock.FakeHTTPClient{}
-		logger = v1.NewNullLogger()
+		memLog = &bytes.Buffer{}
+		logger = v1.NewBufferLogger(memLog)
+		logger.SetLevel(logrus.DebugLevel)
 		cloudInit = &v1mock.FakeCloudInitRunner{}
 		luet = &v1mock.FakeLuet{}
 		fs, cleanup, _ = vfst.NewTestFS(map[string]interface{}{})
@@ -183,6 +189,80 @@ var _ = Describe("Runtime Actions", func() {
 
 			Expect(luet.UnpackChannelCalled()).To(BeTrue())
 			Expect(err).Should(HaveOccurred())
+		})
+	})
+	FDescribe("Build disk", Label("disk", "build"), func() {
+		It("Builds a raw image", func() {
+			// temp dir for output, otherwise we write to .
+			outputDir, _ := utils.TempDir(fs, "", "output")
+			// temp dir for package files, create needed file
+			filesDir, _ := utils.TempDir(fs, "", "elemental-build-disk-files")
+			_ = utils.MkdirAll(fs, filepath.Join(filesDir, "root", "etc", "cos"), constants.DirPerm)
+			_ = fs.WriteFile(filepath.Join(filesDir, "root", "etc", "cos", "grubenv_firstboot"), []byte(""), os.ModePerm)
+
+			// temp dir for part files, create parts
+			partsDir, _ := utils.TempDir(fs, "", "elemental-build-disk-parts")
+			_ = fs.WriteFile(filepath.Join(partsDir, "rootfs.part"), []byte(""), os.ModePerm)
+			_ = fs.WriteFile(filepath.Join(partsDir, "oem.part"), []byte(""), os.ModePerm)
+			_ = fs.WriteFile(filepath.Join(partsDir, "efi.part"), []byte(""), os.ModePerm)
+
+			err := action.BuildDiskRun(cfg, "raw", "x86_64", "OEM", "REC", filepath.Join(outputDir, "disk.raw"))
+			Expect(err).ToNot(HaveOccurred())
+			// Check that we copied all needed files to final image
+			Expect(memLog.String()).To(ContainSubstring("efi.part"))
+			Expect(memLog.String()).To(ContainSubstring("rootfs.part"))
+			Expect(memLog.String()).To(ContainSubstring("oem.part"))
+			output, err := fs.Stat(filepath.Join(outputDir, "disk.raw"))
+			Expect(err).ToNot(HaveOccurred())
+			// Even with empty parts, output image should never be zero due to the truncating
+			// it should be exactly 20Mb(efi size) + 64Mb(oem size) + 2048Mb(recovery size) + 3Mb(hybrid boot) + 1Mb(GPT)
+			partsSize := (20 + 64 + 2048 + 3 + 1) * 1024 * 1024
+			Expect(output.Size()).To(BeNumerically("==", partsSize))
+			// Check that mkfs commands set the label properly and copied the proper dirs
+			err = runner.IncludesCmds([][]string{
+				{"mkfs.ext2", "-L", "REC", "-d", "/tmp/elemental-build-disk-files/root", "/tmp/elemental-build-disk-parts/rootfs.part"},
+				{"mkfs.vfat", "-n", constants.EfiLabel, "/tmp/elemental-build-disk-parts/efi.part"},
+				{"mkfs.ext2", "-L", "OEM", "-d", "/tmp/elemental-build-disk-files/oem", "/tmp/elemental-build-disk-parts/oem.part"},
+				// files should be copied to EFI
+				{"mcopy", "-s", "-i", "/tmp/elemental-build-disk-parts/efi.part", "/tmp/elemental-build-disk-files/efi/EFI", "::EFI"},
+			})
+			Expect(err).ToNot(HaveOccurred())
+		})
+		It("Sets default labels if empty", func() {
+			// temp dir for output, otherwise we write to .
+			outputDir, _ := utils.TempDir(fs, "", "output")
+			// temp dir for package files, create needed file
+			filesDir, _ := utils.TempDir(fs, "", "elemental-build-disk-files")
+			_ = utils.MkdirAll(fs, filepath.Join(filesDir, "root", "etc", "cos"), constants.DirPerm)
+			_ = fs.WriteFile(filepath.Join(filesDir, "root", "etc", "cos", "grubenv_firstboot"), []byte(""), os.ModePerm)
+
+			// temp dir for part files, create parts
+			partsDir, _ := utils.TempDir(fs, "", "elemental-build-disk-parts")
+			_ = fs.WriteFile(filepath.Join(partsDir, "rootfs.part"), []byte(""), os.ModePerm)
+			_ = fs.WriteFile(filepath.Join(partsDir, "oem.part"), []byte(""), os.ModePerm)
+			_ = fs.WriteFile(filepath.Join(partsDir, "efi.part"), []byte(""), os.ModePerm)
+
+			err := action.BuildDiskRun(cfg, "raw", "x86_64", "", "", filepath.Join(outputDir, "disk.raw"))
+			Expect(err).ToNot(HaveOccurred())
+			// Check that we copied all needed files to final image
+			Expect(memLog.String()).To(ContainSubstring("efi.part"))
+			Expect(memLog.String()).To(ContainSubstring("rootfs.part"))
+			Expect(memLog.String()).To(ContainSubstring("oem.part"))
+			output, err := fs.Stat(filepath.Join(outputDir, "disk.raw"))
+			Expect(err).ToNot(HaveOccurred())
+			// Even with empty parts, output image should never be zero due to the truncating
+			// it should be exactly 20Mb(efi size) + 64Mb(oem size) + 2048Mb(recovery size) + 3Mb(hybrid boot) + 1Mb(GPT)
+			partsSize := (20 + 64 + 2048 + 3 + 1) * 1024 * 1024
+			Expect(output.Size()).To(BeNumerically("==", partsSize))
+			// Check that mkfs commands set the label properly and copied the proper dirs
+			err = runner.IncludesCmds([][]string{
+				{"mkfs.ext2", "-L", constants.RecoveryLabel, "-d", "/tmp/elemental-build-disk-files/root", "/tmp/elemental-build-disk-parts/rootfs.part"},
+				{"mkfs.vfat", "-n", constants.EfiLabel, "/tmp/elemental-build-disk-parts/efi.part"},
+				{"mkfs.ext2", "-L", constants.OEMLabel, "-d", "/tmp/elemental-build-disk-files/oem", "/tmp/elemental-build-disk-parts/oem.part"},
+				// files should be copied to EFI
+				{"mcopy", "-s", "-i", "/tmp/elemental-build-disk-parts/efi.part", "/tmp/elemental-build-disk-files/efi/EFI", "::EFI"},
+			})
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 })

--- a/pkg/action/build_test.go
+++ b/pkg/action/build_test.go
@@ -191,7 +191,7 @@ var _ = Describe("Runtime Actions", func() {
 			Expect(err).Should(HaveOccurred())
 		})
 	})
-	FDescribe("Build disk", Label("disk", "build"), func() {
+	Describe("Build disk", Label("disk", "build"), func() {
 		It("Builds a raw image", func() {
 			// temp dir for output, otherwise we write to .
 			outputDir, _ := utils.TempDir(fs, "", "output")

--- a/pkg/action/runtime_test.go
+++ b/pkg/action/runtime_test.go
@@ -20,19 +20,14 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
-	"runtime"
-
 	"github.com/jaypipes/ghw/pkg/block"
+	"path/filepath"
 
-	luetTypes "github.com/mudler/luet/pkg/api/core/types"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/rancher-sandbox/elemental/pkg/action"
 	conf "github.com/rancher-sandbox/elemental/pkg/config"
 	"github.com/rancher-sandbox/elemental/pkg/constants"
-	"github.com/rancher-sandbox/elemental/pkg/luet"
 	v1 "github.com/rancher-sandbox/elemental/pkg/types/v1"
 	"github.com/rancher-sandbox/elemental/pkg/utils"
 	v1mock "github.com/rancher-sandbox/elemental/tests/mocks"
@@ -662,7 +657,7 @@ var _ = Describe("Runtime Actions", func() {
 			logger = v1.NewBufferLogger(memLog)
 			config.Logger = logger
 			logger.SetLevel(logrus.DebugLevel)
-			l = luet.NewLuet(luet.WithLogger(logger))
+			l = &v1mock.FakeLuet{}
 			config.Luet = l
 			// These values are loaded from /etc/cos/config normally via CMD
 			config.StateLabel = constants.StateLabel
@@ -851,38 +846,6 @@ var _ = Describe("Runtime Actions", func() {
 			})
 			It("Successfully upgrades from channel upgrade", Label("channel", "root"), func() {
 				config.ChannelUpgrades = true
-				// Required paths
-				tmpDirBase, _ := os.MkdirTemp("", "elemental")
-				pkgCache, _ := os.MkdirTemp("", "elemental")
-				dbPath, _ := os.MkdirTemp("", "elemental")
-				defer os.RemoveAll(tmpDirBase)
-				defer os.RemoveAll(pkgCache)
-				defer os.RemoveAll(dbPath)
-				// create new config here to add system repos
-				luetSystemConfig := luetTypes.LuetSystemConfig{
-					DatabasePath:   dbPath,
-					PkgsCachePath:  pkgCache,
-					DatabaseEngine: "memory",
-					TmpDirBase:     tmpDirBase,
-				}
-				luetGeneralConfig := luetTypes.LuetGeneralConfig{Debug: false, Quiet: true, Concurrency: runtime.NumCPU()}
-				luetSolver := luetTypes.LuetSolverOptions{}
-				repos := luetTypes.LuetRepositories{}
-				repo := luetTypes.LuetRepository{
-					Name:           "cos",
-					Description:    "cos official",
-					Urls:           []string{"quay.io/costoolkit/releases-green"},
-					Type:           "docker",
-					Priority:       1,
-					Enable:         true,
-					Cached:         true,
-					Authentication: make(map[string]string),
-				}
-				repos = append(repos, repo)
-
-				cfg := luetTypes.LuetConfig{System: luetSystemConfig, Solver: luetSolver, General: luetGeneralConfig, SystemRepositories: repos}
-				l = luet.NewLuet(luet.WithLogger(logger), luet.WithConfig(&cfg))
-				config.Luet = l
 
 				upgrade = action.NewUpgradeAction(config)
 				err := upgrade.Run()
@@ -1132,33 +1095,6 @@ var _ = Describe("Runtime Actions", func() {
 					Expect(f).To(ContainSubstring("recovery"))
 
 					config.ChannelUpgrades = true
-					// Required paths
-					tmpDirBase, _ := utils.TempDir(fs, "", "tmpluet")
-					// create new config here to add system repos
-					luetSystemConfig := luetTypes.LuetSystemConfig{
-						DatabasePath:   filepath.Join(tmpDirBase, "db"),
-						PkgsCachePath:  filepath.Join(tmpDirBase, "cache"),
-						DatabaseEngine: "",
-						TmpDirBase:     tmpDirBase,
-					}
-					luetGeneralConfig := luetTypes.LuetGeneralConfig{Debug: false, Quiet: true, Concurrency: runtime.NumCPU()}
-					luetSolver := luetTypes.LuetSolverOptions{}
-					repos := luetTypes.LuetRepositories{}
-					repo := luetTypes.LuetRepository{
-						Name:           "cos",
-						Description:    "cos official",
-						Urls:           []string{"quay.io/costoolkit/releases-green"},
-						Type:           "docker",
-						Priority:       1,
-						Enable:         true,
-						Cached:         true,
-						Authentication: make(map[string]string),
-					}
-					repos = append(repos, repo)
-
-					cfg := luetTypes.LuetConfig{System: luetSystemConfig, Solver: luetSolver, General: luetGeneralConfig, SystemRepositories: repos}
-					l = luet.NewLuet(luet.WithLogger(logger), luet.WithConfig(&cfg))
-					config.Luet = l
 
 					upgrade = action.NewUpgradeAction(config)
 					err = upgrade.Run()
@@ -1291,35 +1227,6 @@ var _ = Describe("Runtime Actions", func() {
 					Expect(f).To(ContainSubstring("recovery"))
 
 					config.ChannelUpgrades = true
-					// Required paths
-					tmpDirBase, _ := utils.TempDir(fs, "", "elemental")
-					pkgCache, _ := utils.TempDir(fs, "", "elemental")
-					dbPath, _ := utils.TempDir(fs, "", "elemental")
-					// create new config here to add system repos
-					luetSystemConfig := luetTypes.LuetSystemConfig{
-						DatabasePath:   dbPath,
-						PkgsCachePath:  pkgCache,
-						DatabaseEngine: "memory",
-						TmpDirBase:     tmpDirBase,
-					}
-					luetGeneralConfig := luetTypes.LuetGeneralConfig{Debug: false, Quiet: true, Concurrency: runtime.NumCPU()}
-					luetSolver := luetTypes.LuetSolverOptions{}
-					repos := luetTypes.LuetRepositories{}
-					repo := luetTypes.LuetRepository{
-						Name:           "cos",
-						Description:    "cos official",
-						Urls:           []string{"quay.io/costoolkit/releases-green"},
-						Type:           "docker",
-						Priority:       1,
-						Enable:         true,
-						Cached:         true,
-						Authentication: make(map[string]string),
-					}
-					repos = append(repos, repo)
-
-					cfg := luetTypes.LuetConfig{System: luetSystemConfig, Solver: luetSolver, General: luetGeneralConfig, SystemRepositories: repos}
-					l = luet.NewLuet(luet.WithLogger(logger), luet.WithConfig(&cfg))
-					config.Luet = l
 
 					upgrade = action.NewUpgradeAction(config)
 					err = upgrade.Run()

--- a/pkg/action/runtime_test.go
+++ b/pkg/action/runtime_test.go
@@ -811,7 +811,7 @@ var _ = Describe("Runtime Actions", func() {
 				Expect(err).To(HaveOccurred())
 			})
 			It("Successfully upgrades from directory", Label("directory", "root"), func() {
-				config.Directory, _ = utils.TempDir(fs, "", "elemental")
+				config.Directory, _ = utils.TempDir(fs, "", "elementalupgrade")
 				// Create the dir on real os as rsync works on the real os
 				defer fs.RemoveAll(config.Directory)
 				// create a random file on it

--- a/pkg/luet/luet.go
+++ b/pkg/luet/luet.go
@@ -189,7 +189,6 @@ func (l Luet) initLuetRepository(repo v1.Repository) (luetTypes.LuetRepository, 
 func (l Luet) UnpackFromChannel(target string, pkg string, repositories ...v1.Repository) error {
 	var toInstall luetTypes.Packages
 	toInstall = append(toInstall, l.parsePackage(pkg))
-	//l.log.Debugf("Luet config: %+v", l.context.Config)
 
 	repos := l.context.Config.SystemRepositories
 	if len(repositories) > 0 {

--- a/pkg/luet/luet.go
+++ b/pkg/luet/luet.go
@@ -189,7 +189,7 @@ func (l Luet) initLuetRepository(repo v1.Repository) (luetTypes.LuetRepository, 
 func (l Luet) UnpackFromChannel(target string, pkg string, repositories ...v1.Repository) error {
 	var toInstall luetTypes.Packages
 	toInstall = append(toInstall, l.parsePackage(pkg))
-	l.log.Debugf("Luet config: %+v", l.context.Config)
+	//l.log.Debugf("Luet config: %+v", l.context.Config)
 
 	repos := l.context.Config.SystemRepositories
 	if len(repositories) > 0 {

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -174,9 +174,22 @@ type Repository struct {
 
 // BuildConfig represents the config we need for building isos, raw images, artifacts
 type BuildConfig struct {
-	ISO  *LiveISO `yaml:"iso,omitempty" mapstructure:"iso"`
-	Date bool     `yaml:"date,omitempty" mapstructure:"date"`
-	Name string   `yaml:"name,omitempty" mapstructure:"name"`
+	ISO     *LiveISO                    `yaml:"iso,omitempty" mapstructure:"iso"`
+	Date    bool                        `yaml:"date,omitempty" mapstructure:"date"`
+	Name    string                      `yaml:"name,omitempty" mapstructure:"name"`
+	RawDisk map[string]RawDiskArchEntry `yaml:"raw_disk,omitempty" mapstructure:"raw_disk"`
 	// Generic runtime configuration
 	Config
+}
+
+// RawDiskArchEntry represents an arch entry in raw_disk
+type RawDiskArchEntry struct {
+	Repositories []Repository     `yaml:"repo,omitempty"`
+	Packages     []RawDiskPackage `yaml:"packages,omitempty"`
+}
+
+// RawDiskPackage represents a package entry for raw_disk, with a package name and a target to install to
+type RawDiskPackage struct {
+	Name   string `yaml:"name,omitempty"`
+	Target string `yaml:"target,omitempty"`
 }

--- a/pkg/utils/fs.go
+++ b/pkg/utils/fs.go
@@ -20,7 +20,6 @@ limitations under the License.
 package utils
 
 import (
-	"github.com/twpayne/go-vfs/vfst"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -31,6 +30,7 @@ import (
 
 	v1 "github.com/rancher-sandbox/elemental/pkg/types/v1"
 	"github.com/twpayne/go-vfs"
+	"github.com/twpayne/go-vfs/vfst"
 )
 
 // DirSize returns the accumulated size of all files in folder

--- a/pkg/utils/fs.go
+++ b/pkg/utils/fs.go
@@ -20,6 +20,7 @@ limitations under the License.
 package utils
 
 import (
+	"github.com/twpayne/go-vfs/vfst"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -117,7 +118,15 @@ func TempDir(fs v1.FS, dir, prefix string) (name string, err error) {
 	if dir == "" {
 		dir = os.TempDir()
 	}
-
+	// This skips adding random stuff to the created temp dir so the temp dir created is predictable for testing
+	if _, isTestFs := fs.(*vfst.TestFS); isTestFs {
+		err = MkdirAll(fs, filepath.Join(dir, prefix), 0700)
+		if err != nil {
+			return "", err
+		}
+		name = filepath.Join(dir, prefix)
+		return
+	}
 	nconflict := 0
 	for i := 0; i < 10000; i++ {
 		try := filepath.Join(dir, prefix+nextRandom())

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -446,7 +446,7 @@ var _ = Describe("Utils", Label("utils"), func() {
 			Expect(destNames).To(Equal(SourceNames))
 		})
 
-		FIt("Copies all files from source to target respecting excludes", func() {
+		It("Copies all files from source to target respecting excludes", func() {
 			sourceDir, err := utils.TempDir(fs, "", "elementalsource")
 			Expect(err).ShouldNot(HaveOccurred())
 			destDir, err := utils.TempDir(fs, "", "elementaltarget")

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -422,9 +422,9 @@ var _ = Describe("Utils", Label("utils"), func() {
 	})
 	Describe("SyncData", Label("SyncData"), func() {
 		It("Copies all files from source to target", func() {
-			sourceDir, err := utils.TempDir(fs, "", "elemental")
+			sourceDir, err := utils.TempDir(fs, "", "elementalsource")
 			Expect(err).ShouldNot(HaveOccurred())
-			destDir, err := utils.TempDir(fs, "", "elemental")
+			destDir, err := utils.TempDir(fs, "", "elementaltarget")
 			Expect(err).ShouldNot(HaveOccurred())
 
 			for i := 0; i < 5; i++ {
@@ -446,10 +446,10 @@ var _ = Describe("Utils", Label("utils"), func() {
 			Expect(destNames).To(Equal(SourceNames))
 		})
 
-		It("Copies all files from source to target respecting excludes", func() {
-			sourceDir, err := utils.TempDir(fs, "", "elemental")
+		FIt("Copies all files from source to target respecting excludes", func() {
+			sourceDir, err := utils.TempDir(fs, "", "elementalsource")
 			Expect(err).ShouldNot(HaveOccurred())
-			destDir, err := utils.TempDir(fs, "", "elemental")
+			destDir, err := utils.TempDir(fs, "", "elementaltarget")
 			Expect(err).ShouldNot(HaveOccurred())
 
 			utils.MkdirAll(fs, filepath.Join(sourceDir, "host"), constants.DirPerm)
@@ -490,9 +490,9 @@ var _ = Describe("Utils", Label("utils"), func() {
 		})
 
 		It("Copies all files from source to target respecting excludes with '/' prefix", func() {
-			sourceDir, err := utils.TempDir(fs, "", "elemental")
+			sourceDir, err := utils.TempDir(fs, "", "elementalsource")
 			Expect(err).ShouldNot(HaveOccurred())
-			destDir, err := utils.TempDir(fs, "", "elemental")
+			destDir, err := utils.TempDir(fs, "", "elementaltarget")
 			Expect(err).ShouldNot(HaveOccurred())
 
 			utils.MkdirAll(fs, filepath.Join(sourceDir, "host"), constants.DirPerm)
@@ -522,9 +522,9 @@ var _ = Describe("Utils", Label("utils"), func() {
 		})
 
 		It("should not fail if dirs are empty", func() {
-			sourceDir, err := utils.TempDir(fs, "", "elemental")
+			sourceDir, err := utils.TempDir(fs, "", "elementalsource")
 			Expect(err).ShouldNot(HaveOccurred())
-			destDir, err := utils.TempDir(fs, "", "elemental")
+			destDir, err := utils.TempDir(fs, "", "elementaltarget")
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(utils.SyncData(fs, sourceDir, destDir)).To(BeNil())
 		})


### PR DESCRIPTION
This allows a config as follows:


```
raw_disk:
  x86_64:
    repositories:
      - uri: quay.io/costoolkit/releases-green
    # which packages to install and the target to install them at
    packages:
      - name: system/grub2-efi-image
        target: efi
      - name: system/grub2-config
        target: root
      - name: system/grub2-artifacts
        target: root/grub2
      - name: recovery/cos-img
        target: root/cOS
  aarch64:
    repositories:
      - uri: quay.io/costoolkit/releases-green-arm64
    packages:
      - name: system/grub2-efi-image
        target: efi
      - name: system/grub2-config
        target: root
      - name: system/grub2-artifacts
        target: root/grub2
      - name: recovery/cos-img
        target: root/cOS
  odroid_c2:
    repositories:
      - uri: quay.io/costoolkit/releases-green-arm64
    packages:
      - name: system/grub2-efi-image
        target: efi
      - name: system/grub2-config
        target: root
      - name: system/grub2-artifacts
        target: root/grub2
```

Signed-off-by: Itxaka <igarcia@suse.com>