### PR TITLE
build-iso: Improve validation for rootfs source image

### DIFF
--- a/cmd/build-iso_test.go
+++ b/cmd/build-iso_test.go
@@ -45,7 +45,7 @@ var _ = Describe("BuidISO", Label("iso", "cmd"), func() {
 	It("Errors out if no rootfs sources are defined", Label("flags"), func() {
 		_, _, err := executeCommandC(rootCmd, "build-iso")
 		Expect(err).ToNot(BeNil())
-		Expect(err.Error()).To(ContainSubstring("no rootfs image source provided"))
+		Expect(err.Error()).To(ContainSubstring("rootfs source image for building ISO was not provided"))
 	})
 	It("Errors out if overlay roofs path does not exist", Label("flags"), func() {
 		_, _, err := executeCommandC(

--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -154,7 +154,7 @@ var _ = Describe("Config", Label("config"), func() {
 				Expect(iso.HybridMBR).To(Equal(constants.IsoHybridMBR))
 
 				// From config file
-				Expect(iso.Image[0]).To(Equal("recovery/cos-img"))
+				Expect(iso.Image[0].Value()).To(Equal("recovery/cos-img"))
 				Expect(iso.Label).To(Equal("LIVE_LABEL"))
 			})
 		})

--- a/docs/elemental_build-iso.md
+++ b/docs/elemental_build-iso.md
@@ -3,7 +3,11 @@
 builds bootable installation media ISOs
 
 ```
-elemental build-iso IMAGE [flags]
+elemental build-iso SOURCE [flags]
+
+SOURCE - should be provided as uri in following format <sourceType>:<sourceName>
+    * <sourceType> - might be ["dir", "file", "oci", "docker", "channel"], as default is "docker"
+    * <sourceName> - is path to file or directory, image name with tag version or channel name
 ```
 
 ### Options

--- a/pkg/action/build-disk.go
+++ b/pkg/action/build-disk.go
@@ -91,9 +91,13 @@ func BuildDiskRun(cfg *v1.BuildConfig, spec *v1.RawDisk, imgType string, oemLabe
 		if err != nil {
 			return err
 		}
+		imgSource, err := v1.NewSrcFromURI(pkg.Name)
+		if err != nil {
+			return err
+		}
 		err = e.DumpSource(
 			filepath.Join(baseDir, pkg.Target),
-			utils.NewSrcGuessingType(&cfg.Config, pkg.Name),
+			imgSource,
 		)
 		if err != nil {
 			cfg.Logger.Error(err)

--- a/pkg/action/build-iso.go
+++ b/pkg/action/build-iso.go
@@ -237,10 +237,9 @@ func (b BuildISOAction) burnISO(root string) error {
 	return nil
 }
 
-func (b BuildISOAction) applySources(target string, sources ...string) error {
-	var err error
+func (b BuildISOAction) applySources(target string, sources ...*v1.ImageSource) error {
 	for _, src := range sources {
-		err = b.e.DumpSource(target, utils.NewSrcGuessingType(&b.cfg.Config, src))
+		err := b.e.DumpSource(target, src)
 		if err != nil {
 			return err
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -448,10 +448,24 @@ func NewRawDisk(cfg v1.Config) *v1.RawDisk {
 }
 
 func NewISO() *v1.LiveISO {
+	var uefiSrc, imageSrc []*v1.ImageSource
+
+	defaultUEFI := constants.GetDefaultISOUEFI()
+	for _, imgSrc := range defaultUEFI {
+		src, _ := v1.NewSrcFromURI(imgSrc)
+		uefiSrc = append(uefiSrc, src)
+	}
+
+	defaultImage := constants.GetDefaultISOImage()
+	for _, imgSrc := range defaultImage {
+		src, _ := v1.NewSrcFromURI(imgSrc)
+		imageSrc = append(imageSrc, src)
+	}
+
 	return &v1.LiveISO{
 		Label:       constants.ISOLabel,
-		UEFI:        constants.GetDefaultISOUEFI(),
-		Image:       constants.GetDefaultISOImage(),
+		UEFI:        uefiSrc,
+		Image:       imageSrc,
 		HybridMBR:   constants.IsoHybridMBR,
 		BootFile:    constants.IsoBootFile,
 		BootCatalog: constants.IsoBootCatalog,

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -18,6 +18,7 @@ package config_test
 
 import (
 	"path/filepath"
+	"strings"
 
 	"github.com/jaypipes/ghw/pkg/block"
 	. "github.com/onsi/ginkgo/v2"
@@ -395,7 +396,22 @@ var _ = Describe("Types", Label("types", "config"), func() {
 			It("initiates a new LiveISO", func() {
 				iso := config.NewISO()
 				Expect(iso.Label).To(Equal(constants.ISOLabel))
-				Expect(iso.Image).To(Equal(constants.GetDefaultISOImage()))
+				for i, d := range constants.GetDefaultISOImage() {
+					src := strings.Split(d, ":")
+					switch src[0] {
+					case "dir":
+						Expect(iso.Image[i].IsDir()).Should(BeTrue())
+					case "file":
+						Expect(iso.Image[i].IsFile()).Should(BeTrue())
+					case "docker", "oci":
+						Expect(iso.Image[i].IsDocker()).Should(BeTrue())
+					case "channel":
+						Expect(iso.Image[i].IsChannel()).Should(BeTrue())
+					default:
+						Expect(iso.Image[i].IsEmpty()).Should(BeTrue())
+					}
+					Expect(iso.Image[i].Value()).To(Equal(src[1]))
+				}
 			})
 		})
 		Describe("RawDisk", Label("disk"), func() {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -180,19 +180,24 @@ func GetDefaultXorrisoBooloaderArgs(root, bootFile, bootCatalog, hybridMBR strin
 }
 
 func GetDefaultISOImage() []string {
-	return []string{"live/grub2", "live/grub2-efi-image"}
+	return []string{
+		"channel:live/grub2",
+		"channel:live/grub2-efi-image",
+	}
 }
 
 func GetDefaultISOUEFI() []string {
-	return []string{"live/grub2-efi-image"}
+	return []string{
+		"channel:live/grub2-efi-image",
+	}
 }
 
 func GetBuildDiskDefaultPackages() map[string]string {
 	return map[string]string{
-		"system/grub2-efi-image": "efi",
-		"system/grub2-config":    "root",
-		"system/grub2-artifacts": "root/grub2",
-		"recovery/cos-img":       "root/cOS",
+		"channel:system/grub2-efi-image": "efi",
+		"channel:system/grub2-config":    "root",
+		"channel:system/grub2-artifacts": "root/grub2",
+		"channel:recovery/cos-img":       "root/cOS",
 	}
 }
 

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -350,13 +350,13 @@ type Image struct {
 
 // LiveISO represents the configurations needed for a live ISO image
 type LiveISO struct {
-	RootFS      []string `yaml:"rootfs,omitempty" mapstructure:"rootfs"`
-	UEFI        []string `yaml:"uefi,omitempty" mapstructure:"uefi"`
-	Image       []string `yaml:"image,omitempty" mapstructure:"image"`
-	Label       string   `yaml:"label,omitempty" mapstructure:"label"`
-	BootCatalog string   `yaml:"boot-catalog,omitempty" mapstructure:"boot-catalog"`
-	BootFile    string   `yaml:"boot-file,omitempty" mapstructure:"boot-file"`
-	HybridMBR   string   `yaml:"hybrid-mbr,omitempty" mapstructure:"hybrid-mbr,omitempty"`
+	RootFS      []*ImageSource `yaml:"rootfs,omitempty" mapstructure:"rootfs"`
+	UEFI        []*ImageSource `yaml:"uefi,omitempty" mapstructure:"uefi"`
+	Image       []*ImageSource `yaml:"image,omitempty" mapstructure:"image"`
+	Label       string         `yaml:"label,omitempty" mapstructure:"label"`
+	BootCatalog string         `yaml:"boot-catalog,omitempty" mapstructure:"boot-catalog"`
+	BootFile    string         `yaml:"boot-file,omitempty" mapstructure:"boot-file"`
+	HybridMBR   string         `yaml:"hybrid-mbr,omitempty" mapstructure:"hybrid-mbr,omitempty"`
 }
 
 // Sanitize checks the consistency of the struct, returns error

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -442,10 +442,10 @@ func ValidTaggedContainerReference(ref string) bool {
 
 // NewSrcGuessingType returns new v1.ImageSource instance guessing its type
 // applying somne heuristic techniques (by order of preference):
-//   1. Assume it is Dir/File if value is found as a path in host
-//	 2. Assume it is a container registry reference if it matches [<domain>/]<repositry>:<tag>
-//      (only domain is optional)
-//	 3. Fallback to a channel source
+//	1. Assume it is Dir/File if value is found as a path in host
+//	2. Assume it is a container registry reference if it matches [<domain>/]<repositry>:<tag>
+//		(only domain is optional)
+//	3. Fallback to a channel source
 func NewSrcGuessingType(c *v1.Config, value string) *v1.ImageSource {
 	if exists, _ := Exists(c.Fs, value); exists {
 		if dir, _ := IsDir(c.Fs, value); dir {

--- a/tests/fixtures/config/config.yaml
+++ b/tests/fixtures/config/config.yaml
@@ -2,7 +2,7 @@ cosign-key: "someKey"
 repositories:
 - name: "testrepo"
   priority: 2
-  uri: "registry.org/repo"
+  uri: docker:registry.org/repo
   type: "docker"
 cloud-init-paths:
 - "some/path"

--- a/tests/fixtures/config/manifest.yaml
+++ b/tests/fixtures/config/manifest.yaml
@@ -1,10 +1,10 @@
 iso:
   rootfs:
-    - system/cos
+    - channel:system/cos
   uefi:
-    - live/grub2-efi-image
+    - channel:live/grub2-efi-image
   image:
-    - recovery/cos-img
+    - channel:recovery/cos-img
   label: "LIVE_LABEL"
 
 # Raw disk creation values start


### PR DESCRIPTION
For elemental subcommand build-iso improve validation for source image,
as default set it as container image with "latest" tag if empty.
    
For LiveISO struct change types for RootFS, UEFI, Image to []*ImageSource.

Fixes #219

Signed-off-by: Michal Jura <mjura@suse.com>