### PR TITLE
Include bootloader arrangement in build-iso

### DIFF
--- a/cmd/build-iso.go
+++ b/cmd/build-iso.go
@@ -144,6 +144,7 @@ func NewBuildISO(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 	c.Flags().String("overlay-iso", "", "Path of the overlayed iso data")
 	c.Flags().String("label", "", "Label of the ISO volume")
 	c.Flags().StringArray("repo", []string{}, "A repository URI for luet. Can be repeated to add more than one source.")
+	c.Flags().Bool("bootloader-in-rootfs", false, "Fetch ISO bootloader binaries from the rootfs")
 	addArchFlags(c)
 	addCosignFlags(c)
 	addSquashFsCompressionFlags(c)

--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -152,9 +152,6 @@ var _ = Describe("Config", Label("config"), func() {
 				iso, err := ReadBuildISO(cfg, nil)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				// By default
-				Expect(iso.HybridMBR).To(Equal(constants.IsoHybridMBR))
-
 				// From config file
 				Expect(iso.Image[0].Value()).To(Equal("recovery/cos-img"))
 				Expect(iso.Label).To(Equal("LIVE_LABEL"))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -466,13 +466,10 @@ func NewRawDisk() *v1.RawDisk {
 
 func NewISO() *v1.LiveISO {
 	return &v1.LiveISO{
-		Label:        constants.ISOLabel,
-		GrubDefEntry: constants.GrubDefEntry,
-		UEFI:         []*v1.ImageSource{},
-		Image:        []*v1.ImageSource{},
-		HybridMBR:    constants.IsoHybridMBR,
-		BootFile:     constants.IsoBootFile,
-		BootCatalog:  constants.IsoBootCatalog,
+		Label:     constants.ISOLabel,
+		GrubEntry: constants.GrubDefEntry,
+		UEFI:      []*v1.ImageSource{},
+		Image:     []*v1.ImageSource{},
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -465,27 +465,14 @@ func NewRawDisk() *v1.RawDisk {
 }
 
 func NewISO() *v1.LiveISO {
-	var uefiSrc, imageSrc []*v1.ImageSource
-
-	defaultUEFI := constants.GetDefaultISOUEFI()
-	for _, imgSrc := range defaultUEFI {
-		src, _ := v1.NewSrcFromURI(imgSrc)
-		uefiSrc = append(uefiSrc, src)
-	}
-
-	defaultImage := constants.GetDefaultISOImage()
-	for _, imgSrc := range defaultImage {
-		src, _ := v1.NewSrcFromURI(imgSrc)
-		imageSrc = append(imageSrc, src)
-	}
-
 	return &v1.LiveISO{
-		Label:       constants.ISOLabel,
-		UEFI:        uefiSrc,
-		Image:       imageSrc,
-		HybridMBR:   constants.IsoHybridMBR,
-		BootFile:    constants.IsoBootFile,
-		BootCatalog: constants.IsoBootCatalog,
+		Label:        constants.ISOLabel,
+		GrubDefEntry: constants.GrubDefEntry,
+		UEFI:         []*v1.ImageSource{},
+		Image:        []*v1.ImageSource{},
+		HybridMBR:    constants.IsoHybridMBR,
+		BootFile:     constants.IsoBootFile,
+		BootCatalog:  constants.IsoBootCatalog,
 	}
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -18,7 +18,6 @@ package config_test
 
 import (
 	"path/filepath"
-	"strings"
 
 	"github.com/jaypipes/ghw/pkg/block"
 	. "github.com/onsi/ginkgo/v2"
@@ -414,22 +413,8 @@ var _ = Describe("Types", Label("types", "config"), func() {
 			It("initiates a new LiveISO", func() {
 				iso := config.NewISO()
 				Expect(iso.Label).To(Equal(constants.ISOLabel))
-				for i, d := range constants.GetDefaultISOImage() {
-					src := strings.Split(d, ":")
-					switch src[0] {
-					case "dir":
-						Expect(iso.Image[i].IsDir()).Should(BeTrue())
-					case "file":
-						Expect(iso.Image[i].IsFile()).Should(BeTrue())
-					case "docker", "oci":
-						Expect(iso.Image[i].IsDocker()).Should(BeTrue())
-					case "channel":
-						Expect(iso.Image[i].IsChannel()).Should(BeTrue())
-					default:
-						Expect(iso.Image[i].IsEmpty()).Should(BeTrue())
-					}
-					Expect(iso.Image[i].Value()).To(Equal(src[1]))
-				}
+				Expect(len(iso.UEFI)).To(Equal(0))
+				Expect(len(iso.Image)).To(Equal(0))
 			})
 		})
 		Describe("RawDisk", Label("disk"), func() {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -107,10 +107,9 @@ const (
 	SELinuxTargetedContextFile = SELinuxTargetedPath + "/contexts/files/file_contexts"
 	SELinuxTargetedPolicyPath  = SELinuxTargetedPath + "/policy"
 
-	//TODO these paths are abitrary, coupled to package live/grub2 and assuming xz
-	// I'd suggest using `/boot/kernel` and `/boot/initrd`
-	IsoKernelPath = "/boot/kernel.xz"
-	IsoInitrdPath = "/boot/rootfs.xz"
+	//TODO document these paths. They are arbitrary but coupled to grub.cfg
+	IsoKernelPath = "/boot/kernel"
+	IsoInitrdPath = "/boot/initrd"
 
 	// TODO would be nice to discover these ISO loader values instead of hardcoding them
 	// These values are coupled with package live/grub2
@@ -186,19 +185,6 @@ func GetDefaultXorrisoBooloaderArgs(root, bootFile, bootCatalog, hybridMBR strin
 		"-boot_image", "any", "emul_type=no_emulation",
 	}...)
 	return args
-}
-
-func GetDefaultISOImage() []string {
-	return []string{
-		"channel:live/grub2",
-		"channel:live/grub2-efi-image",
-	}
-}
-
-func GetDefaultISOUEFI() []string {
-	return []string{
-		"channel:live/grub2-efi-image",
-	}
 }
 
 func GetBuildDiskDefaultPackages() map[string]string {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -107,7 +107,7 @@ const (
 	SELinuxTargetedContextFile = SELinuxTargetedPath + "/contexts/files/file_contexts"
 	SELinuxTargetedPolicyPath  = SELinuxTargetedPath + "/policy"
 
-	//TODO document these paths. They are arbitrary but coupled to grub.cfg
+	// These paths are arbitrary but coupled to grub.cfg
 	IsoKernelPath = "/boot/kernel"
 	IsoInitrdPath = "/boot/initrd"
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -111,12 +111,6 @@ const (
 	IsoKernelPath = "/boot/kernel"
 	IsoInitrdPath = "/boot/initrd"
 
-	// TODO would be nice to discover these ISO loader values instead of hardcoding them
-	// These values are coupled with package live/grub2
-	IsoHybridMBR   = "/boot/x86_64/loader/boot_hybrid.img"
-	IsoBootCatalog = "/boot/x86_64/boot.catalog"
-	IsoBootFile    = "/boot/x86_64/loader/eltorito.img"
-
 	// Default directory and file fileModes
 	DirPerm        = os.ModeDir | os.ModePerm
 	FilePerm       = 0666

--- a/pkg/live/common.go
+++ b/pkg/live/common.go
@@ -1,0 +1,71 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package live
+
+import (
+	"github.com/rancher/elemental-cli/pkg/constants"
+)
+
+const (
+	efiBootPath           = "/EFI/BOOT"
+	isoLoaderPath         = "/boot/x86_64/loader"
+	grubArm64Path         = grubPrefixDir + "/arm64-efi"
+	grubEfiImagex86Dest   = efiBootPath + "/bootx64.efi"
+	grubEfiImageArm64Dest = efiBootPath + "/bootaa64.efi"
+	grubCfg               = "grub.cfg"
+	grubPrefixDir         = "/boot/grub2"
+	//TODO use some identifer known to be unique
+	grubEfiCfg = "search --no-floppy --file --set=root " + constants.IsoKernelPath +
+		"\nset prefix=($root)" + grubPrefixDir +
+		"\nconfigfile $prefix/" + grubCfg
+
+	// TODO not convinced having such a config here is the best idea
+	grubCfgTemplate = `search --no-floppy --file --set=root /boot/kernel                               
+	set default=0                                                                   
+	set timeout=10                                                                  
+	set timeout_style=menu                                                          
+	set linux=linux                                                                 
+	set initrd=initrd                                                               
+	if [ "${grub_cpu}" = "x86_64" -o "${grub_cpu}" = "i386" -o "${grub_cpu}" = "arm64" ];then
+		if [ "${grub_platform}" = "efi" ]; then                                     
+			if [ "${grub_cpu}" != "arm64" ]; then                                   
+				set linux=linuxefi                                                  
+				set initrd=initrdefi                                                
+			fi                                                                      
+		fi                                                                          
+	fi                                                                              
+	if [ "${grub_platform}" = "efi" ]; then                                         
+		echo "Please press 't' to show the boot menu on this console"               
+	fi                                                                              
+	set font=($root)/boot/${grub_cpu}/loader/grub2/fonts/unicode.pf2                
+	if [ -f ${font} ];then                                                          
+		loadfont ${font}                                                            
+	fi                                                                              
+	menuentry "%s" --class os --unrestricted {                                     
+		echo Loading kernel...                                                      
+		$linux ($root)/boot/kernel cdroot root=live:CDLABEL=%s rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0 rd.cos.disable
+		echo Loading initrd...                                                      
+		$initrd ($root)/boot/initrd                                                 
+	}                                                                               
+																					
+	if [ "${grub_platform}" = "efi" ]; then                                         
+		hiddenentry "Text mode" --hotkey "t" {                                      
+			set textmode=true                                                       
+			terminal_output console                                                 
+		}                                                                           
+	fi`
+)

--- a/pkg/live/green.go
+++ b/pkg/live/green.go
@@ -88,7 +88,7 @@ func (g *GreenLiveBootLoader) PrepareISO(rootDir, imageDir string) error {
 	switch g.buildCfg.Arch {
 	case constants.ArchAmd64, constants.Archx86:
 		// Create eltorito image
-		eltorito, err := g.buildEltoritoImg(rootDir)
+		eltorito, err := g.BuildEltoritoImg(rootDir)
 		if err != nil {
 			return err
 		}
@@ -136,7 +136,7 @@ func (g *GreenLiveBootLoader) PrepareISO(rootDir, imageDir string) error {
 	return g.PrepareEFI(rootDir, imageDir)
 }
 
-func (g *GreenLiveBootLoader) buildEltoritoImg(rootDir string) (string, error) {
+func (g *GreenLiveBootLoader) BuildEltoritoImg(rootDir string) (string, error) {
 	const (
 		grubBiosTarget  = "i386-pc"
 		grubI386BinDir  = "/usr/share/grub2/i386-pc"

--- a/pkg/live/green.go
+++ b/pkg/live/green.go
@@ -1,0 +1,177 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package live
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"strings"
+
+	"github.com/rancher/elemental-cli/pkg/constants"
+	v1 "github.com/rancher/elemental-cli/pkg/types/v1"
+	"github.com/rancher/elemental-cli/pkg/utils"
+)
+
+type GreenLiveBootLoader struct {
+	buildCfg *v1.BuildConfig
+}
+
+func NewGreenLiveBootLoader(cfg *v1.BuildConfig) *GreenLiveBootLoader {
+	return &GreenLiveBootLoader{buildCfg: cfg}
+}
+
+func (g *GreenLiveBootLoader) PrepareEFI(rootDir, uefiDir string) error {
+	const (
+		grubEfiImagex86   = "/usr/share/grub2/x86_64-efi/grub.efi"
+		grubEfiImageArm64 = "/usr/share/grub2/arm64-efi/grub.efi"
+	)
+
+	err := utils.MkdirAll(g.buildCfg.Fs, filepath.Join(uefiDir, efiBootPath), constants.DirPerm)
+	if err != nil {
+		return err
+	}
+
+	switch g.buildCfg.Arch {
+	case constants.ArchAmd64, constants.Archx86:
+		err = utils.CopyFile(
+			g.buildCfg.Fs,
+			filepath.Join(rootDir, grubEfiImagex86),
+			filepath.Join(uefiDir, grubEfiImagex86Dest),
+		)
+	case constants.ArchArm64:
+		err = utils.CopyFile(
+			g.buildCfg.Fs,
+			filepath.Join(rootDir, grubEfiImageArm64),
+			filepath.Join(uefiDir, grubEfiImageArm64Dest),
+		)
+	default:
+		err = fmt.Errorf("Not supported architecture: %v", g.buildCfg.Arch)
+	}
+	if err != nil {
+		return err
+	}
+
+	return g.buildCfg.Fs.WriteFile(filepath.Join(uefiDir, efiBootPath, grubCfg), []byte(grubEfiCfg), constants.FilePerm)
+}
+
+func (g *GreenLiveBootLoader) PrepareISO(rootDir, imageDir, label, menuEntry string) error {
+	const (
+		grubFont          = "/usr/share/grub2/unicode.pf2"
+		grubBootHybridImg = "/usr/share/grub2/i386-pc/boot_hybrid.img"
+		syslinuxFiles     = "/usr/share/syslinux/isolinux.bin " +
+			"/usr/share/syslinux/menu.c32 " +
+			"/usr/share/syslinux/chain.c32 " +
+			"/usr/share/syslinux/mboot.c32"
+	)
+
+	err := utils.MkdirAll(g.buildCfg.Fs, filepath.Join(imageDir, grubPrefixDir), constants.DirPerm)
+	if err != nil {
+		return err
+	}
+
+	switch g.buildCfg.Arch {
+	case constants.ArchAmd64, constants.Archx86:
+		// Create eltorito image
+		eltorito, err := g.buildEltoritoImg(rootDir)
+		if err != nil {
+			return err
+		}
+
+		// Inlude loaders in expected paths
+		loaderDir := filepath.Join(imageDir, isoLoaderPath)
+		err = utils.MkdirAll(g.buildCfg.Fs, loaderDir, constants.DirPerm)
+		if err != nil {
+			return err
+		}
+		loaderFiles := []string{eltorito, grubBootHybridImg}
+		loaderFiles = append(loaderFiles, strings.Split(syslinuxFiles, " ")...)
+		for _, f := range loaderFiles {
+			err = utils.CopyFile(g.buildCfg.Fs, filepath.Join(rootDir, f), loaderDir)
+			if err != nil {
+				return err
+			}
+		}
+		fontsDir := filepath.Join(loaderDir, "/grub2/fonts")
+		err = utils.MkdirAll(g.buildCfg.Fs, fontsDir, constants.DirPerm)
+		if err != nil {
+			return err
+		}
+		err = utils.CopyFile(g.buildCfg.Fs, filepath.Join(rootDir, grubFont), fontsDir)
+		if err != nil {
+			return err
+		}
+	case constants.ArchArm64:
+		// TBC
+	default:
+		return fmt.Errorf("Not supported architecture: %v", g.buildCfg.Arch)
+	}
+
+	// Write grub.cfg file
+	err = g.buildCfg.Fs.WriteFile(
+		filepath.Join(imageDir, grubPrefixDir, grubCfg),
+		[]byte(fmt.Sprintf(grubCfgTemplate, menuEntry, label)),
+		constants.FilePerm,
+	)
+	if err != nil {
+		return err
+	}
+
+	// Include EFI contents in iso root too
+	return g.PrepareEFI(rootDir, imageDir)
+}
+
+func (g *GreenLiveBootLoader) buildEltoritoImg(rootDir string) (string, error) {
+	const (
+		grubBiosTarget  = "i386-pc"
+		grubI386BinDir  = "/usr/share/grub2/i386-pc"
+		grubBiosImg     = grubI386BinDir + "/core.img"
+		grubBiosCDBoot  = grubI386BinDir + "/cdboot.img"
+		grubEltoritoImg = grubI386BinDir + "/eltorito.img"
+		//TODO this list could be optimized
+		grubModules = "ext2 iso9660 linux echo configfile search_label search_fs_file search search_fs_uuid " +
+			"ls normal gzio png fat gettext font minicmd gfxterm gfxmenu all_video xfs btrfs lvm luks " +
+			"gcry_rijndael gcry_sha256 gcry_sha512 crypto cryptodisk test true loadenv part_gpt " +
+			"part_msdos biosdisk vga vbe chain boot"
+	)
+	var args []string
+	args = append(args, "-O", grubBiosTarget)
+	args = append(args, "-o", grubBiosImg)
+	args = append(args, "-p", grubPrefixDir)
+	args = append(args, "-d", grubI386BinDir)
+	args = append(args, strings.Split(grubModules, " ")...)
+
+	chRoot := utils.NewChroot(rootDir, &g.buildCfg.Config)
+	out, err := chRoot.Run("grub2-mkimage", args...)
+	if err != nil {
+		g.buildCfg.Logger.Errorf("grub2-mkimage failed: %s", string(out))
+		g.buildCfg.Logger.Errorf("Error: %v", err)
+		return "", err
+	}
+
+	concatFiles := func() error {
+		return utils.ConcatFiles(
+			g.buildCfg.Fs, []string{grubBiosCDBoot, grubBiosImg},
+			grubEltoritoImg,
+		)
+	}
+	err = chRoot.RunCallback(concatFiles)
+	if err != nil {
+		return "", err
+	}
+	return grubEltoritoImg, nil
+}

--- a/pkg/live/green.go
+++ b/pkg/live/green.go
@@ -29,10 +29,11 @@ import (
 
 type GreenLiveBootLoader struct {
 	buildCfg *v1.BuildConfig
+	spec     *v1.LiveISO
 }
 
-func NewGreenLiveBootLoader(cfg *v1.BuildConfig) *GreenLiveBootLoader {
-	return &GreenLiveBootLoader{buildCfg: cfg}
+func NewGreenLiveBootLoader(cfg *v1.BuildConfig, spec *v1.LiveISO) *GreenLiveBootLoader {
+	return &GreenLiveBootLoader{buildCfg: cfg, spec: spec}
 }
 
 func (g *GreenLiveBootLoader) PrepareEFI(rootDir, uefiDir string) error {
@@ -69,7 +70,7 @@ func (g *GreenLiveBootLoader) PrepareEFI(rootDir, uefiDir string) error {
 	return g.buildCfg.Fs.WriteFile(filepath.Join(uefiDir, efiBootPath, grubCfg), []byte(grubEfiCfg), constants.FilePerm)
 }
 
-func (g *GreenLiveBootLoader) PrepareISO(rootDir, imageDir, label, menuEntry string) error {
+func (g *GreenLiveBootLoader) PrepareISO(rootDir, imageDir string) error {
 	const (
 		grubFont          = "/usr/share/grub2/unicode.pf2"
 		grubBootHybridImg = "/usr/share/grub2/i386-pc/boot_hybrid.img"
@@ -124,7 +125,7 @@ func (g *GreenLiveBootLoader) PrepareISO(rootDir, imageDir, label, menuEntry str
 	// Write grub.cfg file
 	err = g.buildCfg.Fs.WriteFile(
 		filepath.Join(imageDir, grubPrefixDir, grubCfg),
-		[]byte(fmt.Sprintf(grubCfgTemplate, menuEntry, label)),
+		[]byte(fmt.Sprintf(grubCfgTemplate, g.spec.GrubEntry, g.spec.Label)),
 		constants.FilePerm,
 	)
 	if err != nil {

--- a/pkg/live/green_test.go
+++ b/pkg/live/green_test.go
@@ -1,0 +1,216 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package live_test
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+
+	"github.com/rancher/elemental-cli/pkg/config"
+	"github.com/rancher/elemental-cli/pkg/constants"
+	"github.com/rancher/elemental-cli/pkg/live"
+	v1 "github.com/rancher/elemental-cli/pkg/types/v1"
+	"github.com/rancher/elemental-cli/pkg/utils"
+	v1mock "github.com/rancher/elemental-cli/tests/mocks"
+	"github.com/sirupsen/logrus"
+	"github.com/twpayne/go-vfs"
+	"github.com/twpayne/go-vfs/vfst"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("GreenLiveBootloader", Label("green", "live"), func() {
+	var cfg *v1.BuildConfig
+	var runner *v1mock.FakeRunner
+	var fs vfs.FS
+	var logger v1.Logger
+	var mounter *v1mock.ErrorMounter
+	var syscall *v1mock.FakeSyscall
+	var client *v1mock.FakeHTTPClient
+	var cloudInit *v1mock.FakeCloudInitRunner
+	var luet *v1mock.FakeLuet
+	var cleanup func()
+	var memLog *bytes.Buffer
+	var iso *v1.LiveISO
+	var rootDir, imageDir, uefiDir string
+	var i386BinChrootPath string
+	BeforeEach(func() {
+		var err error
+		runner = v1mock.NewFakeRunner()
+		syscall = &v1mock.FakeSyscall{}
+		mounter = v1mock.NewErrorMounter()
+		client = &v1mock.FakeHTTPClient{}
+		memLog = &bytes.Buffer{}
+		logger = v1.NewBufferLogger(memLog)
+		logger.SetLevel(logrus.DebugLevel)
+		cloudInit = &v1mock.FakeCloudInitRunner{}
+		luet = &v1mock.FakeLuet{}
+		fs, cleanup, _ = vfst.NewTestFS(map[string]interface{}{})
+		cfg = config.NewBuildConfig(
+			config.WithFs(fs),
+			config.WithRunner(runner),
+			config.WithLogger(logger),
+			config.WithMounter(mounter),
+			config.WithSyscall(syscall),
+			config.WithClient(client),
+			config.WithCloudInitRunner(cloudInit),
+			config.WithLuet(luet),
+		)
+		iso = config.NewISO()
+
+		rootDir, err = utils.TempDir(fs, "", "rootDir")
+		Expect(err).ShouldNot(HaveOccurred())
+		imageDir, err = utils.TempDir(fs, "", "imageDir")
+		Expect(err).ShouldNot(HaveOccurred())
+		uefiDir, err = utils.TempDir(fs, "", "uefiDir")
+		Expect(err).ShouldNot(HaveOccurred())
+
+		i386BinChrootPath = "/usr/share/grub2/i386-pc"
+		err = utils.MkdirAll(fs, i386BinChrootPath, constants.DirPerm)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		err = fs.WriteFile(filepath.Join(i386BinChrootPath, "cdboot.img"), []byte("cdboot.img"), constants.FilePerm)
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+	AfterEach(func() {
+		cleanup()
+	})
+	It("Creates eltorito image", func() {
+		runner.SideEffect = func(cmd string, args ...string) ([]byte, error) {
+			switch cmd {
+			case "grub2-mkimage":
+				err := fs.WriteFile(filepath.Join(i386BinChrootPath, "core.img"), []byte("core.img"), constants.FilePerm)
+				return []byte{}, err
+			default:
+				return []byte{}, nil
+			}
+		}
+		green := live.NewGreenLiveBootLoader(cfg, iso)
+		eltorito, err := green.BuildEltoritoImg(rootDir)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(eltorito).To(Equal("/usr/share/grub2/i386-pc/eltorito.img"))
+		out, err := fs.ReadFile(eltorito)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(string(out)).To(Equal("cdboot.imgcore.img"))
+	})
+	It("Fails creating eltorito image, grub2-mkimage failure", func() {
+		runner.SideEffect = func(cmd string, args ...string) ([]byte, error) {
+			switch cmd {
+			case "grub2-mkimage":
+				return []byte{}, fmt.Errorf("failed creating core image")
+			default:
+				return []byte{}, nil
+			}
+		}
+		green := live.NewGreenLiveBootLoader(cfg, iso)
+		_, err := green.BuildEltoritoImg(rootDir)
+		Expect(err).Should(HaveOccurred())
+	})
+	It("Fails creating eltorito image, concatenating files failure", func() {
+		// fake runner does not create a fake core.img
+		green := live.NewGreenLiveBootLoader(cfg, iso)
+		_, err := green.BuildEltoritoImg(rootDir)
+		Expect(err).Should(HaveOccurred())
+	})
+	It("Copies the EFI image binaries for x86_64", func() {
+		err := utils.MkdirAll(fs, filepath.Join(rootDir, "/usr/share/grub2/x86_64-efi"), constants.DirPerm)
+		Expect(err).ShouldNot(HaveOccurred())
+		err = fs.WriteFile(
+			filepath.Join(rootDir, "/usr/share/grub2/x86_64-efi/grub.efi"),
+			[]byte("x86_64_efi"), constants.FilePerm,
+		)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		green := live.NewGreenLiveBootLoader(cfg, iso)
+		err = green.PrepareEFI(rootDir, uefiDir)
+		Expect(err).ShouldNot(HaveOccurred())
+		exists, _ := utils.Exists(fs, filepath.Join(uefiDir, "EFI/BOOT/grub.cfg"))
+		Expect(exists).To(BeTrue())
+	})
+	It("Copies the EFI image binaries for arm64", func() {
+		cfg.Arch = constants.ArchArm64
+		err := utils.MkdirAll(fs, filepath.Join(rootDir, "/usr/share/grub2/arm64-efi"), constants.DirPerm)
+		Expect(err).ShouldNot(HaveOccurred())
+		err = fs.WriteFile(
+			filepath.Join(rootDir, "/usr/share/grub2/arm64-efi/grub.efi"),
+			[]byte("arm64-efi"), constants.FilePerm,
+		)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		green := live.NewGreenLiveBootLoader(cfg, iso)
+		err = green.PrepareEFI(rootDir, uefiDir)
+		Expect(err).ShouldNot(HaveOccurred())
+		exists, _ := utils.Exists(fs, filepath.Join(uefiDir, "EFI/BOOT/grub.cfg"))
+		Expect(exists).To(BeTrue())
+	})
+	It("Prepares ISO root with bootloader files", func() {
+		i386BinPath := filepath.Join(rootDir, i386BinChrootPath)
+		err := utils.MkdirAll(fs, i386BinPath, constants.DirPerm)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		err = fs.WriteFile(filepath.Join(i386BinPath, "eltorito.img"), []byte("eltorito"), constants.FilePerm)
+		Expect(err).ShouldNot(HaveOccurred())
+		err = fs.WriteFile(filepath.Join(i386BinPath, "boot_hybrid.img"), []byte("boot_hybrid"), constants.FilePerm)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		syslinuxPath := filepath.Join(rootDir, "/usr/share/syslinux")
+		err = utils.MkdirAll(fs, syslinuxPath, constants.DirPerm)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		err = fs.WriteFile(filepath.Join(syslinuxPath, "isolinux.bin"), []byte("isolinux"), constants.FilePerm)
+		Expect(err).ShouldNot(HaveOccurred())
+		err = fs.WriteFile(filepath.Join(syslinuxPath, "menu.c32"), []byte("menu"), constants.FilePerm)
+		Expect(err).ShouldNot(HaveOccurred())
+		err = fs.WriteFile(filepath.Join(syslinuxPath, "chain.c32"), []byte("chain"), constants.FilePerm)
+		Expect(err).ShouldNot(HaveOccurred())
+		err = fs.WriteFile(filepath.Join(syslinuxPath, "mboot.c32"), []byte("mboot"), constants.FilePerm)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		fontsPath := filepath.Join(rootDir, "/usr/share/grub2")
+		err = utils.MkdirAll(fs, fontsPath, constants.DirPerm)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		err = fs.WriteFile(filepath.Join(fontsPath, "unicode.pf2"), []byte("unicode"), constants.FilePerm)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		runner.SideEffect = func(cmd string, args ...string) ([]byte, error) {
+			switch cmd {
+			case "grub2-mkimage":
+				err := fs.WriteFile(filepath.Join(i386BinChrootPath, "core.img"), []byte("core.img"), constants.FilePerm)
+				return []byte{}, err
+			default:
+				return []byte{}, nil
+			}
+		}
+		err = utils.MkdirAll(fs, filepath.Join(rootDir, "/usr/share/grub2/x86_64-efi"), constants.DirPerm)
+		Expect(err).ShouldNot(HaveOccurred())
+		err = fs.WriteFile(
+			filepath.Join(rootDir, "/usr/share/grub2/x86_64-efi/grub.efi"),
+			[]byte("x86_64_efi"), constants.FilePerm,
+		)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		green := live.NewGreenLiveBootLoader(cfg, iso)
+		err = green.PrepareISO(rootDir, imageDir)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		exists, _ := utils.Exists(fs, filepath.Join(imageDir, "EFI/BOOT/grub.cfg"))
+		Expect(exists).To(BeTrue())
+	})
+})

--- a/pkg/live/live_suite_test.go
+++ b/pkg/live/live_suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package live_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestTypes(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "live test suite")
+}

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -454,10 +454,7 @@ type LiveISO struct {
 	UEFI               []*ImageSource `yaml:"uefi,omitempty" mapstructure:"uefi"`
 	Image              []*ImageSource `yaml:"image,omitempty" mapstructure:"image"`
 	Label              string         `yaml:"label,omitempty" mapstructure:"label"`
-	GrubDefEntry       string         `yaml:"grub-entry-name,omitempty" mapstructure:"grub-entry-name"`
-	BootCatalog        string         `yaml:"boot-catalog,omitempty" mapstructure:"boot-catalog"`
-	BootFile           string         `yaml:"boot-file,omitempty" mapstructure:"boot-file"`
-	HybridMBR          string         `yaml:"hybrid-mbr,omitempty" mapstructure:"hybrid-mbr,omitempty"`
+	GrubEntry          string         `yaml:"grub-entry-name,omitempty" mapstructure:"grub-entry-name"`
 	BootloaderInRootFs bool           `yaml:"bootloader-in-rootfs" mapstructure:"bootloader-in-rootfs"`
 }
 

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -450,13 +450,15 @@ type Image struct {
 
 // LiveISO represents the configurations needed for a live ISO image
 type LiveISO struct {
-	RootFS      []*ImageSource `yaml:"rootfs,omitempty" mapstructure:"rootfs"`
-	UEFI        []*ImageSource `yaml:"uefi,omitempty" mapstructure:"uefi"`
-	Image       []*ImageSource `yaml:"image,omitempty" mapstructure:"image"`
-	Label       string         `yaml:"label,omitempty" mapstructure:"label"`
-	BootCatalog string         `yaml:"boot-catalog,omitempty" mapstructure:"boot-catalog"`
-	BootFile    string         `yaml:"boot-file,omitempty" mapstructure:"boot-file"`
-	HybridMBR   string         `yaml:"hybrid-mbr,omitempty" mapstructure:"hybrid-mbr,omitempty"`
+	RootFS             []*ImageSource `yaml:"rootfs,omitempty" mapstructure:"rootfs"`
+	UEFI               []*ImageSource `yaml:"uefi,omitempty" mapstructure:"uefi"`
+	Image              []*ImageSource `yaml:"image,omitempty" mapstructure:"image"`
+	Label              string         `yaml:"label,omitempty" mapstructure:"label"`
+	GrubDefEntry       string         `yaml:"grub-entry-name,omitempty" mapstructure:"grub-entry-name"`
+	BootCatalog        string         `yaml:"boot-catalog,omitempty" mapstructure:"boot-catalog"`
+	BootFile           string         `yaml:"boot-file,omitempty" mapstructure:"boot-file"`
+	HybridMBR          string         `yaml:"hybrid-mbr,omitempty" mapstructure:"hybrid-mbr,omitempty"`
+	BootloaderInRootFs bool           `yaml:"bootloader-in-rootfs" mapstructure:"bootloader-in-rootfs"`
 }
 
 // Sanitize checks the consistency of the struct, returns error

--- a/tests/mocks/green_mock.go
+++ b/tests/mocks/green_mock.go
@@ -1,0 +1,40 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mocks
+
+import (
+	"fmt"
+)
+
+type LiveBootLoaderMock struct {
+	ErrorEFI bool
+	ErrorISO bool
+}
+
+func (g *LiveBootLoaderMock) PrepareEFI(rootDir, uefiDir string) error {
+	if g.ErrorEFI {
+		return fmt.Errorf("failed preparing EFI binaries")
+	}
+	return nil
+}
+
+func (g *LiveBootLoaderMock) PrepareISO(rootDir, imageDir string) error {
+	if g.ErrorISO {
+		return fmt.Errorf("failed preparing ISO bootloader binaries")
+	}
+	return nil
+}


### PR DESCRIPTION
Related rancher/elemental#263

Note this PR also drops non EFI ISO generation support. With this all ISOs are expected to be grub2 based and hybrid, they boot on EFI, non EFI and as disk or cdrom. Legacy firmware only ISOs based on syslinux are not considered.

If `bootloader-in-rootfs` flag is not provided we keep previous behavior, however if provided, the new logic kicks in and then the main OS image is expected to include all required packages and binaries to set the bootloader.

Signed-off-by: David Cassany <dcassany@suse.com>