### PR TITLE
Protect against wrong squshfs options

### DIFF
--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -225,7 +225,12 @@ func CreateSquashFS(runner v1.Runner, logger v1.Logger, source string, destinati
 	// create args
 	args := []string{source, destination}
 	// append options passed to args in order to have the correct order
-	args = append(args, options...)
+	// protect against options passed together in the same string , i.e. "-x add" instead of "-x", "add"
+	var optionsExpanded []string
+	for _, op := range options {
+		optionsExpanded = append(optionsExpanded, strings.Split(op, " ")...)
+	}
+	args = append(args, optionsExpanded...)
 	out, err := runner.Run("mksquashfs", args...)
 	if err != nil {
 		logger.Debugf("Error running squashfs creation, stdout: %s", out)


### PR DESCRIPTION
Im pretty sure someone somewhere is gonna pass a `-x "-flag value` to
the options, which will result into a breakage of the mksquashfs command
just at the end of the build, after downloading everything and so on, so
try to be a bit smart and expand any squashfs options that have a space
on them into a slice so we can properly use them as args.

Should not affect anything

Signed-off-by: Itxaka <igarcia@suse.com>