### PR TITLE
Add build-iso command defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN go build \
 
 FROM opensuse/leap:$LEAP_VERSION AS elemental
 RUN zypper ref
-RUN zypper in -y xfsprogs parted util-linux-systemd e2fsprogs util-linux udev rsync grub2 dosfstools grub2-x86_64-efi 
+RUN zypper in -y xfsprogs parted util-linux-systemd e2fsprogs util-linux udev rsync grub2 dosfstools grub2-x86_64-efi squashfs mtools xorriso 
 COPY --from=elemental-bin /usr/bin/elemental /usr/bin/elemental
 COPY --from=cosign-bin /usr/bin/cosign /usr/bin/cosign
 # Fix for blkid only using udev on opensuse

--- a/cmd/build-iso_test.go
+++ b/cmd/build-iso_test.go
@@ -44,18 +44,6 @@ var _ = Describe("BuidISO", Label("iso", "cmd"), func() {
 		Expect(buf.String()).To(ContainSubstring("Usage:"))
 		Expect(err.Error()).To(ContainSubstring("no rootfs image source provided"))
 	})
-	It("Errors out if no uefi sources are defined", Label("flags"), func() {
-		_, _, err := executeCommandC(rootCmd, "build-iso", "system/cos")
-		Expect(err).ToNot(BeNil())
-		Expect(buf.String()).To(ContainSubstring("Usage:"))
-		Expect(err.Error()).To(ContainSubstring("no UEFI image sources provided"))
-	})
-	It("Errors out if no iso sources are defined", Label("flags"), func() {
-		_, _, err := executeCommandC(rootCmd, "build-iso", "--iso.uefi", "live/grub2-efi-image", "system/cos")
-		Expect(err).ToNot(BeNil())
-		Expect(buf.String()).To(ContainSubstring("Usage:"))
-		Expect(err.Error()).To(ContainSubstring("no ISO image sources provided"))
-	})
 	It("Errors out if overlay roofs path does not exist", Label("flags"), func() {
 		_, _, err := executeCommandC(
 			rootCmd, "build-iso", "--iso.image", "live/grub2",

--- a/pkg/action/build-iso.go
+++ b/pkg/action/build-iso.go
@@ -58,6 +58,12 @@ func BuildISORun(cfg *v1.BuildConfig) (err error) {
 		return err
 	}
 
+	err = utils.MkdirAll(cfg.Fs, cfg.OutDir, constants.DirPerm)
+	if err != nil {
+		cfg.Logger.Errorf("Failed creating output folder: %s", cfg.OutDir)
+		return err
+	}
+
 	cfg.Logger.Infof("Preparing squashfs root...")
 	err = applySources(cfg.Config, rootDir, cfg.ISO.RootFS...)
 	if err != nil {
@@ -244,6 +250,10 @@ func burnISO(c *v1.BuildConfig, root string) error {
 		outputFile = fmt.Sprintf("%s.iso", c.Name)
 	}
 
+	if c.OutDir != "" {
+		outputFile = filepath.Join(c.OutDir, outputFile)
+	}
+
 	if exists, _ := utils.Exists(c.Fs, outputFile); exists {
 		c.Logger.Warnf("Overwriting already existing %s", outputFile)
 		err := c.Fs.Remove(outputFile)
@@ -298,7 +308,7 @@ func applySource(c v1.Config, target string, src v1.ImageSource) error {
 			return err
 		}
 	} else if src.IsDir() {
-		excludes := []string{"mnt", "proc", "sys", "dev", "tmp", "host", "run"}
+		excludes := []string{"/mnt", "/proc", "/sys", "/dev", "/tmp", "/host", "/run"}
 		err := utils.SyncData(c.Fs, src.Value(), target, excludes...)
 		if err != nil {
 			return err

--- a/pkg/action/build-iso.go
+++ b/pkg/action/build-iso.go
@@ -58,10 +58,12 @@ func BuildISORun(cfg *v1.BuildConfig) (err error) {
 		return err
 	}
 
-	err = utils.MkdirAll(cfg.Fs, cfg.OutDir, constants.DirPerm)
-	if err != nil {
-		cfg.Logger.Errorf("Failed creating output folder: %s", cfg.OutDir)
-		return err
+	if cfg.OutDir != "" {
+		err = utils.MkdirAll(cfg.Fs, cfg.OutDir, constants.DirPerm)
+		if err != nil {
+			cfg.Logger.Errorf("Failed creating output folder: %s", cfg.OutDir)
+			return err
+		}
 	}
 
 	cfg.Logger.Infof("Preparing squashfs root...")

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -166,3 +166,15 @@ func GetDefaultXorrisoBooloaderArgs(root, bootFile, bootCatalog, hybridMBR strin
 	}...)
 	return args
 }
+
+func GetDefaultISOImage() []string {
+	return []string{"live/grub2", "live/grub2-efi-image"}
+}
+
+func GetDefaultISOUEFI() []string {
+	return []string{"live/grub2-efi-image"}
+}
+
+func GetDefaultLuetRepos() []string {
+	return []string{"quay.io/costoolkit/releases-green"}
+}

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -178,6 +178,7 @@ type BuildConfig struct {
 	Date    bool                        `yaml:"date,omitempty" mapstructure:"date"`
 	Name    string                      `yaml:"name,omitempty" mapstructure:"name"`
 	RawDisk map[string]RawDiskArchEntry `yaml:"raw_disk,omitempty" mapstructure:"raw_disk"`
+	OutDir  string                      `yaml:"output,omitempty" mapstructure:"output"`
 	// Generic runtime configuration
 	Config
 }


### PR DESCRIPTION
This commit makes elemental's build-iso command easily operative
on the elemental's docker image.

* Add ISO related tools in Dockerfile
* Add defaults so a manifest.yaml and/or a bunch of flags are not
  needed

Signed-off-by: David Cassany <dcassany@suse.com>