### PR TITLE
Include other configs on config load

### DIFF
--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -182,7 +182,7 @@ type BuildConfig struct {
 	RawDisk map[string]*RawDiskArchEntry `yaml:"raw_disk,omitempty" mapstructure:"raw_disk"`
 	OutDir  string                       `yaml:"output,omitempty" mapstructure:"output"`
 	// Generic runtime configuration
-	Config
+	Config `yaml:",inline" mapstructure:",squash"`
 }
 
 // RawDiskArchEntry represents an arch entry in raw_disk


### PR DESCRIPTION
Without it the embedded struct is ignored by the serialization libraries.

This fixes loading repos from the manifest file for example

Done by @davidcassany 

Signed-off-by: Itxaka <igarcia@suse.com>