### PR TITLE
Fix buld-iso

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,8 @@ test_deps:
 	go install github.com/onsi/ginkgo/v2/ginkgo
 
 test: $(GINKGO)
-	ginkgo run --label-filter !root --fail-fast --slow-spec-threshold 30s --race --covermode=atomic --coverprofile=coverage.txt -p -r ${PKG}
+	ginkgo run --label-filter '!root && !serial' --fail-fast --slow-spec-threshold 30s --race --covermode=atomic --coverprofile=coverage.txt -p -r ${PKG}
+	ginkgo run --label-filter '!root && serial' --fail-fast --slow-spec-threshold 30s --race --covermode=atomic --coverprofile=coverage.txt -r ${PKG}
 
 test_root: $(GINKGO)
 ifneq ($(shell id -u), 0)
@@ -57,7 +58,9 @@ endif
 # Useful test run for local dev. It does not run tests that require root and it does not run tests that require systemctl checks
 # which results in a escalation prompt for privileges. This can block a run until a password or the prompt is cancelled
 test_no_root_no_systemctl:
-	ginkgo run --label-filter '!root && !systemctl' --fail-fast --slow-spec-threshold 30s --race --covermode=atomic --coverprofile=coverage.txt -p -r ${PKG}
+	ginkgo run --label-filter '!root && !systemctl && !serial' --fail-fast --slow-spec-threshold 30s --race --covermode=atomic --coverprofile=coverage.txt -p -r ${PKG}
+	ginkgo run --label-filter '!root && !systemctl && serial' --fail-fast --slow-spec-threshold 30s --race --covermode=atomic --coverprofile=coverage.txt -r ${PKG}
+
 
 license-check:
 	@.github/license_check.sh

--- a/pkg/action/build_test.go
+++ b/pkg/action/build_test.go
@@ -274,7 +274,7 @@ var _ = Describe("Runtime Actions", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 		})
-		It("Builds a raw image", func() {
+		It("Builds a raw image", Label("serial"), func() {
 			// temp dir for output, otherwise we write to .
 			outputDir, _ := utils.TempDir(fs, "", "output")
 			// temp dir for package files, create needed file
@@ -310,7 +310,7 @@ var _ = Describe("Runtime Actions", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 		})
-		It("Builds a raw image with GCE output", func() {
+		It("Builds a raw image with GCE output", Label("serial"), func() {
 			// temp dir for output, otherwise we write to .
 			outputDir, _ := utils.TempDir(fs, "", "output")
 			// temp dir for package files, create needed file
@@ -343,7 +343,7 @@ var _ = Describe("Runtime Actions", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 		})
-		It("Builds a raw image with Azure output", func() {
+		It("Builds a raw image with Azure output", Label("serial"), func() {
 			// temp dir for output, otherwise we write to .
 			outputDir, _ := utils.TempDir(fs, "", "output")
 			// temp dir for package files, create needed file

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -488,6 +488,7 @@ func NewBuildConfig(opts ...GenericOptions) *v1.BuildConfig {
 			Name:     "cos",
 			Type:     "docker",
 			URI:      repo,
+			Arch:     b.Arch,
 			Priority: constants.LuetDefaultRepoPrio,
 		}}
 	}


### PR DESCRIPTION
We forgot to specify the arch in the default Luet repo, causing build-iso to fail (as the repo was dropped because not matching the arch).
The new raw image build tests moreover caused "make test" to fail in my environment: the three tests, when run in parallel, quickly fill up my /tmp dir (7GB). The proposal here is to serialize those test to let one clean-up before the following starts.
