### PR TITLE
Fix default config for RawDisk

### DIFF
--- a/cmd/build-disk.go
+++ b/cmd/build-disk.go
@@ -67,6 +67,14 @@ func NewBuildDisk(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 				return err
 			}
 
+			// Get the spec for the arch only
+			var specArch *v1.RawDiskArchEntry
+			if cfg.Arch == "x86_64" {
+				specArch = spec.X86_64
+			} else {
+				specArch = spec.Arm64
+			}
+
 			// TODO map these to buildconfig and rawdisk structs, so they
 			// are directly unmarshaled and there is no need handle them here
 			imgType, _ := flags.GetString("type")
@@ -76,7 +84,7 @@ func NewBuildDisk(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 
 			// Set the repo depending on the arch we are building for
 			var repos []v1.Repository
-			for _, u := range (*spec)[cfg.Arch].Repositories {
+			for _, u := range specArch.Repositories {
 				repos = append(repos, v1.Repository{
 					URI:         u.URI,
 					Priority:    constants.LuetDefaultRepoPrio,
@@ -97,7 +105,7 @@ func NewBuildDisk(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 				return fmt.Errorf("output file %s exists, refusing to continue", output)
 			}
 
-			err = action.BuildDiskRun(cfg, spec, imgType, oemLabel, recoveryLabel, output)
+			err = action.BuildDiskRun(cfg, specArch, imgType, oemLabel, recoveryLabel, output)
 			if err != nil {
 				return err
 			}

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -283,7 +283,7 @@ func ReadBuildISO(b *v1.BuildConfig, flags *pflag.FlagSet) (*v1.LiveISO, error) 
 }
 
 func ReadBuildDisk(b *v1.BuildConfig, flags *pflag.FlagSet) (*v1.RawDisk, error) {
-	disk := config.NewRawDisk(b.Config)
+	disk := config.NewRawDisk()
 	vp := viper.Sub("raw_disk")
 	if vp == nil {
 		vp = viper.New()

--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -164,10 +164,10 @@ var _ = Describe("Config", Label("config"), func() {
 				Expect(err).ShouldNot(HaveOccurred())
 
 				// From config file
-				Expect(len((*disk)["x86_64"].Packages)).To(Equal(1))
-				Expect((*disk)["x86_64"].Packages[0].Name).To(Equal("system/myos"))
-				Expect(len((*disk)["x86_64"].Repositories)).To(Equal(1))
-				Expect((*disk)["x86_64"].Repositories[0].URI).To(Equal("quay.io/some/repo"))
+				Expect(len(disk.X86_64.Packages)).To(Equal(1))
+				Expect(disk.X86_64.Packages[0].Name).To(Equal("system/myos"))
+				Expect(len(disk.X86_64.Repositories)).To(Equal(1))
+				Expect(disk.X86_64.Repositories[0].URI).To(Equal("quay.io/some/repo"))
 			})
 		})
 	})

--- a/pkg/action/build-disk.go
+++ b/pkg/action/build-disk.go
@@ -35,15 +35,10 @@ import (
 var MB = int64(1024 * 1024)
 var GB = 1024 * MB
 
-func BuildDiskRun(cfg *v1.BuildConfig, spec *v1.RawDisk, imgType string, oemLabel string, recoveryLabel string, output string) (err error) {
+func BuildDiskRun(cfg *v1.BuildConfig, spec *v1.RawDiskArchEntry, imgType string, oemLabel string, recoveryLabel string, output string) (err error) {
 	cfg.Logger.Infof("Building disk image type %s for arch %s", imgType, cfg.Arch)
-	if (*spec)[cfg.Arch] == nil {
-		msg := fmt.Sprintf("no values in the config for arch %s", cfg.Arch)
-		cfg.Logger.Error(msg)
-		return errors.New(msg)
-	}
 
-	if len((*spec)[cfg.Arch].Packages) == 0 {
+	if len(spec.Packages) == 0 {
 		msg := fmt.Sprintf("no packages in the config for arch %s", cfg.Arch)
 		cfg.Logger.Error(msg)
 		return errors.New(msg)
@@ -84,15 +79,16 @@ func BuildDiskRun(cfg *v1.BuildConfig, spec *v1.RawDisk, imgType string, oemLabe
 	rootfsPart := filepath.Join(diskTempDir, "rootfs.part")
 	oemPart := filepath.Join(diskTempDir, "oem.part")
 	efiPart := filepath.Join(diskTempDir, "efi.part")
-
 	// Extract required packages to basedir
-	for _, pkg := range (*spec)[cfg.Arch].Packages {
+	for _, pkg := range spec.Packages {
 		err = os.MkdirAll(filepath.Join(baseDir, pkg.Target), constants.DirPerm)
 		if err != nil {
+			cfg.Logger.Error(err)
 			return err
 		}
 		imgSource, err := v1.NewSrcFromURI(pkg.Name)
 		if err != nil {
+			cfg.Logger.Error(err)
 			return err
 		}
 		err = e.DumpSource(

--- a/pkg/action/build_test.go
+++ b/pkg/action/build_test.go
@@ -232,8 +232,8 @@ var _ = Describe("Runtime Actions", func() {
 	Describe("Build disk", Label("disk", "build"), func() {
 		var rawDisk *v1.RawDisk
 		BeforeEach(func() {
-			rawDisk = config.NewRawDisk(cfg.Config)
-			(*rawDisk)["x86_64"].Packages = []v1.RawDiskPackage{{Name: "oci:what", Target: "what"}}
+			rawDisk = config.NewRawDisk()
+			rawDisk.X86_64.Packages = []v1.RawDiskPackage{{Name: "oci:what", Target: "what"}}
 
 			cfg.Repos = []v1.Repository{{URI: "test"}}
 		})
@@ -251,7 +251,7 @@ var _ = Describe("Runtime Actions", func() {
 			_ = fs.WriteFile(filepath.Join(partsDir, "oem.part"), []byte(""), os.ModePerm)
 			_ = fs.WriteFile(filepath.Join(partsDir, "efi.part"), []byte(""), os.ModePerm)
 
-			err := action.BuildDiskRun(cfg, rawDisk, "raw", "", "", filepath.Join(outputDir, "disk.raw"))
+			err := action.BuildDiskRun(cfg, rawDisk.X86_64, "raw", "", "", filepath.Join(outputDir, "disk.raw"))
 			Expect(err).ToNot(HaveOccurred())
 			// Check that we copied all needed files to final image
 			Expect(memLog.String()).To(ContainSubstring("efi.part"))
@@ -287,7 +287,7 @@ var _ = Describe("Runtime Actions", func() {
 			_ = fs.WriteFile(filepath.Join(partsDir, "oem.part"), []byte(""), os.ModePerm)
 			_ = fs.WriteFile(filepath.Join(partsDir, "efi.part"), []byte(""), os.ModePerm)
 
-			err := action.BuildDiskRun(cfg, rawDisk, "raw", "OEM", "REC", filepath.Join(outputDir, "disk.raw"))
+			err := action.BuildDiskRun(cfg, rawDisk.X86_64, "raw", "OEM", "REC", filepath.Join(outputDir, "disk.raw"))
 			Expect(err).ToNot(HaveOccurred())
 			// Check that we copied all needed files to final image
 			Expect(memLog.String()).To(ContainSubstring("efi.part"))
@@ -323,7 +323,7 @@ var _ = Describe("Runtime Actions", func() {
 			_ = fs.WriteFile(filepath.Join(partsDir, "oem.part"), []byte(""), os.ModePerm)
 			_ = fs.WriteFile(filepath.Join(partsDir, "efi.part"), []byte(""), os.ModePerm)
 
-			err := action.BuildDiskRun(cfg, rawDisk, "gce", "OEM", "REC", filepath.Join(outputDir, "disk.raw"))
+			err := action.BuildDiskRun(cfg, rawDisk.X86_64, "gce", "OEM", "REC", filepath.Join(outputDir, "disk.raw"))
 			Expect(err).ToNot(HaveOccurred())
 			// Check that we copied all needed files to final image
 			Expect(memLog.String()).To(ContainSubstring("efi.part"))
@@ -356,7 +356,7 @@ var _ = Describe("Runtime Actions", func() {
 			_ = fs.WriteFile(filepath.Join(partsDir, "oem.part"), []byte(""), os.ModePerm)
 			_ = fs.WriteFile(filepath.Join(partsDir, "efi.part"), []byte(""), os.ModePerm)
 
-			err := action.BuildDiskRun(cfg, rawDisk, "azure", "OEM", "REC", filepath.Join(outputDir, "disk.raw"))
+			err := action.BuildDiskRun(cfg, rawDisk.X86_64, "azure", "OEM", "REC", filepath.Join(outputDir, "disk.raw"))
 			Expect(err).ToNot(HaveOccurred())
 			// Check that we copied all needed files to final image
 			Expect(memLog.String()).To(ContainSubstring("efi.part"))
@@ -478,21 +478,15 @@ var _ = Describe("Runtime Actions", func() {
 			Expect(hex.EncodeToString(header.Features[:])).To(Equal("00000002"))
 			Expect(hex.EncodeToString(header.DataOffset[:])).To(Equal("ffffffffffffffff"))
 		})
-		It("Fails if the specs does not have an arch", func() {
-			rawDisk = &v1.RawDisk{}
-			err := action.BuildDiskRun(cfg, rawDisk, "raw", "OEM", "REC", "disk.raw")
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("no values in the config for arch %s", cfg.Arch)))
-		})
 		It("Fails if the specs does not have packages", func() {
-			(*rawDisk)["x86_64"].Packages = []v1.RawDiskPackage{}
-			err := action.BuildDiskRun(cfg, rawDisk, "raw", "OEM", "REC", "disk.raw")
+			rawDisk.X86_64.Packages = []v1.RawDiskPackage{}
+			err := action.BuildDiskRun(cfg, rawDisk.X86_64, "raw", "OEM", "REC", "disk.raw")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("no packages in the config for arch %s", cfg.Arch)))
 		})
 		It("Fails if config has no repos", func() {
 			cfg.Repos = []v1.Repository{}
-			err := action.BuildDiskRun(cfg, rawDisk, "raw", "OEM", "REC", "disk.raw")
+			err := action.BuildDiskRun(cfg, rawDisk.X86_64, "raw", "OEM", "REC", "disk.raw")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("no repositories configured for arch %s", cfg.Arch)))
 		})

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -434,7 +434,7 @@ func NewResetSpec(cfg v1.Config) (*v1.ResetSpec, error) {
 	}, nil
 }
 
-func NewRawDisk(cfg v1.Config) *v1.RawDisk {
+func NewRawDisk() *v1.RawDisk {
 	var packages []v1.RawDiskPackage
 	defaultPackages := constants.GetBuildDiskDefaultPackages()
 
@@ -443,7 +443,8 @@ func NewRawDisk(cfg v1.Config) *v1.RawDisk {
 	}
 
 	return &v1.RawDisk{
-		cfg.Arch: &v1.RawDiskArchEntry{Packages: packages},
+		X86_64: &v1.RawDiskArchEntry{Packages: packages},
+		Arm64:  &v1.RawDiskArchEntry{Packages: packages},
 	}
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -416,8 +416,8 @@ var _ = Describe("Types", Label("types", "config"), func() {
 		})
 		Describe("RawDisk", Label("disk"), func() {
 			It("initiates a new RawDisk", func() {
-				disk := config.NewRawDisk(*c)
-				Expect(len((*disk)[c.Arch].Packages)).To(Equal(len(constants.GetBuildDiskDefaultPackages())))
+				disk := config.NewRawDisk()
+				Expect(len(disk.X86_64.Packages)).To(Equal(len(constants.GetBuildDiskDefaultPackages())))
 			})
 		})
 	})

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -388,7 +388,7 @@ type BuildConfig struct {
 }
 
 type RawDisk struct {
-	X86_64 *RawDiskArchEntry `yaml:"x86_64,omitempty" mapstructure:"x86_64"`
+	X86_64 *RawDiskArchEntry `yaml:"x86_64,omitempty" mapstructure:"x86_64"` //nolint:revive
 	Arm64  *RawDiskArchEntry `yaml:"arm64,omitempty" mapstructure:"arm64"`
 }
 

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -387,7 +387,10 @@ type BuildConfig struct {
 	Config `yaml:",inline" mapstructure:",squash"`
 }
 
-type RawDisk map[string]*RawDiskArchEntry
+type RawDisk struct {
+	X86_64 *RawDiskArchEntry `yaml:"x86_64,omitempty" mapstructure:"x86_64"`
+	Arm64  *RawDiskArchEntry `yaml:"arm64,omitempty" mapstructure:"arm64"`
+}
 
 // Sanitize checks the consistency of the struct, returns error
 // if unsolvable inconsistencies are found


### PR DESCRIPTION
Having the config.ZeroFields set to true works for other places but in
the case of build-disk, we have some default in an array of arches and
setting it to true makes the whole thing to dissapear. But if there is
no configuration provided that can supply those values again, we end up
with an empty RaDisk config which is good for nothing.

This removes setting those ZeroFields to true, so the defaults are
always in the RawDisk and if there is a config coming, it will overwrite
it.

Tested locally with no config and providing a config.

As a side effect of the testing, this also adds logging for errors that
didnt have anything, so we could error out and not inform of the why.

Fixes #248 

Signed-off-by: Itxaka <igarcia@suse.com>