### PR TITLE
Switch option for using mtree plugin

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -54,7 +54,7 @@ func addResetFlags(cmd *cobra.Command) {
 	_ = cmd.Flags().MarkDeprecated("docker-image", "'docker-image' is deprecated please use 'system' instead")
 
 	cmd.Flags().String("system.uri", "", "Sets the system image source and its type (e.g. 'docker:registry.org/image:tag')")
-	cmd.Flags().Bool("no-verify", false, "Disable mtree checksum verification (requires images manifests generated with mtree separately)")
+	cmd.Flags().Bool("verify", false, "Enable mtree checksum verification (requires images manifests generated with mtree separately)")
 	cmd.Flags().Bool("strict", false, "Enable strict check of hooks (They need to exit with 0)")
 
 	addCosignFlags(cmd)

--- a/docs/elemental_install.md
+++ b/docs/elemental_install.md
@@ -19,7 +19,7 @@ elemental install DEVICE [flags]
   -i, --iso string                       Performs an installation from the ISO url
       --local                            Use an image from local cache
       --no-format                        Don’t format disks. It is implied that COS_STATE, COS_RECOVERY, COS_PERSISTENT, COS_OEM are already existing
-      --no-verify                        Disable mtree checksum verification (requires images manifests generated with mtree separately)
+      --verify                           Enable mtree checksum verification (requires images manifests generated with mtree separately)
       --part-table string                Partition table type to use (default "gpt")
       --poweroff                         Shutdown the system after install
       --reboot                           Reboot the system after install

--- a/docs/elemental_reset.md
+++ b/docs/elemental_reset.md
@@ -12,7 +12,7 @@ elemental reset [flags]
       --cosign              Enable cosign verification (requires images with signatures)
       --cosign-key string   Sets the URL of the public key to be used by cosign validation
   -h, --help                help for reset
-      --no-verify           Disable mtree checksum verification (requires images manifests generated with mtree separately)
+      --verify              Enable mtree checksum verification (requires images manifests generated with mtree separately)
       --poweroff            Shutdown the system after install
       --reboot              Reboot the system after install
       --reset-persistent    Clear persistent partitions

--- a/docs/elemental_upgrade.md
+++ b/docs/elemental_upgrade.md
@@ -13,7 +13,7 @@ elemental upgrade [flags]
       --cosign-key string                Sets the URL of the public key to be used by cosign validation
   -h, --help                             help for upgrade
       --local                            Use an image from local cache
-      --no-verify                        Disable mtree checksum verification (requires images manifests generated with mtree separately)
+      --verify                           Enable mtree checksum verification (requires images manifests generated with mtree separately)
       --poweroff                         Shutdown the system after install
       --reboot                           Reboot the system after install
       --recovery                         Upgrade the recovery

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -163,7 +163,7 @@ func NewRunConfig(opts ...GenericOptions) *v1.RunConfig {
 // mapstructure unmarshal already took place.
 func CoOccurrenceConfig(cfg *v1.Config) {
 	// Set Luet plugins, we only use the mtree plugin for now
-	if !cfg.NoVerify {
+	if cfg.Verify {
 		cfg.Luet.SetPlugins(constants.LuetMtreePlugin)
 	}
 }

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -46,7 +46,7 @@ type Config struct {
 	Luet                      LuetInterface
 	Client                    HTTPClient
 	Cosign                    bool         `yaml:"cosign,omitempty" mapstructure:"cosign"`
-	NoVerify                  bool         `yaml:"no-verify,omitempty" mapstructure:"no-verify"`
+	Verify                    bool         `yaml:"verify,omitempty" mapstructure:"verify"`
 	CosignPubKey              string       `yaml:"cosign-key,omitempty" mapstructure:"cosign-key"`
 	LocalImage                bool         `yaml:"local,omitempty" mapstructure:"local"`
 	Repos                     []Repository `yaml:"repositories,omitempty" mapstructure:"repositories"`
@@ -58,7 +58,7 @@ type Config struct {
 // if unsolvable inconsistencies are found
 func (c *Config) Sanitize() error {
 	// Set Luet plugins, we only use the mtree plugin for now
-	if !c.NoVerify {
+	if c.Verify {
 		c.Luet.SetPlugins(constants.LuetMtreePlugin)
 	}
 	return nil

--- a/pkg/types/v1/config_test.go
+++ b/pkg/types/v1/config_test.go
@@ -180,6 +180,7 @@ var _ = Describe("Types", Label("types", "config"), func() {
 	Describe("RunConfig", func() {
 		It("runs sanitize method", func() {
 			cfg := config.NewRunConfig(config.WithMounter(v1mocks.NewErrorMounter()))
+			cfg.Config.Verify = true
 
 			// Sets the luet mtree pluing
 			err := cfg.Sanitize()
@@ -190,6 +191,7 @@ var _ = Describe("Types", Label("types", "config"), func() {
 	Describe("BuildConfig", func() {
 		It("runs sanitize method", func() {
 			cfg := config.NewBuildConfig(config.WithMounter(v1mocks.NewErrorMounter()))
+			cfg.Config.Verify = true
 
 			// Sets the luet mtree pluing
 			err := cfg.Sanitize()


### PR DESCRIPTION
We would like to disable mtree plugin by default,
which seems to be not used for now.

Fixes #183

Signed-off-by: Michal Jura <mjura@suse.com>