### PR TITLE
Push to REPO-ci on master merge

### DIFF
--- a/.github/workflows/docker-master.yaml
+++ b/.github/workflows/docker-master.yaml
@@ -1,12 +1,6 @@
 name: Docker build and push
 on:
-  pull_request:
-    paths:
-      - Dockerfile
-      - .github/workflows/docker.yaml
   push:
-    branches:
-      - main
     tags:
       - 'v*'
 jobs:
@@ -27,18 +21,7 @@ jobs:
           echo "Using tag $(git describe --tags `git rev-list --tags --max-count=1`  2>/dev/null || echo 'v0.0.1')"
           TAG=$(git describe --tags `git rev-list --tags --max-count=1` 2>/dev/null || echo "v0.0.1")
           echo "::set-output name=elemental_tag::$TAG"
-      - name: Docker meta for tag
-        if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
-        id: meta
-        uses: docker/metadata-action@v3
-        with:
-          images: |
-            quay.io/costoolkit/elemental-cli
-          tags: |
-            type=semver,pattern=v{{version}}
-            type=raw,value=latest
       - name: Docker meta for master/PR
-        if: !contains(github.ref, 'refs/tags/')
         id: meta
         uses: docker/metadata-action@v3
         with:
@@ -93,7 +76,7 @@ jobs:
           rm disk.img
       - name: Push image  # should be a free build as everything has been cached and loaded
         uses: docker/build-push-action@v2
-        if: ${{ github.event_name != 'pull_request' }}  # push on tag and main merge
+        if: ${{ github.event_name != 'pull_request' }}  # push on main merge
         with:
           context: .
           push: true

--- a/.github/workflows/docker-tag.yaml
+++ b/.github/workflows/docker-tag.yaml
@@ -1,0 +1,88 @@
+name: Docker build and push on tag
+on:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install qemu-tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-utils
+      - name: Export tag
+        id: export_tag
+        run: |
+          echo "Using tag $(git describe --tags `git rev-list --tags --max-count=1`  2>/dev/null || echo 'v0.0.1')"
+          TAG=$(git describe --tags `git rev-list --tags --max-count=1` 2>/dev/null || echo "v0.0.1")
+          echo "::set-output name=elemental_tag::$TAG"
+      - name: Docker meta for tag
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            quay.io/costoolkit/elemental-cli
+          tags: |
+            type=semver,pattern=v{{version}}
+            type=raw,value=latest
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to Quay
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+      - name: Build image
+        uses: docker/build-push-action@v2
+        id: docker_build
+        with:
+          context: .
+          tags: ${{ steps.meta.outputs.tags }}
+          load: true # loads it locally, so it can be used from docker client
+          # cache into GitHub actions cache, nice
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          target: elemental
+          build-args: |
+            ELEMENTAL_VERSION=${{ steps.export_tag.outputs.elemental_tag }}
+            ELEMENTAL_COMMIT=${{ github.sha }}
+      - name: Test elemental image version
+        run: docker run ${{ steps.docker_build.outputs.ImageID }} version --long
+      - name: Test elemental image install with --force-efi
+        run: |
+          # create a 30Gb file
+          qemu-img create -f raw disk-efi.img 30G
+          # mount loop device and get the device
+          LOOP=`sudo losetup -fP --show disk-efi.img`
+          docker run -v /dev/:/dev/ --privileged ${{ steps.docker_build.outputs.ImageID }} install --force-efi --debug -d quay.io/costoolkit/releases-green:cos-system-0.8.6 $LOOP
+          sudo losetup -D $LOOP
+          rm disk-efi.img
+      - name: Test elemental image install
+        run: |
+          # create a 30Gb file
+          qemu-img create -f raw disk.img 30G
+          # mount loop device and get the device
+          LOOP=`sudo losetup -fP --show disk.img`
+          docker run -v /dev/:/dev/ --privileged ${{ steps.docker_build.outputs.ImageID }} install --debug -d quay.io/costoolkit/releases-green:cos-system-0.8.6 $LOOP
+          sudo losetup -D $LOOP
+          rm disk.img
+      - name: Push image  # should be a free build as everything has been cached and loaded
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          # cache into GitHub actions cache, nice
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          target: elemental
+          build-args: |
+            ELEMENTAL_VERSION=${{ steps.export_tag.outputs.elemental_tag }}
+            ELEMENTAL_COMMIT=${{ github.sha }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -36,7 +36,7 @@ jobs:
             quay.io/costoolkit/elemental-cli
           tags: |
             type=semver,pattern=v{{version}}
-            type=sha,format=short,prefix=${{ steps.export_tag.outputs.elemental_tag }}-
+            type=raw,value=latest
       - name: Docker meta for master/PR
         if: !contains(github.ref, 'refs/tags/')
         id: meta
@@ -45,8 +45,8 @@ jobs:
           images: |
             quay.io/costoolkit/elemental-cli-ci
           tags: |
-            type=semver,pattern=v{{version}}
             type=sha,format=short,prefix=${{ steps.export_tag.outputs.elemental_tag }}-
+            type=raw,value=latest
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -27,12 +27,23 @@ jobs:
           echo "Using tag $(git describe --tags `git rev-list --tags --max-count=1`  2>/dev/null || echo 'v0.0.1')"
           TAG=$(git describe --tags `git rev-list --tags --max-count=1` 2>/dev/null || echo "v0.0.1")
           echo "::set-output name=elemental_tag::$TAG"
-      - name: Docker meta
+      - name: Docker meta for tag
+        if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
         id: meta
         uses: docker/metadata-action@v3
         with:
           images: |
             quay.io/costoolkit/elemental-cli
+          tags: |
+            type=semver,pattern=v{{version}}
+            type=sha,format=short,prefix=${{ steps.export_tag.outputs.elemental_tag }}-
+      - name: Docker meta for master/PR
+        if: !contains(github.ref, 'refs/tags/')
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            quay.io/costoolkit/elemental-cli-ci
           tags: |
             type=semver,pattern=v{{version}}
             type=sha,format=short,prefix=${{ steps.export_tag.outputs.elemental_tag }}-
@@ -82,7 +93,7 @@ jobs:
           rm disk.img
       - name: Push image  # should be a free build as everything has been cached and loaded
         uses: docker/build-push-action@v2
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ github.event_name != 'pull_request' }}  # push on tag and main merge
         with:
           context: .
           push: true


### PR DESCRIPTION
Push to different places depending if its a tagged release or a master
merge.

Now that elemental-cli is more stable we no longer need to keep pushing
every master merge to our "release" repo, we cna have a different repo
to push for CI purpouses and other sources consuming development builds.

This patch makes the tagged releases push to
quay.io/costoolkit/elemental-cli and master merges push to
quay.io/costoolkit/elemental-cli-ci

Signed-off-by: Itxaka <igarcia@suse.com>