### PR TITLE
Add squash flags to upgrade cmd

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -79,6 +79,7 @@ func NewUpgradeCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 	c.Flags().Bool("recovery", false, "Upgrade the recovery")
 	addSharedInstallUpgradeFlags(c)
 	addLocalImageFlag(c)
+	addSquashFsCompressionFlags(c)
 	return c
 }
 


### PR DESCRIPTION
In case of recovery being squash we need the flags available

Signed-off-by: Itxaka <igarcia@suse.com>