### PR TITLE
Use a channel to close rsync monitoring goroutine

### DIFF
--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -167,27 +167,25 @@ func SyncData(log v1.Logger, fs v1.FS, source string, target string, excludes ..
 	)
 
 	quit := make(chan bool)
-	if v1.IsDebugLevel(log) {
-		go func() {
-			for {
-				select {
-				case <-quit:
-					return
-				case <-time.After(5 * time.Second):
-					state := task.State()
-					log.Debugf(
-						"progress rsync %s to %s: %.2f / rem. %d / tot. %d / sp. %s",
-						source,
-						target,
-						state.Progress,
-						state.Remain,
-						state.Total,
-						state.Speed,
-					)
-				}
+	go func() {
+		for {
+			select {
+			case <-quit:
+				return
+			case <-time.After(5 * time.Second):
+				state := task.State()
+				log.Debugf(
+					"progress rsync %s to %s: %.2f / rem. %d / tot. %d / sp. %s",
+					source,
+					target,
+					state.Progress,
+					state.Remain,
+					state.Total,
+					state.Speed,
+				)
 			}
-		}()
-	}
+		}
+	}()
 
 	err := task.Run()
 	quit <- true


### PR DESCRIPTION
This commit just makes use of a channel to end up the grsync monitoring goroutine. The `Remain` field of the state turned not to be completely reliable to check rsync was done or not.

Signed-off-by: David Cassany <dcassany@suse.com>