### PR TITLE
Improve SELinux labeling commands

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -100,7 +100,11 @@ const (
 	BuildImgName           = "elemental"
 	UsrLocalPath           = "/usr/local"
 	OEMPath                = "/oem"
-	SELinuxContextFile     = "/etc/selinux/targeted/contexts/files/file_contexts"
+
+	// SELinux targeted policy paths
+	SELinuxTargetedPath        = "/etc/selinux/targeted"
+	SELinuxTargetedContextFile = SELinuxTargetedPath + "/contexts/files/file_contexts"
+	SELinuxTargetedPolicyPath  = SELinuxTargetedPath + "/policy"
 
 	//TODO these paths are abitrary, coupled to package live/grub2 and assuming xz
 	// I'd suggest using `/boot/kernel` and `/boot/initrd`


### PR DESCRIPTION
Ensure setfiles utility makes use of the guest selinux policy. Setfiles
by default makes use of the policy currenlty loaded within the host, if
any. In order to workaround that provide the specific binary policy file
to be loaded instead.

Signed-off-by: David Cassany <dcassany@suse.com>