### PR TITLE
Deactivate unmounted lvm volumes before partitioning

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -82,6 +82,11 @@ func (i InstallAction) Run() (err error) {
 			return fmt.Errorf("use `force` flag to run an installation over the current running deployment")
 		}
 	} else {
+		// Deactivate any active volume on target
+		err = e.DeactivateDevices()
+		if err != nil {
+			return err
+		}
 		// Partition device
 		err = e.PartitionAndFormatDevice(i.spec)
 		if err != nil {

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -315,6 +315,13 @@ var _ = Describe("Install action tests", func() {
 			Expect(installer.Run()).NotTo(BeNil())
 		})
 
+		It("Fails on blkdeactivate errors", Label("disk", "partitions"), func() {
+			spec.Target = device
+			cmdFail = "blkdeactivate"
+			Expect(installer.Run()).NotTo(BeNil())
+			Expect(runner.MatchMilestones([][]string{{"parted"}}))
+		})
+
 		It("Fails on parted errors", Label("disk", "partitions"), func() {
 			spec.Target = device
 			cmdFail = "parted"

--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -544,3 +544,14 @@ func (e Elemental) FindKernelInitrd(rootDir string) (kernel string, initrd strin
 	}
 	return kernel, initrd, nil
 }
+
+// DeactivateDevice deactivates unmounted the block devices present within the system.
+// Useful to deactivate LVM volumes, if any, related to the target device.
+func (e Elemental) DeactivateDevices() error {
+	out, err := e.config.Runner.Run(
+		"blkdeactivate", "--lvmoptions", "retry,wholevg",
+		"--dmoptions", "force,retry", "--errors",
+	)
+	e.config.Logger.Debugf("blkdeactivate command output: %s", string(out))
+	return err
+}

--- a/pkg/elemental/elemental_test.go
+++ b/pkg/elemental/elemental_test.go
@@ -781,6 +781,17 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 			Expect(err).Should(HaveOccurred())
 		})
 	})
+	Describe("DeactivateDevices", Label("blkdeactivate"), func() {
+		It("calls blkdeactivat", func() {
+			el := elemental.NewElemental(config)
+			err := el.DeactivateDevices()
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(runner.CmdsMatch([][]string{{
+				"blkdeactivate", "--lvmoptions", "retry,wholevg",
+				"--dmoptions", "force,retry", "--errors",
+			}})).To(BeNil())
+		})
+	})
 })
 
 // PathInMountPoints will check if the given path is in the mountPoints list


### PR DESCRIPTION
Bug reported in https://github.com/harvester/harvester/issues/2230
Fixes #220 

Signed-off-by: David Cassany <dcassany@suse.com>