### PR TITLE
Add extra partitions config on installation

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -13,6 +13,16 @@ install:
   part-table: gpt
 
   # partitions setup
+  # setting a partition size key to 0 means that the partition will take over the rest of the free space on the disk
+  # after creating the rest of the partitions
+  # by default the persistent partition has a value of 0
+  # if you want any of the extra partitions to fill the rest of the space you will need to set the persistent partition
+  # size to a different value, for example
+  # partitions:
+  #   persistent:
+  #     size: 300
+
+  # default partitions
   # only 'oem', 'recovery', 'state' and 'persistent' objects allowed
   # size in MiB
   partitions:
@@ -24,6 +34,20 @@ install:
       label: COS_RECOVERY
       size: 4096
       fs: ext4
+
+  # extra partitions to create during install
+  # only size, label and fs are used
+  # if no fs is given the partition will be created but not formatted
+  # This partitions are not automounted only created and formatted
+  extra-partitions:
+    - Name: myPartition
+      size: 100
+      fs: ext4
+      label: EXTRA_PARTITION
+    - Name: myOtherPartition
+      size: 0
+      fs: ext4
+      label: EXTRA_PARTITION
 
   # no-format: true skips any disk partitioning and formatting
   # if set to true installation procedure will error out if expected

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package main
 
 import "github.com/rancher/elemental-cli/cmd"

--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -68,8 +68,7 @@ func (e *Elemental) PartitionAndFormatDevice(i *v1.InstallSpec) error {
 		return err
 	}
 
-	parts := i.Partitions.PartitionsByInstallOrder()
-
+	parts := i.Partitions.PartitionsByInstallOrder(i.ExtraPartitions)
 	return e.createPartitions(disk, parts)
 }
 

--- a/pkg/partitioner/disk.go
+++ b/pkg/partitioner/disk.go
@@ -225,7 +225,7 @@ func (dev *Disk) NewPartitionTable(label string) (string, error) {
 	return out, nil
 }
 
-//Size is expressed in MiB here
+// AddPartition adds a partition. Size is expressed in MiB here
 func (dev *Disk) AddPartition(size uint, fileSystem string, pLabel string, flags ...string) (int, error) {
 	pc := NewPartedCall(dev.String(), dev.runner)
 
@@ -323,7 +323,7 @@ func (dev Disk) FindPartitionDevice(partNum int) (string, error) {
 	return "", fmt.Errorf("could not find partition device '%s' for partition %d", device, partNum)
 }
 
-//Size is expressed in MiB here
+// ExpandLastPartition expands the latest partition in the disk. Size is expressed in MiB here
 func (dev *Disk) ExpandLastPartition(size uint) (string, error) {
 	pc := NewPartedCall(dev.String(), dev.runner)
 

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -385,7 +385,6 @@ func (ep ElementalPartitions) PartitionsByInstallOrder(extraPartitions []*Partit
 	if ep.Persistent != nil && !inExcludes(ep.Persistent, excludes...) {
 		// Check if we have to set this partition the latest due size == 0
 		if ep.Persistent.Size == 0 {
-			fmt.Printf("Setting persistent to latest")
 			lastPartition = ep.Persistent
 		} else {
 			partitions = append(partitions, ep.Persistent)
@@ -399,10 +398,8 @@ func (ep ElementalPartitions) PartitionsByInstallOrder(extraPartitions []*Partit
 			if lastPartition != nil {
 				// Ignore this part, we are not setting 2 parts to have 0 size!
 				continue
-			} else {
-				fmt.Printf("Setting %s to latest", p.Name)
-				lastPartition = p
 			}
+			lastPartition = p
 		} else {
 			partitions = append(partitions, p)
 		}

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -124,7 +124,7 @@ type RunConfig struct {
 }
 
 // Sanitize checks the consistency of the struct, returns error
-//if unsolvable inconsistencies are found
+// if unsolvable inconsistencies are found
 func (r *RunConfig) Sanitize() error {
 	return r.Config.Sanitize()
 }
@@ -506,7 +506,7 @@ type BuildConfig struct {
 }
 
 // Sanitize checks the consistency of the struct, returns error
-//if unsolvable inconsistencies are found
+// if unsolvable inconsistencies are found
 func (b *BuildConfig) Sanitize() error {
 	return b.Config.Sanitize()
 }

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -131,20 +131,21 @@ func (r *RunConfig) Sanitize() error {
 
 // InstallSpec struct represents all the installation action details
 type InstallSpec struct {
-	Target       string              `yaml:"target,omitempty" mapstructure:"target"`
-	Firmware     string              `yaml:"firmware,omitempty" mapstructure:"firmware"`
-	PartTable    string              `yaml:"part-table,omitempty" mapstructure:"part-table"`
-	Partitions   ElementalPartitions `yaml:"partitions,omitempty" mapstructure:"partitions"`
-	NoFormat     bool                `yaml:"no-format,omitempty" mapstructure:"no-format"`
-	Force        bool                `yaml:"force,omitempty" mapstructure:"force"`
-	CloudInit    []string            `yaml:"cloud-init,omitempty" mapstructure:"cloud-init"`
-	Iso          string              `yaml:"iso,omitempty" mapstructure:"iso"`
-	GrubDefEntry string              `yaml:"grub-entry-name,omitempty" mapstructure:"grub-entry-name"`
-	Tty          string              `yaml:"tty,omitempty" mapstructure:"tty"`
-	Active       Image               `yaml:"system,omitempty" mapstructure:"system"`
-	Recovery     Image               `yaml:"recovery-system,omitempty" mapstructure:"recovery-system"`
-	Passive      Image
-	GrubConf     string
+	Target          string              `yaml:"target,omitempty" mapstructure:"target"`
+	Firmware        string              `yaml:"firmware,omitempty" mapstructure:"firmware"`
+	PartTable       string              `yaml:"part-table,omitempty" mapstructure:"part-table"`
+	Partitions      ElementalPartitions `yaml:"partitions,omitempty" mapstructure:"partitions"`
+	ExtraPartitions []*Partition        `yaml:"extra-partitions,omitempty" mapstructure:"extra-partitions"`
+	NoFormat        bool                `yaml:"no-format,omitempty" mapstructure:"no-format"`
+	Force           bool                `yaml:"force,omitempty" mapstructure:"force"`
+	CloudInit       []string            `yaml:"cloud-init,omitempty" mapstructure:"cloud-init"`
+	Iso             string              `yaml:"iso,omitempty" mapstructure:"iso"`
+	GrubDefEntry    string              `yaml:"grub-entry-name,omitempty" mapstructure:"grub-entry-name"`
+	Tty             string              `yaml:"tty,omitempty" mapstructure:"tty"`
+	Active          Image               `yaml:"system,omitempty" mapstructure:"system"`
+	Recovery        Image               `yaml:"recovery-system,omitempty" mapstructure:"recovery-system"`
+	Passive         Image
+	GrubConf        string
 }
 
 // Sanitize checks the consistency of the struct, returns error
@@ -165,6 +166,22 @@ func (i *InstallSpec) Sanitize() error {
 		i.Recovery.File = filepath.Join(recoveryMnt, "cOS", constants.RecoverySquashFile)
 	} else {
 		i.Recovery.File = filepath.Join(recoveryMnt, "cOS", constants.RecoveryImgFile)
+	}
+
+	// Check for extra partitions having set its size to 0
+	extraPartsSizeCheck := 0
+	for _, p := range i.ExtraPartitions {
+		if p.Size == 0 {
+			extraPartsSizeCheck++
+		}
+	}
+
+	if extraPartsSizeCheck > 1 {
+		return fmt.Errorf("more than one extra partition has its size set to 0. Only one partition can have its size set to 0 which means that it will take all the available disk space in the device")
+	}
+	// Check for both an extra partition and the persistent partition having size set to 0
+	if extraPartsSizeCheck == 1 && i.Partitions.Persistent.Size == 0 {
+		return fmt.Errorf("both persistent partition and extra partitions have size set to 0. Only one partition can have its size set to 0 which means that it will take all the available disk space in the device")
 	}
 	return i.Partitions.SetFirmwarePartitions(i.Firmware, i.PartTable)
 }
@@ -336,8 +353,10 @@ func NewElementalPartitionsFromList(pl PartitionList) ElementalPartitions {
 
 // PartitionsByInstallOrder sorts partitions according to the default layout
 // nil partitons are ignored
-func (ep ElementalPartitions) PartitionsByInstallOrder(excludes ...*Partition) PartitionList {
+// partition with 0 size is set last
+func (ep ElementalPartitions) PartitionsByInstallOrder(extraPartitions []*Partition, excludes ...*Partition) PartitionList {
 	partitions := PartitionList{}
+	var lastPartition *Partition
 
 	inExcludes := func(part *Partition, list ...*Partition) bool {
 		for _, p := range list {
@@ -364,8 +383,34 @@ func (ep ElementalPartitions) PartitionsByInstallOrder(excludes ...*Partition) P
 		partitions = append(partitions, ep.State)
 	}
 	if ep.Persistent != nil && !inExcludes(ep.Persistent, excludes...) {
-		partitions = append(partitions, ep.Persistent)
+		// Check if we have to set this partition the latest due size == 0
+		if ep.Persistent.Size == 0 {
+			fmt.Printf("Setting persistent to latest")
+			lastPartition = ep.Persistent
+		} else {
+			partitions = append(partitions, ep.Persistent)
+		}
 	}
+	for _, p := range extraPartitions {
+		// Check if we have to set this partition the latest due size == 0
+		// Also check that we didn't set already the persistent to last in which case ignore this
+		// InstallConfig.Sanitize should have already taken care of failing if this is the case, so this is extra protection
+		if p.Size == 0 {
+			if lastPartition != nil {
+				// Ignore this part, we are not setting 2 parts to have 0 size!
+				continue
+			} else {
+				fmt.Printf("Setting %s to latest", p.Name)
+				lastPartition = p
+			}
+		} else {
+			partitions = append(partitions, p)
+		}
+	}
+
+	// Set the last partition in the list the partition which has 0 size, so it grows to use the rest of free space
+	partitions = append(partitions, lastPartition)
+
 	return partitions
 }
 
@@ -376,7 +421,7 @@ func (ep ElementalPartitions) PartitionsByMountPoint(descending bool, excludes .
 	mountPoints := []string{}
 	partitions := PartitionList{}
 
-	for _, p := range ep.PartitionsByInstallOrder(excludes...) {
+	for _, p := range ep.PartitionsByInstallOrder([]*Partition{}, excludes...) {
 		if p.MountPoint != "" {
 			mountPointKeys[p.MountPoint] = p
 			mountPoints = append(mountPoints, p.MountPoint)

--- a/pkg/types/v1/config_test.go
+++ b/pkg/types/v1/config_test.go
@@ -196,7 +196,7 @@ var _ = Describe("Types", Label("types", "config"), func() {
 			err := ep.SetFirmwarePartitions(v1.BIOS, v1.MSDOS)
 			Expect(err).Should(HaveOccurred())
 		})
-		It("initalized an ElementalPartitions from a PartitionList", func() {
+		It("initializes an ElementalPartitions from a PartitionList", func() {
 			ep := v1.NewElementalPartitionsFromList(p)
 			Expect(ep.Persistent != nil).To(BeTrue())
 			Expect(ep.OEM != nil).To(BeTrue())
@@ -205,13 +205,62 @@ var _ = Describe("Types", Label("types", "config"), func() {
 			Expect(ep.State == nil).To(BeTrue())
 			Expect(ep.Recovery == nil).To(BeTrue())
 		})
-		It("returns a partition list by install order", func() {
-			ep := v1.NewElementalPartitionsFromList(p)
-			lst := ep.PartitionsByInstallOrder()
-			Expect(len(lst)).To(Equal(2))
-			Expect(lst[0].Name == "oem").To(BeTrue())
-			Expect(lst[1].Name == "persistent").To(BeTrue())
+		Describe("returns a partition list by install order", Focus, func() {
+			It("with no extra parts", func() {
+				ep := v1.NewElementalPartitionsFromList(p)
+				lst := ep.PartitionsByInstallOrder([]*v1.Partition{})
+				Expect(len(lst)).To(Equal(2))
+				Expect(lst[0].Name == "oem").To(BeTrue())
+				Expect(lst[1].Name == "persistent").To(BeTrue())
+			})
+			It("with extra parts with size > 0", func() {
+				ep := v1.NewElementalPartitionsFromList(p)
+				var extraParts []*v1.Partition
+				extraParts = append(extraParts, &v1.Partition{Name: "extra", Size: 5})
+
+				lst := ep.PartitionsByInstallOrder(extraParts)
+				Expect(len(lst)).To(Equal(3))
+				Expect(lst[0].Name == "oem").To(BeTrue())
+				Expect(lst[1].Name == "extra").To(BeTrue())
+				Expect(lst[2].Name == "persistent").To(BeTrue())
+			})
+			It("with extra part with size == 0 and persistent.Size == 0", func() {
+				ep := v1.NewElementalPartitionsFromList(p)
+				var extraParts []*v1.Partition
+				extraParts = append(extraParts, &v1.Partition{Name: "extra", Size: 0})
+				lst := ep.PartitionsByInstallOrder(extraParts)
+				// Should ignore the wrong partition had have the persistent over it
+				Expect(len(lst)).To(Equal(2))
+				Expect(lst[0].Name == "oem").To(BeTrue())
+				Expect(lst[1].Name == "persistent").To(BeTrue())
+			})
+			It("with extra part with size == 0 and persistent.Size > 0", func() {
+				ep := v1.NewElementalPartitionsFromList(p)
+				ep.Persistent.Size = 10
+				var extraParts []*v1.Partition
+				extraParts = append(extraParts, &v1.Partition{Name: "extra", FilesystemLabel: "LABEL", Size: 0})
+				lst := ep.PartitionsByInstallOrder(extraParts)
+				// Will have our size == 0 partition the latest
+				Expect(len(lst)).To(Equal(3))
+				Expect(lst[0].Name == "oem").To(BeTrue())
+				Expect(lst[1].Name == "persistent").To(BeTrue())
+				Expect(lst[2].Name == "extra").To(BeTrue())
+			})
+			It("with several extra parts with size == 0 and persistent.Size > 0", func() {
+				ep := v1.NewElementalPartitionsFromList(p)
+				ep.Persistent.Size = 10
+				var extraParts []*v1.Partition
+				extraParts = append(extraParts, &v1.Partition{Name: "extra1", Size: 0})
+				extraParts = append(extraParts, &v1.Partition{Name: "extra2", Size: 0})
+				lst := ep.PartitionsByInstallOrder(extraParts)
+				// Should ignore the wrong partition had have the first partition with size 0 added last
+				Expect(len(lst)).To(Equal(3))
+				Expect(lst[0].Name == "oem").To(BeTrue())
+				Expect(lst[1].Name == "persistent").To(BeTrue())
+				Expect(lst[2].Name == "extra1").To(BeTrue())
+			})
 		})
+
 		It("returns a partition list by mount order", func() {
 			ep := v1.NewElementalPartitionsFromList(p)
 			lst := ep.PartitionsByMountPoint(false)
@@ -307,40 +356,68 @@ var _ = Describe("Types", Label("types", "config"), func() {
 		})
 	})
 	Describe("InstallSpec", func() {
-		It("runs sanitize method", func() {
+		var spec *v1.InstallSpec
+
+		BeforeEach(func() {
 			cfg := config.NewConfig(config.WithMounter(v1mocks.NewErrorMounter()))
-			spec := config.NewInstallSpec(*cfg)
-			Expect(spec.Partitions.EFI).To(BeNil())
-			Expect(spec.Active.Source.IsEmpty()).To(BeTrue())
+			spec = config.NewInstallSpec(*cfg)
+		})
+		Describe("sanitize", func() {
+			It("runs method", func() {
+				Expect(spec.Partitions.EFI).To(BeNil())
+				Expect(spec.Active.Source.IsEmpty()).To(BeTrue())
 
-			// Creates firmware partitions
-			spec.Active.Source = v1.NewDirSrc("/dir")
-			spec.Firmware = v1.EFI
-			err := spec.Sanitize()
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(spec.Partitions.EFI).NotTo(BeNil())
+				// Creates firmware partitions
+				spec.Active.Source = v1.NewDirSrc("/dir")
+				spec.Firmware = v1.EFI
+				err := spec.Sanitize()
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(spec.Partitions.EFI).NotTo(BeNil())
 
-			// Sets recovery image file to squashfs file
-			spec.Recovery.FS = constants.SquashFs
-			err = spec.Sanitize()
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(spec.Recovery.File).To(ContainSubstring(constants.RecoverySquashFile))
+				// Sets recovery image file to squashfs file
+				spec.Recovery.FS = constants.SquashFs
+				err = spec.Sanitize()
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(spec.Recovery.File).To(ContainSubstring(constants.RecoverySquashFile))
 
-			// Sets recovery image file to img file
-			spec.Recovery.FS = constants.LinuxImgFs
-			err = spec.Sanitize()
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(spec.Recovery.File).To(ContainSubstring(constants.RecoveryImgFile))
+				// Sets recovery image file to img file
+				spec.Recovery.FS = constants.LinuxImgFs
+				err = spec.Sanitize()
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(spec.Recovery.File).To(ContainSubstring(constants.RecoveryImgFile))
 
-			// Fails without state partition
-			spec.Partitions.State = nil
-			err = spec.Sanitize()
-			Expect(err).Should(HaveOccurred())
+				// Fails without state partition
+				spec.Partitions.State = nil
+				err = spec.Sanitize()
+				Expect(err).Should(HaveOccurred())
 
-			// Fails without an install source
-			spec.Active.Source = v1.NewEmptySrc()
-			err = spec.Sanitize()
-			Expect(err).Should(HaveOccurred())
+				// Fails without an install source
+				spec.Active.Source = v1.NewEmptySrc()
+				err = spec.Sanitize()
+				Expect(err).Should(HaveOccurred())
+			})
+			Describe("with extra partitions", func() {
+				It("fails if persistent and an extra partition have size == 0", func() {
+					spec.ExtraPartitions = append(spec.ExtraPartitions, &v1.Partition{Size: 0})
+					err := spec.Sanitize()
+					Expect(err).Should(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("both persistent partition and extra partitions have size set to 0"))
+				})
+				It("fails if more than one extra partition has size == 0", func() {
+					spec.Partitions.Persistent.Size = 10
+					spec.ExtraPartitions = append(spec.ExtraPartitions, &v1.Partition{Name: "1", Size: 0})
+					spec.ExtraPartitions = append(spec.ExtraPartitions, &v1.Partition{Name: "2", Size: 0})
+					err := spec.Sanitize()
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("more than one extra partition has its size set to 0"))
+				})
+				It("does not fail if persistent size is > 0 and an extra partition has size == 0", func() {
+					spec.ExtraPartitions = append(spec.ExtraPartitions, &v1.Partition{Size: 0})
+					spec.Partitions.Persistent.Size = 10
+					err := spec.Sanitize()
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
 		})
 	})
 	Describe("ResetSpec", func() {

--- a/pkg/types/v1/config_test.go
+++ b/pkg/types/v1/config_test.go
@@ -205,7 +205,7 @@ var _ = Describe("Types", Label("types", "config"), func() {
 			Expect(ep.State == nil).To(BeTrue())
 			Expect(ep.Recovery == nil).To(BeTrue())
 		})
-		Describe("returns a partition list by install order", Focus, func() {
+		Describe("returns a partition list by install order", func() {
 			It("with no extra parts", func() {
 				ep := v1.NewElementalPartitionsFromList(p)
 				lst := ep.PartitionsByInstallOrder([]*v1.Partition{})
@@ -397,6 +397,10 @@ var _ = Describe("Types", Label("types", "config"), func() {
 				Expect(err).Should(HaveOccurred())
 			})
 			Describe("with extra partitions", func() {
+				BeforeEach(func() {
+					// Set a source for the install
+					spec.Active.Source = v1.NewDirSrc("/dir")
+				})
 				It("fails if persistent and an extra partition have size == 0", func() {
 					spec.ExtraPartitions = append(spec.ExtraPartitions, &v1.Partition{Size: 0})
 					err := spec.Sanitize()


### PR DESCRIPTION
This adds a new key to the install config that allows to pass a list of
extra partitions to add during install.

Same keys as the usual partitions exists, name, label, fs, mountpoint,
etc..

Also allows to override the sizes and reorders the partition creation to
take that into account, as the partition with size == 0 (which means use
all the free space available) has to go the last.

This allows creating extra partitions with size 0 and will reorder the
partitions properly to account for this. Also forbids having several
partitions with size == 0 or a persistent and extra partition with both
having size == 0

Fixes https://github.com/rancher/elemental-cli/issues/304


Signed-off-by: Itxaka <igarcia@suse.com>