### PR TITLE
build-iso: Sanitize config file for build-iso

### DIFF
--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -362,7 +362,22 @@ type LiveISO struct {
 // Sanitize checks the consistency of the struct, returns error
 // if unsolvable inconsistencies are found
 func (i *LiveISO) Sanitize() error {
-	// No checks for the time being
+	for _, src := range i.RootFS {
+		if src == nil {
+			return fmt.Errorf("wrong name of source package for rootfs")
+		}
+	}
+	for _, src := range i.UEFI {
+		if src == nil {
+			return fmt.Errorf("wrong name of source package for uefi")
+		}
+	}
+	for _, src := range i.Image {
+		if src == nil {
+			return fmt.Errorf("wrong name of source package for image")
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/types/v1/config_test.go
+++ b/pkg/types/v1/config_test.go
@@ -309,6 +309,36 @@ var _ = Describe("Types", Label("types", "config"), func() {
 		It("runs sanitize method", func() {
 			iso := config.NewISO()
 			Expect(iso.Sanitize()).ShouldNot(HaveOccurred())
+
+			//Success when properly provided source packages
+			spec := &v1.LiveISO{
+				RootFS: []*v1.ImageSource{
+					v1.NewDirSrc("/system/os"),
+					v1.NewChannelSrc("system/os"),
+				},
+				UEFI: []*v1.ImageSource{
+					v1.NewChannelSrc("live/grub2-efi-image"),
+				},
+				Image: []*v1.ImageSource{
+					v1.NewChannelSrc("live/grub2"),
+				},
+			}
+			Expect(spec.Sanitize()).ShouldNot(HaveOccurred())
+			Expect(iso.Sanitize()).ShouldNot(HaveOccurred())
+
+			//Fails when packages were provided in incorrect format
+			spec = &v1.LiveISO{
+				RootFS: []*v1.ImageSource{
+					nil,
+				},
+				UEFI: []*v1.ImageSource{
+					nil,
+				},
+				Image: []*v1.ImageSource{
+					nil,
+				},
+			}
+			Expect(spec.Sanitize()).Should(HaveOccurred())
 		})
 	})
 	Describe("RawDisk", func() {


### PR DESCRIPTION
All source packages in config file for build-iso,
have to be provided in uri format with prefix "dir", "file",
"oci", "docker", "channel" (e.g. channel:live/grub2-efi-image)

Fixes #219

Signed-off-by: Michal Jura <mjura@suse.com>