### PR TITLE
Add --local option to install, build-iso, upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.vscode/
 bin/
 coverage.txt

--- a/cmd/build-iso.go
+++ b/cmd/build-iso.go
@@ -147,6 +147,7 @@ func NewBuildISO(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 	addArchFlags(c)
 	addCosignFlags(c)
 	addSquashFsCompressionFlags(c)
+	addLocalImageFlag(c)
 	return c
 }
 

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -49,6 +49,11 @@ func addSharedInstallUpgradeFlags(cmd *cobra.Command) {
 	addPowerFlags(cmd)
 }
 
+// addLocalImageFlag add local image flag shared between install, pull-image, upgrade
+func addLocalImageFlag(cmd *cobra.Command) {
+	cmd.Flags().Bool("local", false, "Use an image from local cache")
+}
+
 func validateCosignFlags(log v1.Logger) error {
 	if viper.GetString("cosign-key") != "" && !viper.GetBool("cosign") {
 		return errors.New("'cosign-key' requires 'cosign' option to be enabled")

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -95,6 +95,7 @@ func NewInstallCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 	c.Flags().BoolP("force", "", false, "Force install")
 	c.Flags().BoolP("eject-cd", "", false, "Try to eject the cd on reboot, only valid if booting from iso")
 	addSharedInstallUpgradeFlags(c)
+	addLocalImageFlag(c)
 	return c
 }
 

--- a/cmd/pull-image.go
+++ b/cmd/pull-image.go
@@ -95,8 +95,8 @@ func NewPullImageCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 	c.Flags().String("auth-identity-token", "", "Authentication identity token")
 	c.Flags().String("auth-registry-token", "", "Authentication registry token")
 	c.Flags().Bool("verify", false, "Verify signed images to notary before to pull")
-	c.Flags().Bool("local", false, "Use local image")
 	c.Flags().StringArray("plugin", []string{}, "A list of runtime plugins to load. Can be repeated to add more than one plugin")
+	addLocalImageFlag(c)
 	return c
 }
 

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -86,6 +86,7 @@ func NewUpgradeCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 	c.Flags().Bool("recovery", false, "Upgrade the recovery")
 	addSharedInstallUpgradeFlags(c)
 	addSquashFsCompressionFlags(c)
+	addLocalImageFlag(c)
 	return c
 }
 

--- a/docs/elemental_build-iso.md
+++ b/docs/elemental_build-iso.md
@@ -14,6 +14,7 @@ elemental build-iso IMAGE [flags]
       --cosign-key string                Sets the URL of the public key to be used by cosign validation
       --date                             Adds a date suffix into the generated ISO file
   -h, --help                             help for build-iso
+      --local                            Use an image from local cache
       --label string                     Label of the ISO volume
   -n, --name string                      Basename of the generated ISO file
   -o, --output string                    Output directory (defaults to current directory)

--- a/docs/elemental_install.md
+++ b/docs/elemental_install.md
@@ -14,6 +14,7 @@ elemental install DEVICE [flags]
       --cosign-key string         Sets the URL of the public key to be used by cosign validation
       --directory string          Use directory as source to install from
   -d, --docker-image string       Install a specified container image
+      --local                     Use an image from local cache
       --eject-cd                  Try to eject the cd on reboot, only valid if booting from iso
       --force                     Force install
       --force-efi                 Forces an EFI installation

--- a/docs/elemental_pull-image.md
+++ b/docs/elemental_pull-image.md
@@ -16,7 +16,7 @@ elemental pull-image IMAGE DESTINATION [flags]
       --auth-type string             Auth type
       --auth-username string         Username to authenticate to registry/notary
   -h, --help                         help for pull-image
-      --local                        Use local image
+      --local                        Use an image from local cache
       --plugin stringArray           A list of runtime plugins to load. Can be repeated to add more than one plugin
       --verify                       Verify signed images to notary before to pull
 ```

--- a/docs/elemental_upgrade.md
+++ b/docs/elemental_upgrade.md
@@ -13,6 +13,7 @@ elemental upgrade [flags]
       --cosign-key string                Sets the URL of the public key to be used by cosign validation
       --directory string                 Use directory as source to install from
   -d, --docker-image string              Install a specified container image
+      --local                            Use an image from local cache
   -h, --help                             help for upgrade
       --no-verify                        Disable mtree checksum verification (requires images manifests generated with mtree separately)
       --poweroff                         Shutdown the system after install

--- a/pkg/action/build-iso.go
+++ b/pkg/action/build-iso.go
@@ -311,7 +311,7 @@ func applySource(c v1.Config, target string, src v1.ImageSource) error {
 				return err
 			}
 		}
-		err := c.Luet.Unpack(target, src.Value(), false)
+		err := c.Luet.Unpack(target, src.Value(), c.LocalImage)
 		if err != nil {
 			return err
 		}

--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -334,7 +334,7 @@ func (c *Elemental) CopyImage(img *v1.Image) error { // nolint:gocyclo
 				return err
 			}
 		}
-		err = c.config.Luet.Unpack(img.MountPoint, img.Source.Value(), false)
+		err = c.config.Luet.Unpack(img.MountPoint, img.Source.Value(), c.config.LocalImage)
 		if err != nil {
 			return err
 		}

--- a/pkg/luet/luet_test.go
+++ b/pkg/luet/luet_test.go
@@ -69,6 +69,11 @@ var _ = Describe("Types", Label("luet", "types"), func() {
 			image := "quay.io/costoolkit/releases-green:cloud-config-system-0.11-1"
 			Expect(l.Unpack(target, image, false)).NotTo(BeNil())
 		})
+		It("Check that luet can unpack the remote image", Label("unpack", "root"), func() {
+			image := "registry.opensuse.org/opensuse/redis"
+			// Check that luet can unpack the remote image
+			Expect(l.Unpack(target, image, false)).To(BeNil())
+		})
 		It("Check that luet can unpack the local image", Label("unpack", "root"), func() {
 			image := "docker.io/library/alpine"
 			ctx := context.Background()

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -42,6 +42,7 @@ type Config struct {
 	Client                    HTTPClient
 	Cosign                    bool         `yaml:"cosign,omitempty" mapstructure:"cosign"`
 	CosignPubKey              string       `yaml:"cosign-key,omitempty" mapstructure:"cosign-key"`
+	LocalImage                bool         `yaml:"local,omitempty" mapstructure:"local"`
 	Repos                     []Repository `yaml:"repositories,omitempty" mapstructure:"repositories"`
 	Arch                      string       `yaml:"arch,omitempty" mapstructure:"arch"`
 	SquashFsCompressionConfig []string     `yaml:"squash-compression,omitempty" mapstructure:"SquashFsCompressionConfig"`
@@ -78,6 +79,7 @@ type RunConfig struct {
 	ChannelUpgrades bool   `yaml:"CHANNEL_UPGRADES,omitempty" mapstructure:"CHANNEL_UPGRADES"`
 	UpgradeImage    string `yaml:"UPGRADE_IMAGE,omitempty" mapstructure:"UPGRADE_IMAGE"`
 	RecoveryImage   string `yaml:"RECOVERY_IMAGE,omitempty" mapstructure:"RECOVERY_IMAGE"`
+	LocalImage      bool   `yaml:"local,omitempty" mapstructure:"local"`
 	RecoveryUpgrade bool   // configured only via flag, no need to map it to any config
 	ImgSize         uint   `yaml:"DEFAULT_IMAGE_SIZE,omitempty" mapstructure:"DEFAULT_IMAGE_SIZE"`
 	Directory       string `yaml:"directory,omitempty" mapstructure:"directory"`


### PR DESCRIPTION
Add --local option to pull-image, install, build-iso
and upgrade subcommands which uses Unpack() function.

To use image from local cache set option --local

Fixes https://github.com/rancher-sandbox/cOS-toolkit/issues/1279

Signed-off-by: Michal Jura <mjura@suse.com>