### PR TITLE
Set default config dir to /etc/elemental

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -88,28 +88,31 @@ func ReadConfigRun(configDir string, mounter mount.Interface) (*v1.RunConfig, er
 		}
 	}
 
-	if exists, _ := utils.Exists(cfg.Fs, configDir); exists {
-		viper.AddConfigPath(configDir)
-		viper.SetConfigType("yaml")
-		viper.SetConfigName("config")
-		// If a config file is found, read it in.
-		err := viper.MergeInConfig()
-		if err != nil {
-			cfg.Logger.Warnf("error merging config files: %s", err)
-		}
-	}
-
-	// Load extra config files on configdir/config.d/ so we can override config values
-	cfgExtra := fmt.Sprintf("%s/config.d/", strings.TrimSuffix(configDir, "/"))
-	if _, err := os.Stat(cfgExtra); err == nil {
-		viper.AddConfigPath(cfgExtra)
-		_ = filepath.WalkDir(cfgExtra, func(path string, d fs.DirEntry, err error) error {
-			if !d.IsDir() {
-				viper.SetConfigName(d.Name())
-				cobra.CheckErr(viper.MergeInConfig())
+	if configDir != "" {
+		if exists, _ := utils.Exists(cfg.Fs, configDir); exists {
+			viper.AddConfigPath(configDir)
+			viper.SetConfigType("yaml")
+			viper.SetConfigName("config")
+			// If a config file is found, read it in.
+			err := viper.MergeInConfig()
+			if err != nil {
+				cfg.Logger.Warnf("error merging config files: %s", err)
 			}
-			return nil
-		})
+		}
+
+		// Load extra config files on configdir/config.d/ so we can override config values
+		cfgExtra := fmt.Sprintf("%s/config.d/", strings.TrimSuffix(configDir, "/"))
+		if _, err := os.Stat(cfgExtra); err == nil {
+			viper.AddConfigPath(cfgExtra)
+			_ = filepath.WalkDir(cfgExtra, func(path string, d fs.DirEntry, err error) error {
+				if !d.IsDir() {
+					viper.SetConfigType("yaml")
+					viper.SetConfigName(d.Name())
+					cobra.CheckErr(viper.MergeInConfig())
+				}
+				return nil
+			})
+		}
 	}
 
 	viperReadEnv()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,7 +29,7 @@ func NewRootCmd() *cobra.Command {
 		Short: "elemental",
 	}
 	cmd.PersistentFlags().Bool("debug", false, "enable debug output")
-	cmd.PersistentFlags().String("config-dir", "", "set config dir (default is empty)")
+	cmd.PersistentFlags().String("config-dir", "/etc/elemental", "set config dir (default is empty)")
 	cmd.PersistentFlags().String("logfile", "", "set logfile")
 	cmd.PersistentFlags().Bool("quiet", false, "do not output to stdout")
 	_ = viper.BindPFlag("debug", cmd.PersistentFlags().Lookup("debug"))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,7 +29,7 @@ func NewRootCmd() *cobra.Command {
 		Short: "elemental",
 	}
 	cmd.PersistentFlags().Bool("debug", false, "enable debug output")
-	cmd.PersistentFlags().String("config-dir", "/etc/elemental", "set config dir (default is empty)")
+	cmd.PersistentFlags().String("config-dir", "/etc/elemental", "set config dir (default is /etc/elemental)")
 	cmd.PersistentFlags().String("logfile", "", "set logfile")
 	cmd.PersistentFlags().Bool("quiet", false, "do not output to stdout")
 	_ = viper.BindPFlag("debug", cmd.PersistentFlags().Lookup("debug"))


### PR DESCRIPTION
By default we used to set "" as config-dir, this in turn made it scan yaml files from the "/". By setting also a default, we allow derivatives to store yaml config files directly in `/etc/elemental/conf.d/*`

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>