### PR TITLE
Expand build disk

### DIFF
--- a/cmd/convert-disk.go
+++ b/cmd/convert-disk.go
@@ -18,10 +18,10 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/rancher-sandbox/elemental/pkg/action"
 	"strings"
 
 	"github.com/rancher-sandbox/elemental/cmd/config"
+	"github.com/rancher-sandbox/elemental/pkg/action"
 	"github.com/rancher-sandbox/elemental/pkg/utils"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"

--- a/cmd/convert-disk.go
+++ b/cmd/convert-disk.go
@@ -18,24 +18,26 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/rancher-sandbox/elemental/pkg/action"
+	"strings"
 
 	"github.com/rancher-sandbox/elemental/cmd/config"
-	"github.com/rancher-sandbox/elemental/pkg/action"
-	v1 "github.com/rancher-sandbox/elemental/pkg/types/v1"
 	"github.com/rancher-sandbox/elemental/pkg/utils"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	mountUtils "k8s.io/mount-utils"
 )
 
-// NewBuildDisk returns a new instance of the build-disk subcommand and appends it to
+var outputAllowed = []string{"azure", "gce"}
+
+// NewConvertDisk returns a new instance of the convert-disk subcommand and appends it to
 // the root command. requireRoot is to initiate it with or without the CheckRoot
 // pre-run check. This method is mostly used for testing purposes.
-func NewBuildDisk(root *cobra.Command, addCheckRoot bool) *cobra.Command {
+func NewConvertDisk(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 	c := &cobra.Command{
-		Use:   "build-disk",
-		Short: "Build a raw recovery image",
-		Args:  cobra.NoArgs,
+		Use:   "convert-disk RAW_DISK",
+		Short: fmt.Sprintf("converts between a raw disk and a cloud operator disk image (%s)", strings.Join(outputAllowed, ",")),
+		Args:  cobra.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			_ = viper.BindPFlags(cmd.Flags())
 			if addCheckRoot {
@@ -52,12 +54,7 @@ func NewBuildDisk(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 				configDir = "."
 			}
 
-			cfg, err := config.ReadConfigBuild(configDir, mounter, true)
-			if err != nil {
-				return err
-			}
-
-			err = validateCosignFlags(cfg.Logger)
+			cfg, err := config.ReadConfigBuild(configDir, mounter, false)
 			if err != nil {
 				return err
 			}
@@ -65,43 +62,32 @@ func NewBuildDisk(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 			// Set this after parsing of the flags, so it fails on parsing and prints usage properly
 			cmd.SilenceUsage = true
 			cmd.SilenceErrors = true // Do not propagate errors down the line, we control them
+
 			imgType, _ := cmd.Flags().GetString("type")
-			archType, _ := cmd.Flags().GetString("arch")
-			output, _ := cmd.Flags().GetString("output")
-			oemLabel, _ := cmd.Flags().GetString("oem_label")
-			recoveryLabel, _ := cmd.Flags().GetString("recovery_label")
+			keepImage, _ := cmd.Flags().GetBool("keep-source")
+			rawDisk := args[0]
 
-			// Set the repo depending on the arch we are building for
-			var repos []v1.Repository
-			for _, u := range cfg.RawDisk[archType].Repositories {
-				repos = append(repos, v1.Repository{URI: u.URI})
-			}
-			cfg.Config.Repos = repos
-
-			if exists, _ := utils.Exists(cfg.Fs, output); exists {
-				cfg.Logger.Errorf("Output file %s exists, refusing to continue", output)
-				return fmt.Errorf("output file %s exists, refusing to continue", output)
+			if exists, _ := utils.Exists(cfg.Fs, rawDisk); !exists {
+				cfg.Logger.Errorf("Raw image %s doesnt exist", rawDisk)
+				return fmt.Errorf("raw image %s doesnt exist", rawDisk)
 			}
 
-			err = action.BuildDiskRun(cfg, imgType, archType, oemLabel, recoveryLabel, output)
-			if err != nil {
-				return err
+			switch imgType {
+			case "azure":
+				err = action.Raw2Azure(rawDisk, cfg.Fs, cfg.Logger, keepImage)
+			case "gce":
+				err = action.Raw2Gce(rawDisk, cfg.Fs, cfg.Logger, keepImage)
 			}
 
-			return nil
+			return err
 		},
 	}
 	root.AddCommand(c)
-	imgType := newEnumFlag([]string{"raw", "azure", "gce"}, "raw")
-	archType := newEnumFlag([]string{"x86_64", "aarch64"}, "x86_64")
+	imgType := newEnumFlag(outputAllowed, "azure")
 	c.Flags().VarP(imgType, "type", "t", "Type of image to create")
-	c.Flags().VarP(archType, "arch", "a", "Arch to build the image for")
-	c.Flags().StringP("output", "o", "disk.raw", "Output file (Extension auto changes based of the image type)")
-	c.Flags().String("oem_label", "COS_OEM", "Oem partition label")
-	c.Flags().String("recovery_label", "COS_RECOVERY", "Recovery partition label")
-	addCosignFlags(c)
+	c.Flags().Bool("keep-source", false, "Keep the source image, otherwise it will delete it once transformed.")
 	return c
 }
 
 // register the subcommand into rootCmd
-var _ = NewBuildDisk(rootCmd, true)
+var _ = NewConvertDisk(rootCmd, false)

--- a/pkg/action/build-disk.go
+++ b/pkg/action/build-disk.go
@@ -164,7 +164,7 @@ func Raw2Gce(source string, fs v1.FS, logger v1.Logger, keepOldImage bool) error
 	// The RAW image file must have a size in an increment of 1 GB. For example, the file must be either 10 GB or 11 GB but not 10.5 GB.
 	// The disk image filename must be disk.raw.
 	// The compressed file must be a .tar.gz file that uses gzip compression and the --format=oldgnu option for the tar utility.
-	logger.Info("Transforming raw image into azure format")
+	logger.Info("Transforming raw image into gce format")
 	actImg, err := fs.Open(source)
 	if err != nil {
 		return err

--- a/pkg/action/build-disk.go
+++ b/pkg/action/build-disk.go
@@ -17,6 +17,9 @@ limitations under the License.
 package action
 
 import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -28,6 +31,7 @@ import (
 )
 
 var MB = int64(1024 * 1024)
+var GB = 1024 * MB
 
 func BuildDiskRun(cfg *v1.BuildConfig, imgType string, arch string, oemLabel string, recoveryLabel string, output string) (err error) {
 	cfg.Logger.Infof("Building disk image type %s for arch %s", imgType, arch)
@@ -133,7 +137,131 @@ func BuildDiskRun(cfg *v1.BuildConfig, imgType string, arch string, oemLabel str
 		return err
 	}
 
+	switch imgType {
+	case "raw":
+		// Nothing to do here
+		cfg.Logger.Infof("Done! Image created at %s", output)
+	case "azure":
+		err = Raw2Azure(output, cfg.Fs, cfg.Logger, false)
+		if err != nil {
+			return err
+		}
+		cfg.Logger.Infof("Done! Image created at %s", fmt.Sprintf("%s.tar.gz", output))
+	case "gce":
+		err = Raw2Gce(output, cfg.Fs, cfg.Logger, false)
+		if err != nil {
+			return err
+		}
+		cfg.Logger.Infof("Done! Image created at %s", fmt.Sprintf("%s.vhd", output))
+	}
+
 	return err
+}
+
+// Raw2Gce transforms an image from RAW format into GCE format
+// THIS REMOVES THE SOURCE IMAGE BY DEFAULT
+func Raw2Gce(source string, fs v1.FS, logger v1.Logger, keepOldImage bool) error {
+	// The RAW image file must have a size in an increment of 1 GB. For example, the file must be either 10 GB or 11 GB but not 10.5 GB.
+	// The disk image filename must be disk.raw.
+	// The compressed file must be a .tar.gz file that uses gzip compression and the --format=oldgnu option for the tar utility.
+	logger.Info("Transforming raw image into azure format")
+	actImg, err := fs.Open(source)
+	if err != nil {
+		return err
+	}
+	info, err := actImg.Stat()
+	if err != nil {
+		return err
+	}
+	actualSize := info.Size()
+	finalSizeGB := actualSize/GB + 1
+	finalSizeBytes := finalSizeGB * GB
+	logger.Infof("Resizing img from %d to %d", actualSize, finalSizeBytes)
+	// REMEMBER TO SEEK!
+	_, _ = actImg.Seek(0, io.SeekEnd)
+	_ = actImg.Truncate(finalSizeBytes)
+	_ = actImg.Close()
+
+	// Tar gz the image
+	logger.Infof("Compressing raw image into a tar.gz")
+	// Create destination file
+	file, err := os.Create(fmt.Sprintf("%s.tar.gz", source))
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	// Create gzip writer
+	gzipWriter := gzip.NewWriter(file)
+	defer gzipWriter.Close()
+	// Create tarwriter pointing to our gzip writer
+	tarWriter := tar.NewWriter(gzipWriter)
+	defer tarWriter.Close()
+
+	// Open disk.raw
+	sourceFile, _ := fs.Open(source)
+	sourceStat, _ := sourceFile.Stat()
+	defer sourceFile.Close()
+
+	// Add disk.raw file
+	header := &tar.Header{
+		Name:   sourceStat.Name(),
+		Size:   sourceStat.Size(),
+		Mode:   int64(sourceStat.Mode()),
+		Format: tar.FormatGNU,
+	}
+	// Write header with all the info
+	err = tarWriter.WriteHeader(header)
+	if err != nil {
+		return err
+	}
+	// copy the actual data
+	_, err = io.Copy(tarWriter, sourceFile)
+	if err != nil {
+		return err
+	}
+	// Remove full raw image, we already got the compressed one
+	if !keepOldImage {
+		_ = fs.RemoveAll(source)
+	}
+	return nil
+}
+
+// Raw2Azure transforms an image from RAW format into Azure format
+// THIS REMOVES THE SOURCE IMAGE BY DEFAULT
+func Raw2Azure(source string, fs v1.FS, logger v1.Logger, keepOldImage bool) error {
+	// All VHDs on Azure must have a virtual size aligned to 1 MB (1024 × 1024 bytes)
+	// The Hyper-V virtual hard disk (VHDX) format isn't supported in Azure, only fixed VHD
+	logger.Info("Transforming raw image into azure format")
+	actImg, err := fs.Open(source)
+	if err != nil {
+		return err
+	}
+	info, _ := actImg.Stat()
+	actualSize := info.Size()
+	finalSizeBytes := ((actualSize + MB - 1) / MB) * MB
+	logger.Infof("Resizing img from %d to %d", actualSize, finalSizeBytes)
+	// REMEMBER TO SEEK!
+	_, _ = actImg.Seek(0, io.SeekEnd)
+	_ = actImg.Truncate(finalSizeBytes)
+	_ = actImg.Close()
+	// Copy raw to new image with VHD appended
+	err = utils.CopyFile(fs, source, fmt.Sprintf("%s.vhd", source))
+	if err != nil {
+		return err
+	}
+	// Open it
+	vhdFile, err := fs.OpenFile(fmt.Sprintf("%s.vhd", source), os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		return err
+	}
+	// Transform it to VHD
+	utils.RawDiskToFixedVhd(vhdFile)
+	_ = vhdFile.Close()
+	// Remove raw image
+	if !keepOldImage {
+		_ = fs.RemoveAll(source)
+	}
+	return nil
 }
 
 // CreateFinalImage creates the final image by truncating the image with the proper sizes, concatenating the contents of the

--- a/pkg/action/build_test.go
+++ b/pkg/action/build_test.go
@@ -268,7 +268,7 @@ var _ = Describe("Runtime Actions", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 		})
-		It("Transforms raw image into GCE image", func() {
+		It("Transforms raw image into GCE image", Label("gce"), func() {
 			tmpDir, err := utils.TempDir(fs, "", "")
 			defer fs.RemoveAll(tmpDir)
 			Expect(err).ToNot(HaveOccurred())
@@ -283,9 +283,10 @@ var _ = Describe("Runtime Actions", func() {
 			// Log should have the rounded size (1Gb)
 			Expect(memLog.String()).To(ContainSubstring(strconv.Itoa(1 * 1024 * 1024 * 1024)))
 			// Should be a tar file
-			Expect(dockerArchive.IsArchivePath(filepath.Join(tmpDir, "disk.raw.tar.gz"))).To(BeTrue())
+			realPath, _ := fs.RawPath(tmpDir)
+			Expect(dockerArchive.IsArchivePath(filepath.Join(realPath, "disk.raw.tar.gz"))).To(BeTrue())
 		})
-		It("Transforms raw image into Azure image", Label("test"), func() {
+		It("Transforms raw image into Azure image", func() {
 			tmpDir, err := utils.TempDir(fs, "", "")
 			defer fs.RemoveAll(tmpDir)
 			Expect(err).ToNot(HaveOccurred())
@@ -318,7 +319,7 @@ var _ = Describe("Runtime Actions", func() {
 			Expect(hex.EncodeToString(header.Features[:])).To(Equal("00000002"))
 			Expect(hex.EncodeToString(header.DataOffset[:])).To(Equal("ffffffffffffffff"))
 		})
-		It("Transforms raw image into Azure image (really small image)", Label("test"), func() {
+		It("Transforms raw image into Azure image (really small image)", func() {
 			// This tests that the resize works for extreme small images
 			// Not sure if we ever will enconuter them (less than 1 Mb images?) but just in case
 			tmpDir, err := utils.TempDir(fs, "", "")

--- a/pkg/action/build_test.go
+++ b/pkg/action/build_test.go
@@ -18,11 +18,14 @@ package action_test
 
 import (
 	"bytes"
+	"encoding/binary"
+	"encoding/hex"
 	"errors"
-	"github.com/sirupsen/logrus"
 	"os"
 	"path/filepath"
+	"strconv"
 
+	dockerArchive "github.com/docker/docker/pkg/archive"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/rancher-sandbox/elemental/pkg/action"
@@ -31,6 +34,7 @@ import (
 	v1 "github.com/rancher-sandbox/elemental/pkg/types/v1"
 	"github.com/rancher-sandbox/elemental/pkg/utils"
 	v1mock "github.com/rancher-sandbox/elemental/tests/mocks"
+	"github.com/sirupsen/logrus"
 	"github.com/twpayne/go-vfs"
 	"github.com/twpayne/go-vfs/vfst"
 )
@@ -263,6 +267,96 @@ var _ = Describe("Runtime Actions", func() {
 				{"mcopy", "-s", "-i", "/tmp/elemental-build-disk-parts/efi.part", "/tmp/elemental-build-disk-files/efi/EFI", "::EFI"},
 			})
 			Expect(err).ToNot(HaveOccurred())
+		})
+		It("Transforms raw image into GCE image", func() {
+			tmpDir, err := utils.TempDir(fs, "", "")
+			defer fs.RemoveAll(tmpDir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
+			f, err := fs.Create(filepath.Join(tmpDir, "disk.raw"))
+			Expect(err).ToNot(HaveOccurred())
+			// Set a non rounded size
+			f.Truncate(34 * 1024 * 1024)
+			f.Close()
+			err = action.Raw2Gce(filepath.Join(tmpDir, "disk.raw"), fs, logger, false)
+			Expect(err).ToNot(HaveOccurred())
+			// Log should have the rounded size (1Gb)
+			Expect(memLog.String()).To(ContainSubstring(strconv.Itoa(1 * 1024 * 1024 * 1024)))
+			// Should be a tar file
+			Expect(dockerArchive.IsArchivePath(filepath.Join(tmpDir, "disk.raw.tar.gz"))).To(BeTrue())
+		})
+		It("Transforms raw image into Azure image", Label("test"), func() {
+			tmpDir, err := utils.TempDir(fs, "", "")
+			defer fs.RemoveAll(tmpDir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
+			f, err := fs.Create(filepath.Join(tmpDir, "disk.raw"))
+			Expect(err).ToNot(HaveOccurred())
+			// write something
+			_ = f.Truncate(23 * 1024 * 1024)
+			_ = f.Close()
+			err = action.Raw2Azure(filepath.Join(tmpDir, "disk.raw"), fs, logger, true)
+			Expect(err).ToNot(HaveOccurred())
+			info, err := fs.Stat(filepath.Join(tmpDir, "disk.raw.vhd"))
+			Expect(err).ToNot(HaveOccurred())
+			// Should have be rounded up to the next MB
+			Expect(info.Size()).To(BeNumerically("==", 23*1024*1024))
+
+			// Read the header
+			f, _ = fs.Open(filepath.Join(tmpDir, "disk.raw.vhd"))
+			info, _ = f.Stat()
+			// Dump the header from the file into our VHDHeader
+			buff := make([]byte, 512)
+			_, _ = f.ReadAt(buff, info.Size()-512)
+			_ = f.Close()
+
+			header := utils.VHDHeader{}
+			err = binary.Read(bytes.NewBuffer(buff[:]), binary.BigEndian, &header)
+			Expect(err).ToNot(HaveOccurred())
+			// Just check the fields that we know the value of, that should indicate that the header is valid
+			Expect(hex.EncodeToString(header.DiskType[:])).To(Equal("00000002"))
+			Expect(hex.EncodeToString(header.Features[:])).To(Equal("00000002"))
+			Expect(hex.EncodeToString(header.DataOffset[:])).To(Equal("ffffffffffffffff"))
+		})
+		It("Transforms raw image into Azure image (really small image)", Label("test"), func() {
+			// This tests that the resize works for extreme small images
+			// Not sure if we ever will enconuter them (less than 1 Mb images?) but just in case
+			tmpDir, err := utils.TempDir(fs, "", "")
+			defer fs.RemoveAll(tmpDir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
+			f, err := fs.Create(filepath.Join(tmpDir, "disk.raw"))
+			Expect(err).ToNot(HaveOccurred())
+			// write something
+			_, _ = f.WriteString("Hi")
+			_ = f.Close()
+			err = action.Raw2Azure(filepath.Join(tmpDir, "disk.raw"), fs, logger, true)
+			Expect(err).ToNot(HaveOccurred())
+			info, err := fs.Stat(filepath.Join(tmpDir, "disk.raw"))
+			Expect(err).ToNot(HaveOccurred())
+			// Should be smaller than 1Mb
+			Expect(info.Size()).To(BeNumerically("<", 1*1024*1024))
+
+			info, err = fs.Stat(filepath.Join(tmpDir, "disk.raw.vhd"))
+			Expect(err).ToNot(HaveOccurred())
+			// Should have be rounded up to the next MB
+			Expect(info.Size()).To(BeNumerically("==", 1*1024*1024))
+
+			// Read the header
+			f, _ = fs.Open(filepath.Join(tmpDir, "disk.raw.vhd"))
+			info, _ = f.Stat()
+			// Dump the header from the file into our VHDHeader
+			buff := make([]byte, 512)
+			_, _ = f.ReadAt(buff, info.Size()-512)
+			_ = f.Close()
+
+			header := utils.VHDHeader{}
+			err = binary.Read(bytes.NewBuffer(buff[:]), binary.BigEndian, &header)
+			Expect(err).ToNot(HaveOccurred())
+			// Just check the fields that we know the value of, that should indicate that the header is valid
+			Expect(hex.EncodeToString(header.DiskType[:])).To(Equal("00000002"))
+			Expect(hex.EncodeToString(header.Features[:])).To(Equal("00000002"))
+			Expect(hex.EncodeToString(header.DataOffset[:])).To(Equal("ffffffffffffffff"))
 		})
 	})
 })

--- a/pkg/action/runtime_test.go
+++ b/pkg/action/runtime_test.go
@@ -766,7 +766,7 @@ var _ = Describe("Runtime Actions", func() {
 				_ = fs.RemoveAll(activeImg)
 				_ = fs.RemoveAll(passiveImg)
 			})
-			It("Successfully upgrades from docker image", Label("docker", "root"), func() {
+			It("Successfully upgrades from docker image", Label("docker"), func() {
 				config.DockerImg = "alpine"
 				upgrade = action.NewUpgradeAction(config)
 				err := upgrade.Run()
@@ -805,7 +805,7 @@ var _ = Describe("Runtime Actions", func() {
 				_, err = fs.Stat(transitionImg)
 				Expect(err).To(HaveOccurred())
 			})
-			It("Successfully upgrades from directory", Label("directory", "root"), func() {
+			It("Successfully upgrades from directory", Label("directory"), func() {
 				config.Directory, _ = utils.TempDir(fs, "", "elementalupgrade")
 				// Create the dir on real os as rsync works on the real os
 				defer fs.RemoveAll(config.Directory)
@@ -844,7 +844,7 @@ var _ = Describe("Runtime Actions", func() {
 				Expect(err).To(HaveOccurred())
 
 			})
-			It("Successfully upgrades from channel upgrade", Label("channel", "root"), func() {
+			It("Successfully upgrades from channel upgrade", Label("channel"), func() {
 				config.ChannelUpgrades = true
 
 				upgrade = action.NewUpgradeAction(config)
@@ -878,9 +878,9 @@ var _ = Describe("Runtime Actions", func() {
 				_, err = fs.Stat(transitionImg)
 				Expect(err).To(HaveOccurred())
 			})
-			It("Successfully upgrades with cosign", Pending, Label("channel", "cosign", "root"), func() {})
-			It("Successfully upgrades with mtree", Pending, Label("channel", "mtree", "root"), func() {})
-			It("Successfully upgrades with strict", Pending, Label("channel", "strict", "root"), func() {})
+			It("Successfully upgrades with cosign", Pending, Label("channel", "cosign"), func() {})
+			It("Successfully upgrades with mtree", Pending, Label("channel", "mtree"), func() {})
+			It("Successfully upgrades with strict", Pending, Label("channel", "strict"), func() {})
 		})
 		Describe(fmt.Sprintf("Booting from %s", constants.PassiveLabel), Label("passive_label"), func() {
 			BeforeEach(func() {
@@ -905,7 +905,7 @@ var _ = Describe("Runtime Actions", func() {
 				_ = fs.RemoveAll(activeImg)
 				_ = fs.RemoveAll(passiveImg)
 			})
-			It("does not backup active img to passive", Label("docker", "root"), func() {
+			It("does not backup active img to passive", Label("docker"), func() {
 				config.DockerImg = "alpine"
 				upgrade = action.NewUpgradeAction(config)
 				err := upgrade.Run()
@@ -1012,7 +1012,7 @@ var _ = Describe("Runtime Actions", func() {
 					// Create recoveryImgSquash so ti identifies that we are using squash recovery
 					_ = fs.WriteFile(recoveryImgSquash, []byte("recovery"), constants.FilePerm)
 				})
-				It("Successfully upgrades recovery from docker image", Label("docker", "root"), func() {
+				It("Successfully upgrades recovery from docker image", Label("docker"), func() {
 					// This should be the old image
 					info, err := fs.Stat(recoveryImgSquash)
 					Expect(err).ToNot(HaveOccurred())
@@ -1052,7 +1052,7 @@ var _ = Describe("Runtime Actions", func() {
 					Expect(err).To(HaveOccurred())
 
 				})
-				It("Successfully upgrades recovery from directory", Label("directory", "root"), func() {
+				It("Successfully upgrades recovery from directory", Label("directory"), func() {
 					config.Directory, _ = utils.TempDir(fs, "", "elemental")
 					// create a random file on it
 					_ = fs.WriteFile(fmt.Sprintf("%s/file.file", config.Directory), []byte("something"), constants.FilePerm)
@@ -1084,7 +1084,7 @@ var _ = Describe("Runtime Actions", func() {
 					Expect(err).To(HaveOccurred())
 
 				})
-				It("Successfully upgrades recovery from channel upgrade", Label("channel", "root"), func() {
+				It("Successfully upgrades recovery from channel upgrade", Label("channel"), func() {
 					// This should be the old image
 					info, err := fs.Stat(recoveryImgSquash)
 					Expect(err).ToNot(HaveOccurred())
@@ -1143,7 +1143,7 @@ var _ = Describe("Runtime Actions", func() {
 					_ = fs.WriteFile(recoveryImg, []byte("recovery"), constants.FilePerm)
 
 				})
-				It("Successfully upgrades recovery from docker image", Label("docker", "root"), func() {
+				It("Successfully upgrades recovery from docker image", Label("docker"), func() {
 					// This should be the old image
 					info, err := fs.Stat(recoveryImg)
 					Expect(err).ToNot(HaveOccurred())
@@ -1182,9 +1182,10 @@ var _ = Describe("Runtime Actions", func() {
 						_, err := fs.Stat(img)
 						Expect(err).To(HaveOccurred())
 					}
+					fmt.Printf(memLog.String())
 
 				})
-				It("Successfully upgrades recovery from directory", Label("directory", "root"), func() {
+				It("Successfully upgrades recovery from directory", Label("directory"), func() {
 					config.Directory, _ = utils.TempDir(fs, "", "elemental")
 					// create a random file on it
 					_ = fs.WriteFile(fmt.Sprintf("%s/file.file", config.Directory), []byte("something"), constants.FilePerm)
@@ -1215,7 +1216,7 @@ var _ = Describe("Runtime Actions", func() {
 					info, err = fs.Stat(transitionImgRecovery)
 					Expect(err).To(HaveOccurred())
 				})
-				It("Successfully upgrades recovery from channel upgrade", Label("channel", "root"), func() {
+				It("Successfully upgrades recovery from channel upgrade", Label("channel"), func() {
 					// This should be the old image
 					info, err := fs.Stat(recoveryImg)
 					Expect(err).ToNot(HaveOccurred())

--- a/pkg/action/runtime_test.go
+++ b/pkg/action/runtime_test.go
@@ -356,7 +356,6 @@ var _ = Describe("Runtime Actions", func() {
 		})
 
 	})
-
 	Describe("Install Action", Label("install"), func() {
 		var device, cmdFail string
 		var err error

--- a/pkg/utils/vhd.go
+++ b/pkg/utils/vhd.go
@@ -56,8 +56,8 @@ func newVHDFixed(size uint64) VHDHeader {
 	hexToField("ffffffffffffffff", header.DataOffset[:])
 	t := uint32(time.Now().Unix() - 946684800)
 	binary.BigEndian.PutUint32(header.Timestamp[:], t)
-	hexToField("656C656D656E74616C", header.CreatorApplication[:]) // Cos
-	hexToField("73757365", header.CreatorHostOS[:])                // SUSE
+	hexToField("656c656d", header.CreatorApplication[:]) // Cos
+	hexToField("73757365", header.CreatorHostOS[:])      // SUSE
 	binary.BigEndian.PutUint64(header.OriginalSize[:], size)
 	binary.BigEndian.PutUint64(header.CurrentSize[:], size)
 	// Divide size into 512 to get the total sectors
@@ -70,13 +70,13 @@ func newVHDFixed(size uint64) VHDHeader {
 	hexToField("00000000", header.Checksum[:])
 	uuid := uuidPkg.Generate()
 	copy(header.UniqueID[:], uuid.String())
-	generateChecksum(header)
+	generateChecksum(&header)
 	return header
 }
 
 // generateChecksum generates the checksum of the vhd header
 // Lifted from the official VHD Format Spec
-func generateChecksum(header VHDHeader) {
+func generateChecksum(header *VHDHeader) {
 	buffer := new(bytes.Buffer)
 	_ = binary.Write(buffer, binary.BigEndian, header)
 	checksum := 0

--- a/pkg/utils/vhd.go
+++ b/pkg/utils/vhd.go
@@ -1,0 +1,155 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+	"math"
+	"os"
+	"time"
+
+	uuidPkg "github.com/distribution/distribution/uuid"
+)
+
+// This file contains utils to work with VHD disks
+
+type VHDHeader struct {
+	Cookie   [8]byte // Cookies are used to uniquely identify the original creator of the hard disk image
+	Features [4]byte // This is a bit field used to indicate specific feature support.
+	// Can be 0x00000000 (no features), 0x00000001 (Temporary, candidate for deletion on shutdown) or 0x00000002 (Reserved)
+	FileFormatVersion  [4]byte   // Divided into a major/minor version and matches the version of the specification used in creating the file.
+	DataOffset         [8]byte   // For fixed disks, this field should be set to 0xFFFFFFFF.
+	Timestamp          [4]byte   // Sstores the creation time of a hard disk image. This is the number of seconds since January 1, 2000 12:00:00 AM in UTC/GMT.
+	CreatorApplication [4]byte   // Used to document which application created the hard disk.
+	CreatorVersion     [4]byte   // This field holds the major/minor version of the application that created the hard disk image.
+	CreatorHostOS      [4]byte   // This field stores the type of host operating system this disk image is created on.
+	OriginalSize       [8]byte   // This field stores the size of the hard disk in bytes, from the perspective of the virtual machine, at creation time. Info only
+	CurrentSize        [8]byte   // This field stores the current size of the hard disk, in bytes, from the perspective of the virtual machine.
+	DiskGeometry       [4]byte   // This field stores the cylinder, heads, and sectors per track value for the hard disk.
+	DiskType           [4]byte   // Fixed = 2, Dynamic = 3, Differencing = 4
+	Checksum           [4]byte   // This field holds a basic checksum of the hard disk footer. It is just a one’s complement of the sum of all the bytes in the footer without the checksum field.
+	UniqueId           [16]byte  // This is a 128-bit universally unique identifier (UUID).
+	SavedState         [1]byte   // This field holds a one-byte flag that describes whether the system is in saved state. If the hard disk is in the saved state the value is set to 1
+	Reserved           [427]byte // This field contains zeroes.
+}
+
+func newVHDFixed(size uint64) VHDHeader {
+	header := VHDHeader{}
+	hexToField("00000002", header.Features[:])
+	hexToField("00010000", header.FileFormatVersion[:])
+	hexToField("ffffffffffffffff", header.DataOffset[:])
+	t := uint32(time.Now().Unix() - 946684800)
+	binary.BigEndian.PutUint32(header.Timestamp[:], t)
+	hexToField("656C656D656E74616C", header.CreatorApplication[:]) // Cos
+	hexToField("73757365", header.CreatorHostOS[:])                // SUSE
+	binary.BigEndian.PutUint64(header.OriginalSize[:], size)
+	binary.BigEndian.PutUint64(header.CurrentSize[:], size)
+	// Divide size into 512 to get the total sectors
+	totalSectors := float64(size / 512)
+	geometry := chsCalculation(uint64(totalSectors))
+	binary.BigEndian.PutUint16(header.DiskGeometry[:2], uint16(geometry.cylinders))
+	header.DiskGeometry[2] = uint8(geometry.heads)
+	header.DiskGeometry[3] = uint8(geometry.sectorsPerTrack)
+	hexToField("00000002", header.DiskType[:]) // Fixed 0x00000002
+	hexToField("00000000", header.Checksum[:])
+	uuid := uuidPkg.Generate()
+	copy(header.UniqueId[:], uuid.String())
+	generateChecksum(header)
+	return header
+}
+
+// generateChecksum generates the checksum of the vhd header
+// Lifted from the official VHD Format Spec
+func generateChecksum(header VHDHeader) {
+	buffer := new(bytes.Buffer)
+	_ = binary.Write(buffer, binary.BigEndian, header)
+	checksum := 0
+	bb := buffer.Bytes()
+	for counter := 0; counter < 512; counter++ {
+		checksum += int(bb[counter])
+	}
+	binary.BigEndian.PutUint32(header.Checksum[:], uint32(^checksum))
+}
+
+// hexToField decodes an hex to bytes and copies it to the given header field
+func hexToField(hexs string, field []byte) {
+	h, _ := hex.DecodeString(hexs)
+	copy(field, h)
+}
+
+// chs is a simple struct to represent the cylinders/heads/sectors for a given sector count
+type chs struct {
+	cylinders       uint
+	heads           uint
+	sectorsPerTrack uint
+}
+
+// chsCalculation calculates the cylinders, headers and sectors per track for a given sector count
+// Exactly the same code on the official VHD format spec
+func chsCalculation(sectors uint64) chs {
+	var sectorsPerTrack,
+		heads,
+		cylinderTimesHeads,
+		cylinders float64
+	totalSectors := float64(sectors)
+
+	if totalSectors > 65535*16*255 {
+		totalSectors = 65535 * 16 * 255
+	}
+
+	if totalSectors >= 65535*16*63 {
+		sectorsPerTrack = 255
+		heads = 16
+		cylinderTimesHeads = math.Floor(totalSectors / sectorsPerTrack)
+	} else {
+		sectorsPerTrack = 17
+		cylinderTimesHeads = math.Floor(totalSectors / sectorsPerTrack)
+		heads = math.Floor((cylinderTimesHeads + 1023) / 1024)
+		if heads < 4 {
+			heads = 4
+		}
+		if (cylinderTimesHeads >= (heads * 1024)) || heads > 16 {
+			sectorsPerTrack = 31
+			heads = 16
+			cylinderTimesHeads = math.Floor(totalSectors / sectorsPerTrack)
+		}
+		if cylinderTimesHeads >= (heads * 1024) {
+			sectorsPerTrack = 63
+			heads = 16
+			cylinderTimesHeads = math.Floor(totalSectors / sectorsPerTrack)
+		}
+	}
+
+	cylinders = cylinderTimesHeads / heads
+
+	return chs{
+		cylinders:       uint(cylinders),
+		heads:           uint(heads),
+		sectorsPerTrack: uint(sectorsPerTrack),
+	}
+}
+
+// RawDiskToFixedVhd will write the proper header to a give os.File to convert it from a simple raw disk to a Fixed VHD
+// RawDiskToFixedVhd makes no effort into opening/closing/checking if the file exists
+func RawDiskToFixedVhd(diskFile *os.File) {
+	info, _ := diskFile.Stat()
+	size := uint64(info.Size())
+	header := newVHDFixed(size)
+	_ = binary.Write(diskFile, binary.BigEndian, header)
+}

--- a/pkg/utils/vhd.go
+++ b/pkg/utils/vhd.go
@@ -44,7 +44,7 @@ type VHDHeader struct {
 	DiskGeometry       [4]byte   // This field stores the cylinder, heads, and sectors per track value for the hard disk.
 	DiskType           [4]byte   // Fixed = 2, Dynamic = 3, Differencing = 4
 	Checksum           [4]byte   // This field holds a basic checksum of the hard disk footer. It is just a one’s complement of the sum of all the bytes in the footer without the checksum field.
-	UniqueId           [16]byte  // This is a 128-bit universally unique identifier (UUID).
+	UniqueID           [16]byte  // This is a 128-bit universally unique identifier (UUID).
 	SavedState         [1]byte   // This field holds a one-byte flag that describes whether the system is in saved state. If the hard disk is in the saved state the value is set to 1
 	Reserved           [427]byte // This field contains zeroes.
 }
@@ -69,7 +69,7 @@ func newVHDFixed(size uint64) VHDHeader {
 	hexToField("00000002", header.DiskType[:]) // Fixed 0x00000002
 	hexToField("00000000", header.Checksum[:])
 	uuid := uuidPkg.Generate()
-	copy(header.UniqueId[:], uuid.String())
+	copy(header.UniqueID[:], uuid.String())
 	generateChecksum(header)
 	return header
 }
@@ -145,7 +145,7 @@ func chsCalculation(sectors uint64) chs {
 	}
 }
 
-// RawDiskToFixedVhd will write the proper header to a give os.File to convert it from a simple raw disk to a Fixed VHD
+// RawDiskToFixedVhd will write the proper header to a given os.File to convert it from a simple raw disk to a Fixed VHD
 // RawDiskToFixedVhd makes no effort into opening/closing/checking if the file exists
 func RawDiskToFixedVhd(diskFile *os.File) {
 	info, _ := diskFile.Stat()


### PR DESCRIPTION
 - Small fix for image existing, just refuse to overwrite by default
 - Supports output for GCE and azure images
 - No external tools required, all done in pure golang!
 - Autoclean middle image if generating a gce/azure image
 - Adds new command transform-disk
 - Transform-disk uses the same code as build-disk
 - Transform-disk allows to keep the base raw image
 - Adds some vhd tooling for the build/transform stuff

Signed-off-by: Itxaka <igarcia@suse.com>