### PR TITLE
Fix GO-2022-0586

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/distribution/distribution v2.8.1+incompatible
 	github.com/docker/docker v20.10.17+incompatible
 	github.com/docker/go-units v0.4.0
-	github.com/hashicorp/go-getter v1.5.11
+	github.com/hashicorp/go-getter v1.6.1
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/jaypipes/ghw v0.9.1-0.20220511134554-dac2f19e1c76
 	github.com/joho/godotenv v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -928,6 +928,8 @@ github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9n
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-getter v1.5.11 h1:wioTuNmaBU3IE9vdFtFMcmZWj0QzLc6DYaP6sNe5onY=
 github.com/hashicorp/go-getter v1.5.11/go.mod h1:9i48BP6wpWweI/0/+FBjqLrp9S8XtwUGjiu0QkWHEaY=
+github.com/hashicorp/go-getter v1.6.1 h1:NASsgP4q6tL94WH6nJxKWj8As2H/2kop/bB1d8JMyRY=
+github.com/hashicorp/go-getter v1.6.1/go.mod h1:IZCrswsZPeWv9IkVnLElzRU/gz/QPi6pZHn4tv6vbwA=
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-hclog v0.12.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-hclog v1.0.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
@@ -2117,6 +2119,7 @@ golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220408201424-a24fb2fb8a0f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220422013727-9388b58f7150/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220517195934-5e4e11fc645e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e h1:CsOuNlbOuf0mzxJIefr6Q4uAUetRUwZE4qt7VfzP+xo=
 golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/vendor/github.com/hashicorp/go-getter/client_option.go
+++ b/vendor/github.com/hashicorp/go-getter/client_option.go
@@ -1,46 +1,100 @@
 package getter
 
-import "context"
+import (
+	"context"
+	"os"
+)
 
-// A ClientOption allows to configure a client
+// ClientOption is used to configure a client.
 type ClientOption func(*Client) error
 
-// Configure configures a client with options.
+// Configure applies all of the given client options, along with any default
+// behavior including context, decompressors, detectors, and getters used by
+// the client.
 func (c *Client) Configure(opts ...ClientOption) error {
+	// If the context has not been configured use the background context.
 	if c.Ctx == nil {
 		c.Ctx = context.Background()
 	}
+
+	// Store the options used to configure this client.
 	c.Options = opts
+
+	// Apply all of the client options.
 	for _, opt := range opts {
 		err := opt(c)
 		if err != nil {
 			return err
 		}
 	}
-	// Default decompressor values
+
+	// If the client was not configured with any Decompressors, Detectors,
+	// or Getters, use the default values for each.
 	if c.Decompressors == nil {
 		c.Decompressors = Decompressors
 	}
-	// Default detector values
 	if c.Detectors == nil {
 		c.Detectors = Detectors
 	}
-	// Default getter values
 	if c.Getters == nil {
 		c.Getters = Getters
 	}
 
+	// Set the client for each getter, so the top-level client can know
+	// the getter-specific client functions or progress tracking.
 	for _, getter := range c.Getters {
 		getter.SetClient(c)
 	}
+
 	return nil
 }
 
 // WithContext allows to pass a context to operation
 // in order to be able to cancel a download in progress.
-func WithContext(ctx context.Context) func(*Client) error {
+func WithContext(ctx context.Context) ClientOption {
 	return func(c *Client) error {
 		c.Ctx = ctx
+		return nil
+	}
+}
+
+// WithDecompressors specifies which Decompressor are available.
+func WithDecompressors(decompressors map[string]Decompressor) ClientOption {
+	return func(c *Client) error {
+		c.Decompressors = decompressors
+		return nil
+	}
+}
+
+// WithDecompressors specifies which compressors are available.
+func WithDetectors(detectors []Detector) ClientOption {
+	return func(c *Client) error {
+		c.Detectors = detectors
+		return nil
+	}
+}
+
+// WithGetters specifies which getters are available.
+func WithGetters(getters map[string]Getter) ClientOption {
+	return func(c *Client) error {
+		c.Getters = getters
+		return nil
+	}
+}
+
+// WithMode specifies which client mode the getters should operate in.
+func WithMode(mode ClientMode) ClientOption {
+	return func(c *Client) error {
+		c.Mode = mode
+		return nil
+	}
+}
+
+// WithUmask specifies how to mask file permissions when storing local
+// files or decompressing an archive.
+func WithUmask(mode os.FileMode) ClientOption {
+	return func(c *Client) error {
+		c.Umask = mode
 		return nil
 	}
 }

--- a/vendor/github.com/hashicorp/go-getter/copy_dir.go
+++ b/vendor/github.com/hashicorp/go-getter/copy_dir.go
@@ -2,6 +2,7 @@ package getter
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,8 +17,11 @@ func mode(mode, umask os.FileMode) os.FileMode {
 // should already exist.
 //
 // If ignoreDot is set to true, then dot-prefixed files/folders are ignored.
-func copyDir(ctx context.Context, dst string, src string, ignoreDot bool, umask os.FileMode) error {
-	src, err := filepath.EvalSymlinks(src)
+func copyDir(ctx context.Context, dst string, src string, ignoreDot bool, disableSymlinks bool, umask os.FileMode) error {
+	// We can safely evaluate the symlinks here, even if disabled, because they
+	// will be checked before actual use in walkFn and copyFile
+	var err error
+	src, err = filepath.EvalSymlinks(src)
 	if err != nil {
 		return err
 	}
@@ -26,6 +30,20 @@ func copyDir(ctx context.Context, dst string, src string, ignoreDot bool, umask 
 		if err != nil {
 			return err
 		}
+
+		if disableSymlinks {
+			fileInfo, err := os.Lstat(path)
+			if err != nil {
+				return fmt.Errorf("failed to check copy file source for symlinks: %w", err)
+			}
+			if fileInfo.Mode()&os.ModeSymlink == os.ModeSymlink {
+				return ErrSymlinkCopy
+			}
+			// if info.Mode()&os.ModeSymlink == os.ModeSymlink {
+			// 	return ErrSymlinkCopy
+			// }
+		}
+
 		if path == src {
 			return nil
 		}
@@ -59,7 +77,7 @@ func copyDir(ctx context.Context, dst string, src string, ignoreDot bool, umask 
 		}
 
 		// If we have a file, copy the contents.
-		_, err = copyFile(ctx, dstPath, path, info.Mode(), umask)
+		_, err = copyFile(ctx, dstPath, path, disableSymlinks, info.Mode(), umask)
 		return err
 	}
 

--- a/vendor/github.com/hashicorp/go-getter/decompress_zip.go
+++ b/vendor/github.com/hashicorp/go-getter/decompress_zip.go
@@ -74,7 +74,9 @@ func (d *ZipDecompressor) Decompress(dst, src string, dir bool, umask os.FileMod
 		// Open the file for reading
 		srcF, err := f.Open()
 		if err != nil {
-			srcF.Close()
+			if srcF != nil {
+				srcF.Close()
+			}
 			return err
 		}
 

--- a/vendor/github.com/hashicorp/go-getter/get_file_unix.go
+++ b/vendor/github.com/hashicorp/go-getter/get_file_unix.go
@@ -87,7 +87,13 @@ func (g *FileGetter) GetFile(dst string, u *url.URL) error {
 		return os.Symlink(path, dst)
 	}
 
+	var disableSymlinks bool
+
+	if g.client != nil && g.client.DisableSymlinks {
+		disableSymlinks = true
+	}
+
 	// Copy
-	_, err = copyFile(ctx, dst, path, fi.Mode(), g.client.umask())
+	_, err = copyFile(ctx, dst, path, disableSymlinks, fi.Mode(), g.client.umask())
 	return err
 }

--- a/vendor/github.com/hashicorp/go-getter/get_file_windows.go
+++ b/vendor/github.com/hashicorp/go-getter/get_file_windows.go
@@ -111,8 +111,14 @@ func (g *FileGetter) GetFile(dst string, u *url.URL) error {
 		}
 	}
 
+	var disableSymlinks bool
+
+	if g.client != nil && g.client.DisableSymlinks {
+		disableSymlinks = true
+	}
+
 	// Copy
-	_, err = copyFile(ctx, dst, path, 0666, g.client.umask())
+	_, err = copyFile(ctx, dst, path, disableSymlinks, 0666, g.client.umask())
 	return err
 }
 

--- a/vendor/github.com/hashicorp/go-getter/get_gcs.go
+++ b/vendor/github.com/hashicorp/go-getter/get_gcs.go
@@ -3,13 +3,15 @@ package getter
 import (
 	"context"
 	"fmt"
-	"golang.org/x/oauth2"
-	"google.golang.org/api/option"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
+
+	"golang.org/x/oauth2"
+	"google.golang.org/api/option"
 
 	"cloud.google.com/go/storage"
 	"google.golang.org/api/iterator"
@@ -19,10 +21,20 @@ import (
 // a GCS bucket.
 type GCSGetter struct {
 	getter
+
+	// Timeout sets a deadline which all GCS operations should
+	// complete within. Zero value means no timeout.
+	Timeout time.Duration
 }
 
 func (g *GCSGetter) ClientMode(u *url.URL) (ClientMode, error) {
 	ctx := g.Context()
+
+	if g.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, g.Timeout)
+		defer cancel()
+	}
 
 	// Parse URL
 	bucket, object, _, err := g.parseURL(u)
@@ -60,6 +72,12 @@ func (g *GCSGetter) ClientMode(u *url.URL) (ClientMode, error) {
 
 func (g *GCSGetter) Get(dst string, u *url.URL) error {
 	ctx := g.Context()
+
+	if g.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, g.Timeout)
+		defer cancel()
+	}
 
 	// Parse URL
 	bucket, object, _, err := g.parseURL(u)
@@ -119,6 +137,12 @@ func (g *GCSGetter) Get(dst string, u *url.URL) error {
 
 func (g *GCSGetter) GetFile(dst string, u *url.URL) error {
 	ctx := g.Context()
+
+	if g.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, g.Timeout)
+		defer cancel()
+	}
 
 	// Parse URL
 	bucket, object, fragment, err := g.parseURL(u)

--- a/vendor/github.com/hashicorp/go-getter/get_git.go
+++ b/vendor/github.com/hashicorp/go-getter/get_git.go
@@ -14,6 +14,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	urlhelper "github.com/hashicorp/go-getter/helper/url"
 	safetemp "github.com/hashicorp/go-safetemp"
@@ -24,6 +25,10 @@ import (
 // a git repository.
 type GitGetter struct {
 	getter
+
+	// Timeout sets a deadline which all git CLI operations should
+	// complete within. Zero value means no timeout.
+	Timeout time.Duration
 }
 
 var defaultBranchRegexp = regexp.MustCompile(`\s->\sorigin/(.*)`)
@@ -35,6 +40,13 @@ func (g *GitGetter) ClientMode(_ *url.URL) (ClientMode, error) {
 
 func (g *GitGetter) Get(dst string, u *url.URL) error {
 	ctx := g.Context()
+
+	if g.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, g.Timeout)
+		defer cancel()
+	}
+
 	if _, err := exec.LookPath("git"); err != nil {
 		return fmt.Errorf("git must be available and on the PATH")
 	}
@@ -76,7 +88,7 @@ func (g *GitGetter) Get(dst string, u *url.URL) error {
 	var sshKeyFile string
 	if sshKey != "" {
 		// Check that the git version is sufficiently new.
-		if err := checkGitVersion("2.3"); err != nil {
+		if err := checkGitVersion(ctx, "2.3"); err != nil {
 			return fmt.Errorf("Error using ssh key: %v", err)
 		}
 
@@ -123,7 +135,7 @@ func (g *GitGetter) Get(dst string, u *url.URL) error {
 
 	// Next: check out the proper tag/branch if it is specified, and checkout
 	if ref != "" {
-		if err := g.checkout(dst, ref); err != nil {
+		if err := g.checkout(ctx, dst, ref); err != nil {
 			return err
 		}
 	}
@@ -161,8 +173,8 @@ func (g *GitGetter) GetFile(dst string, u *url.URL) error {
 	return fg.GetFile(dst, u)
 }
 
-func (g *GitGetter) checkout(dst string, ref string) error {
-	cmd := exec.Command("git", "checkout", ref)
+func (g *GitGetter) checkout(ctx context.Context, dst string, ref string) error {
+	cmd := exec.CommandContext(ctx, "git", "checkout", ref)
 	cmd.Dir = dst
 	return getRunCommand(cmd)
 }
@@ -182,7 +194,7 @@ func (g *GitGetter) clone(ctx context.Context, dst, sshKeyFile string, u *url.UR
 
 	originalRef := ref // we handle an unspecified ref differently than explicitly selecting the default branch below
 	if ref == "" {
-		ref = findRemoteDefaultBranch(u)
+		ref = findRemoteDefaultBranch(ctx, u)
 	}
 	if depth > 0 {
 		args = append(args, "--depth", strconv.Itoa(depth))
@@ -211,7 +223,7 @@ func (g *GitGetter) clone(ctx context.Context, dst, sshKeyFile string, u *url.UR
 		// If we didn't add --depth and --branch above then we will now be
 		// on the remote repository's default branch, rather than the selected
 		// ref, so we'll need to fix that before we return.
-		return g.checkout(dst, originalRef)
+		return g.checkout(ctx, dst, originalRef)
 	}
 	return nil
 }
@@ -226,18 +238,18 @@ func (g *GitGetter) update(ctx context.Context, dst, sshKeyFile, ref string, dep
 		// Not a branch, switch to default branch. This will also catch
 		// non-existent branches, in which case we want to switch to default
 		// and then checkout the proper branch later.
-		ref = findDefaultBranch(dst)
+		ref = findDefaultBranch(ctx, dst)
 	}
 
 	// We have to be on a branch to pull
-	if err := g.checkout(dst, ref); err != nil {
+	if err := g.checkout(ctx, dst, ref); err != nil {
 		return err
 	}
 
 	if depth > 0 {
-		cmd = exec.Command("git", "pull", "--depth", strconv.Itoa(depth), "--ff-only")
+		cmd = exec.CommandContext(ctx, "git", "pull", "--depth", strconv.Itoa(depth), "--ff-only")
 	} else {
-		cmd = exec.Command("git", "pull", "--ff-only")
+		cmd = exec.CommandContext(ctx, "git", "pull", "--ff-only")
 	}
 
 	cmd.Dir = dst
@@ -260,9 +272,9 @@ func (g *GitGetter) fetchSubmodules(ctx context.Context, dst, sshKeyFile string,
 // findDefaultBranch checks the repo's origin remote for its default branch
 // (generally "master"). "master" is returned if an origin default branch
 // can't be determined.
-func findDefaultBranch(dst string) string {
+func findDefaultBranch(ctx context.Context, dst string) string {
 	var stdoutbuf bytes.Buffer
-	cmd := exec.Command("git", "branch", "-r", "--points-at", "refs/remotes/origin/HEAD")
+	cmd := exec.CommandContext(ctx, "git", "branch", "-r", "--points-at", "refs/remotes/origin/HEAD")
 	cmd.Dir = dst
 	cmd.Stdout = &stdoutbuf
 	err := cmd.Run()
@@ -275,9 +287,9 @@ func findDefaultBranch(dst string) string {
 
 // findRemoteDefaultBranch checks the remote repo's HEAD symref to return the remote repo's
 // default branch. "master" is returned if no HEAD symref exists.
-func findRemoteDefaultBranch(u *url.URL) string {
+func findRemoteDefaultBranch(ctx context.Context, u *url.URL) string {
 	var stdoutbuf bytes.Buffer
-	cmd := exec.Command("git", "ls-remote", "--symref", u.String(), "HEAD")
+	cmd := exec.CommandContext(ctx, "git", "ls-remote", "--symref", u.String(), "HEAD")
 	cmd.Stdout = &stdoutbuf
 	err := cmd.Run()
 	matches := lsRemoteSymRefRegexp.FindStringSubmatch(stdoutbuf.String())
@@ -326,13 +338,13 @@ func setupGitEnv(cmd *exec.Cmd, sshKeyFile string) {
 // checkGitVersion is used to check the version of git installed on the system
 // against a known minimum version. Returns an error if the installed version
 // is older than the given minimum.
-func checkGitVersion(min string) error {
+func checkGitVersion(ctx context.Context, min string) error {
 	want, err := version.NewVersion(min)
 	if err != nil {
 		return err
 	}
 
-	out, err := exec.Command("git", "version").Output()
+	out, err := exec.CommandContext(ctx, "git", "version").Output()
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/hashicorp/go-getter/get_hg.go
+++ b/vendor/github.com/hashicorp/go-getter/get_hg.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"time"
 
 	urlhelper "github.com/hashicorp/go-getter/helper/url"
 	safetemp "github.com/hashicorp/go-safetemp"
@@ -17,6 +18,10 @@ import (
 // a Mercurial repository.
 type HgGetter struct {
 	getter
+
+	// Timeout sets a deadline which all hg CLI operations should
+	// complete within. Zero value means no timeout.
+	Timeout time.Duration
 }
 
 func (g *HgGetter) ClientMode(_ *url.URL) (ClientMode, error) {
@@ -25,6 +30,13 @@ func (g *HgGetter) ClientMode(_ *url.URL) (ClientMode, error) {
 
 func (g *HgGetter) Get(dst string, u *url.URL) error {
 	ctx := g.Context()
+
+	if g.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, g.Timeout)
+		defer cancel()
+	}
+
 	if _, err := exec.LookPath("hg"); err != nil {
 		return fmt.Errorf("hg must be available and on the PATH")
 	}
@@ -53,12 +65,12 @@ func (g *HgGetter) Get(dst string, u *url.URL) error {
 		return err
 	}
 	if err != nil {
-		if err := g.clone(dst, newURL); err != nil {
+		if err := g.clone(ctx, dst, newURL); err != nil {
 			return err
 		}
 	}
 
-	if err := g.pull(dst, newURL); err != nil {
+	if err := g.pull(ctx, dst, newURL); err != nil {
 		return err
 	}
 
@@ -101,13 +113,13 @@ func (g *HgGetter) GetFile(dst string, u *url.URL) error {
 	return fg.GetFile(dst, u)
 }
 
-func (g *HgGetter) clone(dst string, u *url.URL) error {
-	cmd := exec.Command("hg", "clone", "-U", u.String(), dst)
+func (g *HgGetter) clone(ctx context.Context, dst string, u *url.URL) error {
+	cmd := exec.CommandContext(ctx, "hg", "clone", "-U", "--", u.String(), dst)
 	return getRunCommand(cmd)
 }
 
-func (g *HgGetter) pull(dst string, u *url.URL) error {
-	cmd := exec.Command("hg", "pull")
+func (g *HgGetter) pull(ctx context.Context, dst string, u *url.URL) error {
+	cmd := exec.CommandContext(ctx, "hg", "pull")
 	cmd.Dir = dst
 	return getRunCommand(cmd)
 }
@@ -115,7 +127,7 @@ func (g *HgGetter) pull(dst string, u *url.URL) error {
 func (g *HgGetter) update(ctx context.Context, dst string, u *url.URL, rev string) error {
 	args := []string{"update"}
 	if rev != "" {
-		args = append(args, rev)
+		args = append(args, "--", rev)
 	}
 
 	cmd := exec.CommandContext(ctx, "hg", args...)

--- a/vendor/github.com/hashicorp/go-getter/go.mod
+++ b/vendor/github.com/hashicorp/go-getter/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/stretchr/testify v1.2.2 // indirect
 	github.com/ulikunitz/xz v0.5.8
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
+	golang.org/x/sys v0.0.0-20220517195934-5e4e11fc645e // indirect
 	google.golang.org/api v0.9.0
 	gopkg.in/cheggaaa/pb.v1 v1.0.27 // indirect
 )

--- a/vendor/github.com/hashicorp/go-getter/go.sum
+++ b/vendor/github.com/hashicorp/go-getter/go.sum
@@ -114,6 +114,8 @@ golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0 h1:HyfiK1WMnHj5FXFXatD+Qs1A/xC2Run6RzeW1SyHxpc=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220517195934-5e4e11fc645e h1:w36l2Uw3dRan1K3TyXriXvY+6T56GNmlKGcqiQUJDfM=
+golang.org/x/sys v0.0.0-20220517195934-5e4e11fc645e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=

--- a/vendor/github.com/hashicorp/go-getter/source.go
+++ b/vendor/github.com/hashicorp/go-getter/source.go
@@ -58,7 +58,9 @@ func SourceDirSubdir(src string) (string, string) {
 //
 // The returned path is the full absolute path.
 func SubdirGlob(dst, subDir string) (string, error) {
-	matches, err := filepath.Glob(filepath.Join(dst, subDir))
+	pattern := filepath.Join(dst, subDir)
+
+	matches, err := filepath.Glob(pattern)
 	if err != nil {
 		return "", err
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -397,7 +397,7 @@ github.com/gorilla/mux
 github.com/hashicorp/errwrap
 # github.com/hashicorp/go-cleanhttp v0.5.2
 github.com/hashicorp/go-cleanhttp
-# github.com/hashicorp/go-getter v1.5.11
+# github.com/hashicorp/go-getter v1.6.1
 ## explicit
 github.com/hashicorp/go-getter
 github.com/hashicorp/go-getter/helper/url


### PR DESCRIPTION
  Malicious HTTP responses can cause a number of misbehaviors,
  including overwriting local files, resource exhaustion, and
  panics. * Protocol switching, endless redirect, and
  configuration bypass are possible through abuse of custom HTTP
  response header processing. * Arbitrary host access is possible
  through go-getter path traversal, symlink processing, and
  command injection flaws. * Asymmetric resource exhaustion can
  occur when go-getter processes malicious HTTP responses. * A
  panic can be triggered when go-getter processed
  password-protected ZIP files.

  Found in: github.com/hashicorp/go-getter@v1.5.11
  Fixed in: github.com/hashicorp/go-getter@v1.6.1
  More info: https://pkg.go.dev/vuln/GO-2022-0586

Signed-off-by: Itxaka <igarcia@suse.com>