### PR TITLE
Use /etc/os-release on install and reset

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -58,12 +58,10 @@ install:
   cloud-init: "https://some.cloud-init.org/my-config-file"
 
   # grub menu entry, this is the string that will be displayed
-  grub-default-entry: cOS
+  grub-entry-name: cOS
 
   # tty console to add into the kernel parameters
   tty: ttyS0
-
-
 
 # configuration for the 'reset' command
 reset:
@@ -82,12 +80,10 @@ reset:
   passive.label: COS_PASSIVE
 
   # grub menu entry, this is the string that will be displayed
-  grub-default-entry: cOS
+  grub-entry-name: cOS
 
   # tty console to add into the kernel parameters
   tty: ttyS0
-
-
 
 # configuration used for the 'ugrade' command
 upgrade:
@@ -106,9 +102,8 @@ upgrade:
     fs: squashfs
     uri: channel:recovery/cos
 
-  # filesystem label of the passive backup image
-  passive.label: COS_PASSIVE
-
+  # grub menu entry, this is the string that will be displayed
+  grub-entry-name: cOS
 
 # use cosing to validate images from container registries
 cosign: true
@@ -124,6 +119,13 @@ strict: false
 # Additional paths for look for cloud-init files
 cloud-init-paths:
 - "/some/path"
+
+# Respositories defined for channel sources
+repositories:
+- name: "some_repo"
+  uri: "registry.org/repo"
+  type: "docker"
+  priority: 10
   
 # reboot/power off when done
 reboot: false

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -130,6 +130,16 @@ func (i InstallAction) Run() (err error) {
 		return err
 	}
 
+	// Installation rebrand (only grub for now)
+	err = e.SetDefaultGrubEntry(
+		i.spec.Partitions.State.MountPoint,
+		i.spec.Active.MountPoint,
+		i.spec.GrubDefEntry,
+	)
+	if err != nil {
+		return err
+	}
+
 	// Unmount active image
 	err = e.UnmountImage(&i.spec.Active)
 	if err != nil {
@@ -147,12 +157,6 @@ func (i InstallAction) Run() (err error) {
 	}
 
 	err = i.installHook(cnst.AfterInstallHook, false)
-	if err != nil {
-		return err
-	}
-
-	// Installation rebrand (only grub for now)
-	err = e.SetDefaultGrubEntry(i.spec.Partitions.State.MountPoint, i.spec.GrubDefEntry)
 	if err != nil {
 		return err
 	}

--- a/pkg/action/reset.go
+++ b/pkg/action/reset.go
@@ -126,6 +126,16 @@ func (r ResetAction) Run() (err error) {
 		return err
 	}
 
+	// installation rebrand (only grub for now)
+	err = e.SetDefaultGrubEntry(
+		r.spec.Partitions.State.MountPoint,
+		r.spec.Active.MountPoint,
+		r.spec.GrubDefEntry,
+	)
+	if err != nil {
+		return err
+	}
+
 	// Unmount active image
 	err = e.UnmountImage(&r.spec.Active)
 	if err != nil {
@@ -139,12 +149,6 @@ func (r ResetAction) Run() (err error) {
 	}
 
 	err = r.resetHook(cnst.AfterResetHook, false)
-	if err != nil {
-		return err
-	}
-
-	// installation rebrand (only grub for now)
-
 	if err != nil {
 		return err
 	}

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -156,12 +156,8 @@ func (u *UpgradeAction) Run() (err error) {
 	// Only apply rebrand stage for system upgrades
 	if !u.spec.RecoveryUpgrade {
 		u.Info("rebranding")
-		osRelease, err := utils.LoadEnvFile(u.config.Config.Fs, filepath.Join(upgradeImg.MountPoint, "etc", "os-release"))
-		if err != nil {
-			u.config.Logger.Warnf("Could not load os-release file: %v", err)
-		}
 
-		err = e.SetDefaultGrubEntry(mountPart.MountPoint, osRelease["GRUB_ENTRY_NAME"])
+		err = e.SetDefaultGrubEntry(mountPart.MountPoint, upgradeImg.MountPoint, u.spec.GrubDefEntry)
 		if err != nil {
 			u.Error("failed setting default entry")
 			return err

--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -514,7 +514,7 @@ func (e Elemental) SetDefaultGrubEntry(partMountPoint string, imgMountPoint stri
 			e.config.Logger.Warnf("Could not load os-release file: %v", err)
 			return nil
 		}
-		defaultEntry, _ = osRelease["GRUB_ENTRY_NAME"]
+		defaultEntry = osRelease["GRUB_ENTRY_NAME"]
 		if defaultEntry == "" {
 			e.config.Logger.Debug("unset grub default entry")
 			return nil

--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -507,14 +507,22 @@ func (e Elemental) UpdateSourcesFormDownloadedISO(workDir string, activeImg *v1.
 
 // Sets the default_meny_entry value in RunConfig.GrubOEMEnv file at in
 // State partition mountpoint.
-func (e Elemental) SetDefaultGrubEntry(mountPoint string, defaultEntry string) error {
+func (e Elemental) SetDefaultGrubEntry(partMountPoint string, imgMountPoint string, defaultEntry string) error {
 	if defaultEntry == "" {
-		e.config.Logger.Debug("unset grub default entry")
-		return nil
+		osRelease, err := utils.LoadEnvFile(e.config.Fs, filepath.Join(imgMountPoint, "etc", "os-release"))
+		if err != nil {
+			e.config.Logger.Warnf("Could not load os-release file: %v", err)
+			return nil
+		}
+		defaultEntry, _ = osRelease["GRUB_ENTRY_NAME"]
+		if defaultEntry == "" {
+			e.config.Logger.Debug("unset grub default entry")
+			return nil
+		}
 	}
 	grub := utils.NewGrub(e.config)
 	return grub.SetPersistentVariables(
-		filepath.Join(mountPoint, cnst.GrubOEMEnv),
+		filepath.Join(partMountPoint, cnst.GrubOEMEnv),
 		map[string]string{"default_menu_entry": defaultEntry},
 	)
 }

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -92,7 +92,7 @@ type InstallSpec struct {
 	Force        bool                `yaml:"force,omitempty" mapstructure:"force"`
 	CloudInit    string              `yaml:"cloud-init,omitempty" mapstructure:"cloud-init"`
 	Iso          string              `yaml:"iso,omitempty" mapstructure:"iso"`
-	GrubDefEntry string              `yaml:"grub-default-entry,omitempty" mapstructure:"grub-default-entry"`
+	GrubDefEntry string              `yaml:"grub-entry-name,omitempty" mapstructure:"grub-default-entry"`
 	Tty          string              `yaml:"tty,omitempty" mapstructure:"tty"`
 	Active       Image               `yaml:"system,omitempty" mapstructure:"system"`
 	Recovery     Image               `yaml:"recovery-system,omitempty" mapstructure:"recovery-system"`
@@ -115,7 +115,7 @@ func (i *InstallSpec) Sanitize() error {
 // ResetSpec struct represents all the reset action details
 type ResetSpec struct {
 	FormatPersistent bool   `yaml:"reset-persistent,omitempty" mapstructure:"reset-persistent"`
-	GrubDefEntry     string `yaml:"grub-default-entry,omitempty" mapstructure:"grub-default-entry"`
+	GrubDefEntry     string `yaml:"grub-entry-name,omitempty" mapstructure:"grub-default-entry"`
 	Tty              string `yaml:"tty,omitempty" mapstructure:"tty"`
 	Active           Image  `yaml:"system,omitempty" mapstructure:"system"`
 	Passive          Image
@@ -141,7 +141,7 @@ type UpgradeSpec struct {
 	RecoveryUpgrade bool   `yaml:"recovery,omitempty" mapstructure:"recovery"`
 	Active          Image  `yaml:"system,omitempty" mapstructure:"system"`
 	Recovery        Image  `yaml:"recovery-system,omitempty" mapstructure:"recovery-system"`
-	GrubDefEntry    string `yaml:"grub-default-entry,omitempty" mapstructure:"grub-default-entry"`
+	GrubDefEntry    string `yaml:"grub-entry-name,omitempty" mapstructure:"grub-default-entry"`
 	Passive         Image
 	Partitions      ElementalPartitions
 }

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -138,9 +138,10 @@ func (r *ResetSpec) Sanitize() error {
 }
 
 type UpgradeSpec struct {
-	RecoveryUpgrade bool  `yaml:"recovery,omitempty" mapstructure:"recovery"`
-	Active          Image `yaml:"system,omitempty" mapstructure:"system"`
-	Recovery        Image `yaml:"recovery-system,omitempty" mapstructure:"recovery-system"`
+	RecoveryUpgrade bool   `yaml:"recovery,omitempty" mapstructure:"recovery"`
+	Active          Image  `yaml:"system,omitempty" mapstructure:"system"`
+	Recovery        Image  `yaml:"recovery-system,omitempty" mapstructure:"recovery-system"`
+	GrubDefEntry    string `yaml:"grub-default-entry,omitempty" mapstructure:"grub-default-entry"`
 	Passive         Image
 	Partitions      ElementalPartitions
 }


### PR DESCRIPTION
This commit makes `install` and `reset` commands to read the `/etc/os-release` file of the installed image to load the `GRUB_ENTRY_NAME` variable, if set, it is used as the default grub menu entry. Note this value can also be configured within the `config.yaml` file. The configuration file has higher priority.

In addition this commit also also adds the `grub-entry-name` configuration option on upgrade command, so `install`, `reset` and `upgrade` share the same behavior in order to set the grub menu entry.

Solves the regression commented in https://github.com/rancher-sandbox/cOS-toolkit/pull/1307#discussion_r875851741

Signed-off-by: David Cassany <dcassany@suse.com>