### PR TITLE
Allow overriding default grub entry or fallback to default

### DIFF
--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -375,6 +375,7 @@ var _ = Describe("Install action tests", func() {
 
 		It("Fails setting the grub default entry", Label("grub"), func() {
 			spec.Target = device
+			spec.GrubDefEntry = "cOS"
 			cmdFail = "grub2-editenv"
 			Expect(installer.Run()).NotTo(BeNil())
 			Expect(runner.MatchMilestones([][]string{{"grub2-editenv", filepath.Join(constants.StateDir, constants.GrubOEMEnv)}}))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -219,15 +219,14 @@ func NewInstallSpec(cfg v1.Config) *v1.InstallSpec {
 	}
 
 	return &v1.InstallSpec{
-		Firmware:     firmware,
-		PartTable:    v1.GPT,
-		Partitions:   NewInstallElementalParitions(),
-		GrubDefEntry: constants.GrubDefEntry,
-		GrubConf:     constants.GrubConf,
-		Tty:          constants.DefaultTty,
-		Active:       activeImg,
-		Recovery:     recoveryImg,
-		Passive:      passiveImg,
+		Firmware:   firmware,
+		PartTable:  v1.GPT,
+		Partitions: NewInstallElementalParitions(),
+		GrubConf:   constants.GrubConf,
+		Tty:        constants.DefaultTty,
+		Active:     activeImg,
+		Recovery:   recoveryImg,
+		Passive:    passiveImg,
 	}
 }
 

--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -525,8 +525,9 @@ func (e Elemental) UpdateSourcesFormDownloadedISO(workDir string, activeImg *v1.
 	return nil
 }
 
-// Sets the default_meny_entry value in RunConfig.GrubOEMEnv file at in
-// State partition mountpoint.
+// SetDefaultGrubEntry Sets the default_meny_entry value in RunConfig.GrubOEMEnv file at in
+// State partition mountpoint. If there is not a custom value in the os-release file, we do nothing
+// As the grub config already has a sane default
 func (e Elemental) SetDefaultGrubEntry(partMountPoint string, imgMountPoint string, defaultEntry string) error {
 	if defaultEntry == "" {
 		osRelease, err := utils.LoadEnvFile(e.config.Fs, filepath.Join(imgMountPoint, "etc", "os-release"))
@@ -535,11 +536,12 @@ func (e Elemental) SetDefaultGrubEntry(partMountPoint string, imgMountPoint stri
 			return nil
 		}
 		defaultEntry = osRelease["GRUB_ENTRY_NAME"]
+		// If its still empty then do nothing
 		if defaultEntry == "" {
-			e.config.Logger.Debug("unset grub default entry")
 			return nil
 		}
 	}
+	e.config.Logger.Infof("Setting default grub entry to %s", cnst.GrubDefEntry)
 	grub := utils.NewGrub(e.config)
 	return grub.SetPersistentVariables(
 		filepath.Join(partMountPoint, cnst.GrubOEMEnv),


### PR DESCRIPTION
The way this was done before it didnt allow a derivative to override the
default grub entry by setting the GRUB_ENTRY_NAME in the os-release file
as it will only look up that if the entry was empty, but we were always
initializing it to the defaul cOS value.

This patch makes the default grub empty on the config empty by default
and falls back to it in case we cant load it from the os-release file

Signed-off-by: Itxaka <igarcia@suse.com>