### PR TITLE
Fix build-iso command when no arguments are provided

### DIFF
--- a/cmd/build-iso.go
+++ b/cmd/build-iso.go
@@ -84,10 +84,15 @@ func NewBuildISO(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 					}
 					// ensure we set it as a docker type
 					imgSource = v1.NewDockerSrc(imageName)
+				} else if err != nil {
+					cfg.Logger.Errorf("not a valid rootfs source image argument: %s", args[0])
+					return err
 				}
 				spec.RootFS = []*v1.ImageSource{imgSource}
-			} else {
-				return fmt.Errorf("rootfs source image for building ISO was not provided")
+			} else if len(spec.RootFS) == 0 {
+				errmsg := "rootfs source image for building ISO was not provided"
+				cfg.Logger.Errorf(errmsg)
+				return fmt.Errorf(errmsg)
 			}
 
 			// Repos and overlays can't be unmarshaled directly as they require
@@ -129,6 +134,7 @@ func NewBuildISO(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 			buildISO := action.NewBuildISOAction(cfg, spec)
 			err = buildISO.ISORun()
 			if err != nil {
+				cfg.Logger.Errorf(err.Error())
 				return err
 			}
 

--- a/cmd/build-iso_test.go
+++ b/cmd/build-iso_test.go
@@ -47,6 +47,11 @@ var _ = Describe("BuidISO", Label("iso", "cmd"), func() {
 		Expect(err).ToNot(BeNil())
 		Expect(err.Error()).To(ContainSubstring("rootfs source image for building ISO was not provided"))
 	})
+	It("Errors out if rootfs is a non valid argument", Label("flags"), func() {
+		_, _, err := executeCommandC(rootCmd, "build-iso", "/no/image/reference")
+		Expect(err).ToNot(BeNil())
+		Expect(err.Error()).To(ContainSubstring("unknown source type for"))
+	})
 	It("Errors out if overlay roofs path does not exist", Label("flags"), func() {
 		_, _, err := executeCommandC(
 			rootCmd, "build-iso", "system/cos", "--overlay-rootfs", "/nonexistingpath",
@@ -63,7 +68,7 @@ var _ = Describe("BuidISO", Label("iso", "cmd"), func() {
 	})
 	It("Errors out if overlay iso path does not exist", Label("flags"), func() {
 		_, _, err := executeCommandC(
-			rootCmd, "build-iso", "/my/rootfs", "--overlay-iso", "/nonexistingpath",
+			rootCmd, "build-iso", "some/image:latest", "--overlay-iso", "/nonexistingpath",
 		)
 		Expect(err).ToNot(BeNil())
 		Expect(err.Error()).To(ContainSubstring("Invalid path"))


### PR DESCRIPTION
In previous changes of build-iso command we omitted the case where all
the configurations are comming from the manifest and no rootfs image
is provided within the command line.

Signed-off-by: David Cassany <dcassany@suse.com>