### PR TITLE
Ensure we properly propagate repository arch configuration in repos

### DIFF
--- a/cmd/build-iso.go
+++ b/cmd/build-iso.go
@@ -128,7 +128,7 @@ func NewBuildISO(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 			}
 
 			for _, u := range repoURIs {
-				cfg.Repos = append(cfg.Repos, v1.Repository{URI: u, Priority: constants.LuetRepoMaxPrio})
+				cfg.Repos = append(cfg.Repos, v1.Repository{URI: u, Priority: constants.LuetRepoMaxPrio, Arch: cfg.Arch})
 			}
 
 			buildISO := action.NewBuildISOAction(cfg, spec)

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -122,7 +122,7 @@ func ReadConfigBuild(configDir string, flags *pflag.FlagSet, mounter mount.Inter
 	// If a config file is found, read it in.
 	_ = viper.MergeInConfig()
 
-	// Bind runconfig flags
+	// Bind buildconfig flags
 	bindGivenFlags(viper.GetViper(), flags)
 	// merge environment variables on top for rootCmd
 	viperReadEnv(viper.GetViper(), "BUILD", constants.GetBuildKeyEnvMap())
@@ -133,6 +133,7 @@ func ReadConfigBuild(configDir string, flags *pflag.FlagSet, mounter mount.Inter
 		cfg.Logger.Warnf("error unmarshalling config: %s", err)
 	}
 
+	err = cfg.Sanitize()
 	cfg.Logger.Debugf("Full config loaded: %s", litter.Sdump(cfg))
 	return cfg, err
 }

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -133,8 +133,6 @@ func ReadConfigBuild(configDir string, flags *pflag.FlagSet, mounter mount.Inter
 		cfg.Logger.Warnf("error unmarshalling config: %s", err)
 	}
 
-	l.Arch = cfg.Arch
-
 	cfg.Logger.Debugf("Full config loaded: %s", litter.Sdump(cfg))
 	return cfg, err
 }

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -404,6 +404,12 @@ type BuildConfig struct {
 	Config `yaml:",inline" mapstructure:",squash"`
 }
 
+// Sanitize checks the consistency of the struct, returns error
+//if unsolvable inconsistencies are found
+func (b *BuildConfig) Sanitize() error {
+	return b.Config.Sanitize()
+}
+
 type RawDisk struct {
 	X86_64 *RawDiskArchEntry `yaml:"x86_64,omitempty" mapstructure:"x86_64"` //nolint:revive
 	Arm64  *RawDiskArchEntry `yaml:"arm64,omitempty" mapstructure:"arm64"`

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -62,6 +62,8 @@ func (c *Config) Sanitize() error {
 	if c.Verify {
 		c.Luet.SetPlugins(constants.LuetMtreePlugin)
 	}
+	// Ensure luet arch matches Config.Arch
+	c.Luet.SetArch(c.Arch)
 	return nil
 }
 

--- a/pkg/types/v1/luet.go
+++ b/pkg/types/v1/luet.go
@@ -21,4 +21,5 @@ type LuetInterface interface {
 	UnpackFromChannel(string, string, ...Repository) error
 	SetPlugins(...string)
 	GetPlugins() []string
+	SetArch(string)
 }

--- a/tests/mocks/luet_mock.go
+++ b/tests/mocks/luet_mock.go
@@ -31,6 +31,7 @@ type FakeLuet struct {
 	unpackCalled                bool
 	unpackFromChannelCalled     bool
 	plugins                     []string
+	arch                        string
 }
 
 func NewFakeLuet() *FakeLuet {
@@ -75,4 +76,8 @@ func (l *FakeLuet) SetPlugins(plugins ...string) {
 
 func (l *FakeLuet) GetPlugins() []string {
 	return l.plugins
+}
+
+func (l *FakeLuet) SetArch(arch string) {
+	l.arch = arch
 }


### PR DESCRIPTION
This commit ensures repository architecture is properly propageted from
`--repo` flag down to luet repository configuration.

In addition a repository without any architecture is set to the current
target architecture in v1.Config.

Fixes rancher/elemental-toolkit#1519

Signed-off-by: David Cassany <dcassany@suse.com>