### PR TITLE
Exclude only root-located directories

### DIFF
--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -339,7 +339,7 @@ func (c *Elemental) CopyImage(img *v1.Image) error { // nolint:gocyclo
 			return err
 		}
 	} else if img.Source.IsDir() {
-		excludes := []string{"mnt", "proc", "sys", "dev", "tmp", "host", "run"}
+		excludes := []string{"/mnt", "/proc", "/sys", "/dev", "/tmp", "/host", "/run"}
 		err = utils.SyncData(c.config.Fs, img.Source.Value(), img.MountPoint, excludes...)
 		if err != nil {
 			return err


### PR DESCRIPTION
This commit fixes https://github.com/rancher-sandbox/elemental/issues/164.

It was wrongly implied to exclude root level directories when copying from a directory,
resulting in other folder, such as /var/run to be excluded as well.

It also includes specific unit tests to avoid falling into this in the
future if we ever change the underlying lib.

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>