### PR TITLE
Add an OsConfig struct to track differences in base systems

### DIFF
--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -536,9 +536,9 @@ func CalcFileChecksum(fs v1.FS, fileName string) (string, error) {
 	return fmt.Sprintf("%x", h.Sum(nil)), nil
 }
 
-// IdentifySourceSystem tries to find the os-release file in a given dir and identify the system based on the data in there
-func IdentifySourceSystem(vfs v1.FS, path string) (string, error) {
-	var system string
+// IdentifySourceSystem tries to find the os-release file in a given dir and return a cnst.OsConfig
+func IdentifySourceSystem(vfs v1.FS, path string, arch string) (cnst.OsConfig, error) {
+	var system cnst.OsConfig
 	var found bool
 	err := WalkDirFs(vfs, path, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -551,11 +551,11 @@ func IdentifySourceSystem(vfs v1.FS, path string) (string, error) {
 			}
 			switch osRelease["ID"] {
 			case cnst.Fedora:
-				system = cnst.Fedora
+				system = cnst.NewFedoraOsConfig(arch)
 			case cnst.Ubuntu:
-				system = cnst.Ubuntu
+				system = cnst.NewUbuntuOsConfig(arch)
 			default:
-				system = cnst.Suse
+				system = cnst.NewSuseOsConfig(arch)
 			}
 			found = true
 		}


### PR DESCRIPTION
Currently we have no single struct to manage any differences between base systems when running elemental-cli. This produced some weird code in order to support different names or paths for some files like the shim efi files.

This patch introduces an OsSystem struct which can house paths or names for fiels across systems so we can access those values independtly of the base system and not complicate our code much more.

Currently supporting the different shim names for EFI systems.

This patch also introduces some extra constants to use under the grub package in order to centralize those paths and names.

Signed-off-by: Itxaka <igarcia@suse.com>