### PR TITLE
build-iso: add computation of the sha256 checksum

### DIFF
--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -17,6 +17,7 @@ limitations under the License.
 package utils
 
 import (
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
@@ -496,4 +497,20 @@ func GolangArchToArch(arch string) (string, error) {
 	default:
 		return "", errInvalidArch
 	}
+}
+
+// CalcFileChecksum opens the given file and returns the sha256 checksum of it.
+func CalcFileChecksum(fs v1.FS, fileName string) (string, error) {
+	f, err := fs.Open(fileName)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/jaypipes/ghw/pkg/block"
@@ -750,6 +751,21 @@ var _ = Describe("Utils", Label("utils"), func() {
 			utils.MkdirAll(fs, "/path", constants.DirPerm)
 			_, err := utils.FindFileWithPrefix(fs, "/path", "prefix", "anotherprefix")
 			Expect(err).Should(HaveOccurred())
+		})
+	})
+	Describe("CalcFileChecksum", Label("checksum"), func() {
+		It("compute correct sha256 checksum", func() {
+			testData := strings.Repeat("abcdefghilmnopqrstuvz\n", 20)
+			testDataSHA256 := "7f182529f6362ae9cfa952ab87342a7180db45d2c57b52b50a68b6130b15a422"
+
+			err := fs.Mkdir("/iso", constants.DirPerm)
+			Expect(err).ShouldNot(HaveOccurred())
+			err = fs.WriteFile("/iso/test.iso", []byte(testData), 0644)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			checksum, err := utils.CalcFileChecksum(fs, "/iso/test.iso")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(checksum).To(Equal(testDataSHA256))
 		})
 	})
 	Describe("Grub", Label("grub"), func() {


### PR DESCRIPTION
Add sha256 file when building the iso.

Fixes #228 