### PR TITLE
utils: Drop NewSourceGuessingType()

### DIFF
--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -440,24 +440,6 @@ func ValidTaggedContainerReference(ref string) bool {
 	return true
 }
 
-// NewSrcGuessingType returns new v1.ImageSource instance guessing its type
-// applying somne heuristic techniques (by order of preference):
-//	1. Assume it is Dir/File if value is found as a path in host
-//	2. Assume it is a container registry reference if it matches [<domain>/]<repositry>:<tag>
-//		(only domain is optional)
-//	3. Fallback to a channel source
-func NewSrcGuessingType(c *v1.Config, value string) *v1.ImageSource {
-	if exists, _ := Exists(c.Fs, value); exists {
-		if dir, _ := IsDir(c.Fs, value); dir {
-			return v1.NewDirSrc(value)
-		}
-		return v1.NewFileSrc(value)
-	} else if ValidTaggedContainerReference(value) {
-		return v1.NewDockerSrc(value)
-	}
-	return v1.NewChannelSrc(value)
-}
-
 // FindFileWithPrefix looks for a file in the given path matching one of the given
 // prefixes. Returns the found file path including the given path. It does not
 // check subfolders recusively

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -696,40 +696,6 @@ var _ = Describe("Utils", Label("utils"), func() {
 			Expect(err).Should(HaveOccurred())
 		})
 	})
-	Describe("NewSourceGuessingType", Label("source"), func() {
-		It("Creates a new Docker source for a tagged reference", func() {
-			src := utils.NewSrcGuessingType(config, "registry.suse.com/elemental/image:v0.1")
-			Expect(src.IsDocker()).To(BeTrue())
-			src = utils.NewSrcGuessingType(config, "registry.suse.com:1906/elemental/image:tag")
-			Expect(src.IsDocker()).To(BeTrue())
-			src = utils.NewSrcGuessingType(config, "elemental/image:tag")
-			Expect(src.IsDocker()).To(BeTrue())
-		})
-		It("Creates a new Directory source from a path only if it exists", func() {
-			err := utils.MkdirAll(fs, "/dir", constants.DirPerm)
-			Expect(err).ShouldNot(HaveOccurred())
-			src := utils.NewSrcGuessingType(config, "/dir")
-			Expect(src.IsDir()).To(BeTrue())
-			src = utils.NewSrcGuessingType(config, "/folder")
-			Expect(src.IsDir()).To(BeFalse())
-		})
-		It("Creates a new File source from a path only if it exists", func() {
-			err := utils.MkdirAll(fs, "/dir", constants.DirPerm)
-			Expect(err).ShouldNot(HaveOccurred())
-			_, err = fs.Create("/dir/file")
-			Expect(err).ShouldNot(HaveOccurred())
-			src := utils.NewSrcGuessingType(config, "/dir/file")
-			Expect(src.IsFile()).To(BeTrue())
-			src = utils.NewSrcGuessingType(config, "/dir/otherfile")
-			Expect(src.IsFile()).To(BeFalse())
-		})
-		It("Creates a new Channel source", func() {
-			src := utils.NewSrcGuessingType(config, "system/cos")
-			Expect(src.IsChannel()).To(BeTrue())
-			src = utils.NewSrcGuessingType(config, "cos")
-			Expect(src.IsChannel()).To(BeTrue())
-		})
-	})
 	Describe("FindFileWithPrefix", Label("find"), func() {
 		BeforeEach(func() {
 			err := utils.MkdirAll(fs, "/path/inner", constants.DirPerm)


### PR DESCRIPTION
We would like to remove and stop using NewSourceGuessingType(),
instead of it NewSrcFromURI() shoud be used from
github.com/rancher/elemental-cli/pkg/types/v1

Fixes #219

Signed-off-by: Michal Jura <mjura@suse.com>