### PR TITLE
Improve build-iso flags

### DIFF
--- a/cmd/build-disk.go
+++ b/cmd/build-disk.go
@@ -83,7 +83,7 @@ func NewBuildDisk(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 			// Set the repo depending on the arch we are building for
 			var repos []v1.Repository
 			for _, u := range cfg.RawDisk[archType].Repositories {
-				repos = append(repos, v1.Repository{URI: u.URI})
+				repos = append(repos, v1.Repository{URI: u.URI, Priority: constants.LuetDefaultRepoPrio})
 			}
 			cfg.Config.Repos = repos
 
@@ -94,13 +94,12 @@ func NewBuildDisk(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 
 			// Set defaults if they are empty
 			if len(cfg.Config.Repos) == 0 {
-				for _, repo := range constants.GetDefaultLuetRepos() {
-					if archType != "x86_64" {
-						repo = fmt.Sprintf("%s-%s", repo, archType)
-					}
-					cfg.Logger.Infof("Repositories are empty, setting default value: %s", repo)
-					cfg.Config.Repos = append(cfg.Config.Repos, v1.Repository{URI: repo})
+				repo := constants.LuetDefaultRepoURI
+				if archType != "x86_64" {
+					repo = fmt.Sprintf("%s-%s", repo, archType)
 				}
+				cfg.Logger.Infof("Repositories are empty, setting default value: %s", repo)
+				cfg.Config.Repos = append(cfg.Config.Repos, v1.Repository{URI: repo, Priority: constants.LuetDefaultRepoPrio})
 
 				cfg.RawDisk[archType].Repositories = cfg.Config.Repos
 			}

--- a/cmd/build-iso_test.go
+++ b/cmd/build-iso_test.go
@@ -46,27 +46,21 @@ var _ = Describe("BuidISO", Label("iso", "cmd"), func() {
 	})
 	It("Errors out if overlay roofs path does not exist", Label("flags"), func() {
 		_, _, err := executeCommandC(
-			rootCmd, "build-iso", "--iso.image", "live/grub2",
-			"--iso.uefi", "live/grub2-efi-image", "system/cos",
-			"--overlay-rootfs", "/nonexistingpath",
+			rootCmd, "build-iso", "system/cos", "--overlay-rootfs", "/nonexistingpath",
 		)
 		Expect(err).ToNot(BeNil())
 		Expect(err.Error()).To(ContainSubstring("Invalid path"))
 	})
 	It("Errors out if overlay uefi path does not exist", Label("flags"), func() {
 		_, _, err := executeCommandC(
-			rootCmd, "build-iso", "--iso.image", "live/grub2",
-			"--iso.uefi", "live/grub2-efi-image", "system/cos",
-			"--overlay-uefi", "/nonexistingpath",
+			rootCmd, "build-iso", "someimage:latest", "--overlay-uefi", "/nonexistingpath",
 		)
 		Expect(err).ToNot(BeNil())
 		Expect(err.Error()).To(ContainSubstring("Invalid path"))
 	})
 	It("Errors out if overlay iso path does not exist", Label("flags"), func() {
 		_, _, err := executeCommandC(
-			rootCmd, "build-iso", "--iso.image", "live/grub2",
-			"--iso.uefi", "live/grub2-efi-image", "system/cos",
-			"--overlay-iso", "/nonexistingpath",
+			rootCmd, "build-iso", "/my/rootfs", "--overlay-iso", "/nonexistingpath",
 		)
 		Expect(err).ToNot(BeNil())
 		Expect(err.Error()).To(ContainSubstring("Invalid path"))

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -81,6 +81,9 @@ const (
 	BeforeResetHook        = "before-reset"
 	LuetCosignPlugin       = "luet-cosign"
 	LuetMtreePlugin        = "luet-mtree"
+	LuetDefaultRepoURI     = "quay.io/costoolkit/releases-green"
+	LuetRepoMaxPrio        = 1
+	LuetDefaultRepoPrio    = 90
 	UpgradeActive          = "active"
 	UpgradeRecovery        = "recovery"
 	ChannelSource          = "system/cos"
@@ -173,10 +176,6 @@ func GetDefaultISOImage() []string {
 
 func GetDefaultISOUEFI() []string {
 	return []string{"live/grub2-efi-image"}
-}
-
-func GetDefaultLuetRepos() []string {
-	return []string{"quay.io/costoolkit/releases-green"}
 }
 
 func GetBuildDiskDefaultPackages() map[string]string {


### PR DESCRIPTION
This commit changes `--iso.label` flag to `--label` and drops
`--iso.image` and `--iso.uefi` flags since this are unlikely to be used
and they can still be set by using a custom manifest.yaml.

Finally it also changes `--repo` flag behavior to append repos on top
of whatever is defined in the manifest or by default. Appended
repositories with `--repo` flag are always having highest priority.

Signed-off-by: David Cassany <dcassany@suse.com>