### PR TITLE
Allow multiple cloud-init files in installation spec

### DIFF
--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -280,6 +280,8 @@ var _ = Describe("Config", Label("config"), func() {
 				Expect(err).ShouldNot(HaveOccurred())
 				err = os.Setenv("ELEMENTAL_INSTALL_SYSTEM", "itwillbeignored")
 				Expect(err).ShouldNot(HaveOccurred())
+				err = os.Setenv("ELEMENTAL_INSTALL_CLOUD_INIT", "path/to/file1.yaml,/absolute/path/to/file2.yaml")
+				Expect(err).ShouldNot(HaveOccurred())
 
 				spec, err := ReadInstallSpec(cfg, flags)
 				Expect(err).ShouldNot(HaveOccurred())
@@ -290,6 +292,10 @@ var _ = Describe("Config", Label("config"), func() {
 				// Uses recovery and no-format defined in confing.yaml
 				Expect(spec.Recovery.Source.Value() == "recovery/image:latest")
 				Expect(spec.NoFormat == true)
+				// Gets multiple cloud-init files from env vars as comma separated values
+				Expect(len(spec.CloudInit)).To(Equal(2))
+				Expect(spec.CloudInit[0]).To(Equal("path/to/file1.yaml"))
+				Expect(spec.CloudInit[1]).To(Equal("/absolute/path/to/file2.yaml"))
 			})
 		})
 		Describe("Read ResetSpec", Label("install"), func() {

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -93,7 +93,7 @@ func NewInstallCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 	pTableType := newEnumFlag([]string{v1.GPT, v1.MSDOS}, v1.GPT)
 
 	root.AddCommand(c)
-	c.Flags().StringP("cloud-init", "c", "", "Cloud-init config file")
+	c.Flags().StringSliceP("cloud-init", "c", []string{}, "Cloud-init config files")
 	c.Flags().StringP("iso", "i", "", "Performs an installation from the ISO url")
 	c.Flags().StringP("partition-layout", "p", "", "Partitioning layout file")
 	_ = c.Flags().MarkDeprecated("partition-layout", "'partition-layout' is deprecated and ignored please use a config file instead")

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -267,9 +267,9 @@ var _ = Describe("Install action tests", func() {
 
 		It("Successfully installs and adds remote cloud-config", Label("cloud-config"), func() {
 			spec.Target = device
-			spec.CloudInit = "http://my.config.org"
+			spec.CloudInit = []string{"http://my.config.org"}
 			utils.MkdirAll(fs, constants.OEMDir, constants.DirPerm)
-			_, err := fs.Create(filepath.Join(constants.OEMDir, "99_custom.yaml"))
+			_, err := fs.Create(filepath.Join(constants.OEMDir, "90_custom.yaml"))
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(installer.Run()).To(BeNil())
 			Expect(client.WasGetCalledWith("http://my.config.org")).To(BeTrue())
@@ -353,7 +353,7 @@ var _ = Describe("Install action tests", func() {
 
 		It("Fails if requested remote cloud config can't be downloaded", Label("cloud-config"), func() {
 			spec.Target = device
-			spec.CloudInit = "http://my.config.org"
+			spec.CloudInit = []string{"http://my.config.org"}
 			client.Error = true
 			Expect(installer.Run()).NotTo(BeNil())
 			Expect(client.WasGetCalledWith("http://my.config.org")).To(BeTrue())

--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -396,10 +396,10 @@ func (e *Elemental) DumpSource(target string, imgSrc *v1.ImageSource) (info inte
 }
 
 // CopyCloudConfig will check if there is a cloud init in the config and store it on the target
-func (e *Elemental) CopyCloudConfig(cloudInit string) (err error) {
-	if cloudInit != "" {
-		customConfig := filepath.Join(cnst.OEMDir, "99_custom.yaml")
-		err = utils.GetSource(e.config, cloudInit, customConfig)
+func (e *Elemental) CopyCloudConfig(cloudInit []string) (err error) {
+	for i, ci := range cloudInit {
+		customConfig := filepath.Join(cnst.OEMDir, fmt.Sprintf("9%d_custom.yaml", i))
+		err = utils.GetSource(e.config, ci, customConfig)
 		if err != nil {
 			return err
 		}

--- a/pkg/elemental/elemental_test.go
+++ b/pkg/elemental/elemental_test.go
@@ -872,19 +872,19 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 		})
 		It("Copies the cloud config file", func() {
 			testString := "In a galaxy far far away..."
-			cloudInit := "/config.yaml"
-			err := fs.WriteFile(cloudInit, []byte(testString), cnst.FilePerm)
+			cloudInit := []string{"/config.yaml"}
+			err := fs.WriteFile(cloudInit[0], []byte(testString), cnst.FilePerm)
 			Expect(err).To(BeNil())
 			Expect(err).To(BeNil())
 
 			err = e.CopyCloudConfig(cloudInit)
 			Expect(err).To(BeNil())
-			copiedFile, err := fs.ReadFile(fmt.Sprintf("%s/99_custom.yaml", cnst.OEMDir))
+			copiedFile, err := fs.ReadFile(fmt.Sprintf("%s/90_custom.yaml", cnst.OEMDir))
 			Expect(err).To(BeNil())
 			Expect(copiedFile).To(ContainSubstring(testString))
 		})
 		It("Doesnt do anything if the config file is not set", func() {
-			err := e.CopyCloudConfig("")
+			err := e.CopyCloudConfig([]string{})
 			Expect(err).To(BeNil())
 		})
 	})

--- a/pkg/partitioner/parted.go
+++ b/pkg/partitioner/parted.go
@@ -75,6 +75,7 @@ func (pc PartedCall) optionsBuilder() []string {
 		opts = append(opts, "rm", fmt.Sprintf("%d", partnum))
 	}
 
+	isFat, _ := regexp.Compile("fat|vfat")
 	for _, part := range pc.parts {
 		var pLabel string
 		if label == constants.GPT && part.PLabel != "" {
@@ -87,7 +88,7 @@ func (pc PartedCall) optionsBuilder() []string {
 
 		opts = append(opts, "mkpart", pLabel)
 
-		if matched, _ := regexp.MatchString("fat|vfat", part.FileSystem); matched { // nolint:staticcheck
+		if isFat.MatchString(part.FileSystem) {
 			opts = append(opts, "fat32")
 		} else {
 			opts = append(opts, part.FileSystem)

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -137,7 +137,7 @@ type InstallSpec struct {
 	Partitions   ElementalPartitions `yaml:"partitions,omitempty" mapstructure:"partitions"`
 	NoFormat     bool                `yaml:"no-format,omitempty" mapstructure:"no-format"`
 	Force        bool                `yaml:"force,omitempty" mapstructure:"force"`
-	CloudInit    string              `yaml:"cloud-init,omitempty" mapstructure:"cloud-init"`
+	CloudInit    []string            `yaml:"cloud-init,omitempty" mapstructure:"cloud-init"`
 	Iso          string              `yaml:"iso,omitempty" mapstructure:"iso"`
 	GrubDefEntry string              `yaml:"grub-entry-name,omitempty" mapstructure:"grub-entry-name"`
 	Tty          string              `yaml:"tty,omitempty" mapstructure:"tty"`


### PR DESCRIPTION
Part of rancher/elemental-operator#52

Signed-off-by: David Cassany <dcassany@suse.com>