### PR TITLE
Drop luet init from BuildConfig

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -37,7 +37,6 @@ import (
 	"github.com/rancher/elemental-cli/internal/version"
 	"github.com/rancher/elemental-cli/pkg/config"
 	"github.com/rancher/elemental-cli/pkg/constants"
-	"github.com/rancher/elemental-cli/pkg/luet"
 	v1 "github.com/rancher/elemental-cli/pkg/types/v1"
 	"github.com/rancher/elemental-cli/pkg/utils"
 )
@@ -106,12 +105,9 @@ func ReadConfigBuild(configDir string, flags *pflag.FlagSet, mounter mount.Inter
 		configDir = "."
 	}
 
-	l := luet.NewLuet(luet.WithLogger(logger))
-
 	cfg := config.NewBuildConfig(
 		config.WithLogger(logger),
 		config.WithMounter(mounter),
-		config.WithLuet(l),
 	)
 
 	configLogger(cfg.Logger, cfg.Fs)

--- a/pkg/luet/luet.go
+++ b/pkg/luet/luet.go
@@ -382,6 +382,7 @@ func (l Luet) createLuetConfig() *luetTypes.LuetConfig {
 	if l.TmpDir != "" {
 		config.System.TmpDirBase = l.TmpDir
 		config.System.PkgsCachePath = l.TmpDir
+		config.System.DatabasePath = l.TmpDir
 	}
 	return config
 }


### PR DESCRIPTION
We are already calling NewConfig inside BuildConfig and that will make
sure that a luet instance is properly created.

This fixes the issue of having temp files in the dir running elemental
as the BuildConfig luet was misconfigured with no tempDir and no FS

Fixes #175 

Signed-off-by: Itxaka <igarcia@suse.com>