### PR TITLE
Fallback to docker type if URI source is of an unknown type

### DIFF
--- a/cmd/build-iso.go
+++ b/cmd/build-iso.go
@@ -77,14 +77,7 @@ func NewBuildISO(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 
 			if len(args) == 1 {
 				imgSource, err := v1.NewSrcFromURI(args[0])
-				if err != nil && utils.ValidContainerReference(args[0]) {
-					imageName := args[0]
-					if !utils.ValidTaggedContainerReference(imageName) {
-						imageName = imageName + ":latest"
-					}
-					// ensure we set it as a docker type
-					imgSource = v1.NewDockerSrc(imageName)
-				} else if err != nil {
+				if err != nil {
 					cfg.Logger.Errorf("not a valid rootfs source image argument: %s", args[0])
 					return err
 				}

--- a/pkg/types/v1/common_test.go
+++ b/pkg/types/v1/common_test.go
@@ -63,15 +63,27 @@ var _ = Describe("Types", Label("types", "common"), func() {
 			_, err = o.CustomUnmarshal("docker:some/image")
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(o.IsDocker()).To(BeTrue())
+
+			// No scheme is parsed as an image reference and
+			// defaults to latest tag if none
+			_, err = o.CustomUnmarshal("registry.company.org/my/image")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(o.IsDocker()).To(BeTrue())
+			Expect(o.Value()).To(Equal("registry.company.org/my/image:latest"))
+
+			_, err = o.CustomUnmarshal("registry.company.org/my/image:tag")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(o.IsDocker()).To(BeTrue())
+			Expect(o.Value()).To(Equal("registry.company.org/my/image:tag"))
 		})
 		It("fails to unmarshal non string types", func() {
 			o := v1.NewEmptySrc()
 			_, err := o.CustomUnmarshal(map[string]string{})
 			Expect(err).Should(HaveOccurred())
 		})
-		It("fails to unmarshal unknown scheme", func() {
+		It("fails to unmarshal unknown scheme and invalid image reference", func() {
 			o := v1.NewEmptySrc()
-			_, err := o.CustomUnmarshal("scheme:some.opaque.uri.org")
+			_, err := o.CustomUnmarshal("scheme://some.uri.org")
 			Expect(err).Should(HaveOccurred())
 		})
 		It("fails to unmarshal invalid uri", func() {


### PR DESCRIPTION
This commit unmarshals unknown source URI types as docker image
references.

Part of rancher/elemental-toolkit#1347

Signed-off-by: David Cassany <dcassany@suse.com>