### PR TITLE
Add space after 'Downloading'

### DIFF
--- a/vendor/github.com/mudler/luet/pkg/installer/client/docker.go
+++ b/vendor/github.com/mudler/luet/pkg/installer/client/docker.go
@@ -156,7 +156,7 @@ func (c *DockerClient) DownloadFile(name string) (string, error) {
 		}
 
 		imageName := fmt.Sprintf("%s:%s", uri, helpers.SanitizeImageString(name))
-		c.context.Info("Downloading", imageName)
+		c.context.Info("Downloading ", imageName)
 
 		info, err := docker.DownloadAndExtractDockerImage(c.context, imageName, temp, c.auth, c.RepoData.Verify)
 		if err != nil {


### PR DESCRIPTION
Otherwise the log looks a bit strange:
```
Downloadingquay.io/costoolkit/releases-green:repository.yaml
```

Signed-off-by: Klaus Kämpf <kkaempf@suse.de>