### PR TITLE
Exclude /etc/resolv.conf from syncing during upgrade

### DIFF
--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -369,7 +369,7 @@ func (e *Elemental) DumpSource(target string, imgSrc *v1.ImageSource) (info inte
 			return nil, err
 		}
 	} else if imgSrc.IsDir() {
-		excludes := []string{"/mnt", "/proc", "/sys", "/dev", "/tmp", "/host", "/run"}
+		excludes := []string{"/etc/resolv.conf", "/mnt", "/proc", "/sys", "/dev", "/tmp", "/host", "/run"}
 		err = utils.SyncData(e.config.Logger, e.config.Fs, imgSrc.Value(), target, excludes...)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
/etc/resolv.conf shouldn't never be copied from source directory
to target OS image. It will be generated by network service during booting.

Fixes https://github.com/orgs/rancher/projects/9

Signed-off-by: Michal Jura <mjura@suse.com>