### PR TITLE
Create ISO for EFI only or BIOS only, not both

### DIFF
--- a/cmd/build-iso.go
+++ b/cmd/build-iso.go
@@ -135,6 +135,9 @@ func NewBuildISO(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 			return nil
 		},
 	}
+
+	firmType := newEnumFlag([]string{v1.EFI, v1.BIOS}, v1.EFI)
+
 	root.AddCommand(c)
 	c.Flags().StringP("name", "n", "", "Basename of the generated ISO file")
 	c.Flags().StringP("output", "o", "", "Output directory (defaults to current directory)")
@@ -145,6 +148,8 @@ func NewBuildISO(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 	c.Flags().String("label", "", "Label of the ISO volume")
 	c.Flags().StringArray("repo", []string{}, "A repository URI for luet. Can be repeated to add more than one source.")
 	c.Flags().Bool("bootloader-in-rootfs", false, "Fetch ISO bootloader binaries from the rootfs")
+	c.Flags().Var(firmType, "firmware", "Firmware to install for: 'efi' or 'bios'. (defaults to 'efi')")
+	_ = c.Flags().MarkDeprecated("firmware", "'firmware' is deprecated. 'bios' firmware support is deprecated.")
 	addArchFlags(c)
 	addCosignFlags(c)
 	addSquashFsCompressionFlags(c)

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -102,7 +102,7 @@ func NewInstallCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 
 	c.Flags().Bool("force-efi", false, "Forces an EFI installation")
 	_ = c.Flags().MarkDeprecated("force-efi", "'force-efi' is deprecated please use 'firmware' instead")
-	c.Flags().Var(firmType, "firmware", "Firmware to install for ('esp' or 'bios')")
+	c.Flags().Var(firmType, "firmware", "Firmware to install for: 'efi' or 'bios'. (defaults to 'efi')")
 
 	c.Flags().Bool("force-gpt", false, "Forces a GPT partition table")
 	_ = c.Flags().MarkDeprecated("force-gpt", "'force-gpt' is deprecated please use 'part-table' instead")

--- a/pkg/action/build-iso.go
+++ b/pkg/action/build-iso.go
@@ -155,7 +155,7 @@ func (b *BuildISOAction) ISORun() (err error) {
 	}
 
 	b.cfg.Logger.Infof("Creating ISO image...")
-	err = b.burnISO(isoDir, filepath.Join(isoTmpDir, filepath.Join(isoTmpDir, constants.IsoEFIImg)))
+	err = b.burnISO(isoDir, filepath.Join(isoTmpDir, constants.IsoEFIImg))
 	if err != nil {
 		b.cfg.Logger.Errorf("Failed preparing ISO's root tree: %v", err)
 		return err

--- a/pkg/action/build-iso.go
+++ b/pkg/action/build-iso.go
@@ -110,18 +110,20 @@ func (b *BuildISOAction) ISORun() (err error) {
 		return err
 	}
 
-	b.cfg.Logger.Infof("Preparing EFI image...")
-	if b.spec.BootloaderInRootFs {
-		err = b.liveBoot.PrepareEFI(rootDir, uefiDir)
+	if b.spec.Firmware == v1.EFI {
+		b.cfg.Logger.Infof("Preparing EFI image...")
+		if b.spec.BootloaderInRootFs {
+			err = b.liveBoot.PrepareEFI(rootDir, uefiDir)
+			if err != nil {
+				b.cfg.Logger.Errorf("Failed fetching EFI data: %v", err)
+				return err
+			}
+		}
+		err = b.applySources(uefiDir, b.spec.UEFI...)
 		if err != nil {
-			b.cfg.Logger.Errorf("Failed fetching EFI data: %v", err)
+			b.cfg.Logger.Errorf("Failed installing EFI packages: %v", err)
 			return err
 		}
-	}
-	err = b.applySources(uefiDir, b.spec.UEFI...)
-	if err != nil {
-		b.cfg.Logger.Errorf("Failed installing EFI packages: %v", err)
-		return err
 	}
 
 	b.cfg.Logger.Infof("Preparing ISO image root tree...")
@@ -138,14 +140,22 @@ func (b *BuildISOAction) ISORun() (err error) {
 		return err
 	}
 
-	err = b.prepareISORoot(isoDir, rootDir, uefiDir)
+	err = b.prepareISORoot(isoDir, rootDir)
 	if err != nil {
 		b.cfg.Logger.Errorf("Failed preparing ISO's root tree: %v", err)
 		return err
 	}
 
+	if b.spec.Firmware == v1.EFI {
+		b.cfg.Logger.Info("Creating EFI image...")
+		err = b.createEFI(uefiDir, filepath.Join(isoTmpDir, constants.IsoEFIImg))
+		if err != nil {
+			return err
+		}
+	}
+
 	b.cfg.Logger.Infof("Creating ISO image...")
-	err = b.burnISO(isoDir)
+	err = b.burnISO(isoDir, filepath.Join(isoTmpDir, filepath.Join(isoTmpDir, constants.IsoEFIImg)))
 	if err != nil {
 		b.cfg.Logger.Errorf("Failed preparing ISO's root tree: %v", err)
 		return err
@@ -154,7 +164,7 @@ func (b *BuildISOAction) ISORun() (err error) {
 	return err
 }
 
-func (b BuildISOAction) prepareISORoot(isoDir string, rootDir string, uefiDir string) error {
+func (b BuildISOAction) prepareISORoot(isoDir string, rootDir string) error {
 	kernel, initrd, err := b.e.FindKernelInitrd(rootDir)
 	if err != nil {
 		b.cfg.Logger.Error("Could not find kernel and/or initrd")
@@ -184,11 +194,6 @@ func (b BuildISOAction) prepareISORoot(isoDir string, rootDir string, uefiDir st
 		return err
 	}
 
-	b.cfg.Logger.Info("Creating EFI image...")
-	err = b.createEFI(uefiDir, filepath.Join(isoDir, constants.IsoEFIPath))
-	if err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -227,7 +232,7 @@ func (b BuildISOAction) createEFI(root string, img string) error {
 	return nil
 }
 
-func (b BuildISOAction) burnISO(root string) error {
+func (b BuildISOAction) burnISO(root, efiImg string) error {
 	cmd := "xorriso"
 	var outputFile string
 	var isoFileName string
@@ -253,10 +258,10 @@ func (b BuildISOAction) burnISO(root string) error {
 	}
 
 	args := []string{
-		"-volid", b.spec.Label, "-joliet", "on", "-padding", "0",
+		"-volid", b.spec.Label /*"-joliet", "on"*/, "-padding", "0",
 		"-outdev", outputFile, "-map", root, "/", "-chmod", "0755", "--",
 	}
-	args = append(args, live.XorrisoBooloaderArgs(root)...)
+	args = append(args, live.XorrisoBooloaderArgs(root, efiImg, b.spec.Firmware)...)
 
 	out, err := b.cfg.Runner.Run(cmd, args...)
 	b.cfg.Logger.Debugf("Xorriso: %s", string(out))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -470,6 +470,7 @@ func NewISO() *v1.LiveISO {
 		GrubEntry: constants.GrubDefEntry,
 		UEFI:      []*v1.ImageSource{},
 		Image:     []*v1.ImageSource{},
+		Firmware:  v1.EFI,
 	}
 }
 

--- a/pkg/live/common.go
+++ b/pkg/live/common.go
@@ -18,22 +18,22 @@ package live
 
 import (
 	"fmt"
-	"path/filepath"
 
 	"github.com/rancher/elemental-cli/pkg/constants"
+	v1 "github.com/rancher/elemental-cli/pkg/types/v1"
 )
 
 const (
-	isoEFIPath            = "/boot/uefi.img"
 	efiBootPath           = "/EFI/BOOT"
-	isoLoaderPath         = "/boot/x86_64/loader"
+	isoLoaderPathX86      = "/boot/x86_64/loader"
+	isoLoaderPathArm64    = "/boot/arm64/loader"
 	grubArm64Path         = grubPrefixDir + "/arm64-efi"
 	grubEfiImagex86Dest   = efiBootPath + "/bootx64.efi"
 	grubEfiImageArm64Dest = efiBootPath + "/bootaa64.efi"
 	grubCfg               = "grub.cfg"
 	grubPrefixDir         = "/boot/grub2"
 
-	// TODO document any custom bootloader must match this setup as these are not configurable
+	// TODO document any custom BIOS bootloader must match this setup as these are not configurable
 	// and coupled with the xorriso call
 	isoHybridMBR   = "/boot/x86_64/loader/boot_hybrid.img"
 	isoBootCatalog = "/boot/x86_64/boot.catalog"
@@ -45,32 +45,33 @@ const (
 		"\nconfigfile $prefix/" + grubCfg
 
 	// TODO not convinced having such a config here is the best idea
-	grubCfgTemplate = `search --no-floppy --file --set=root /boot/kernel                               
-	set default=0                                                                   
-	set timeout=10                                                                  
-	set timeout_style=menu                                                          
-	set linux=linux                                                                 
-	set initrd=initrd                                                               
+	grubCfgTemplate = `search --no-floppy --file --set=root /boot/kernel
+	set default=0
+	set timeout=10
+	set timeout_style=menu
+	set linux=linux
+	set initrd=initrd
 	if [ "${grub_cpu}" = "x86_64" -o "${grub_cpu}" = "i386" -o "${grub_cpu}" = "arm64" ];then
-		if [ "${grub_platform}" = "efi" ]; then                                     
-			if [ "${grub_cpu}" != "arm64" ]; then                                   
-				set linux=linuxefi                                                  
-				set initrd=initrdefi                                                
-			fi                                                                      
-		fi                                                                          
-	fi                                                                              
-	if [ "${grub_platform}" = "efi" ]; then                                         
-		echo "Please press 't' to show the boot menu on this console"               
-	fi                                                                              
-	set font=($root)/boot/${grub_cpu}/loader/grub2/fonts/unicode.pf2                
-	if [ -f ${font} ];then                                                          
-		loadfont ${font}                                                            
-	fi                                                                              
-	menuentry "%s" --class os --unrestricted {                                     
-		echo Loading kernel...                                                      
-		$linux ($root)/boot/kernel cdroot root=live:CDLABEL=%s rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0 rd.cos.disable
-		echo Loading initrd...                                                      
-		$initrd ($root)/boot/initrd                                                 
+		if [ "${grub_platform}" = "efi" ]; then
+			if [ "${grub_cpu}" != "arm64" ]; then
+				set linux=linuxefi
+				set initrd=initrdefi
+			fi
+		fi
+	fi
+	if [ "${grub_platform}" = "efi" ]; then
+		echo "Please press 't' to show the boot menu on this console"
+	fi
+	set font=($root)/boot/${grub_cpu}/loader/grub2/fonts/unicode.pf2
+	if [ -f ${font} ];then
+		loadfont ${font}
+	fi
+
+	menuentry "%s" --class os --unrestricted {
+		echo Loading kernel...
+		$linux ($root)` + constants.IsoKernelPath + `cdroot root=live:CDLABEL=%s rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0 rd.cos.disable
+		echo Loading initrd...
+		$initrd ($root)` + constants.IsoInitrdPath + `
 	}                                                                               
 																					
 	if [ "${grub_platform}" = "efi" ]; then                                         
@@ -81,23 +82,35 @@ const (
 	fi`
 )
 
-func XorrisoBooloaderArgs(root string) []string {
-	args := []string{
-		"-boot_image", "grub", fmt.Sprintf("bin_path=%s", isoBootFile),
-		"-boot_image", "grub", fmt.Sprintf("grub2_mbr=%s/%s", root, isoHybridMBR),
-		"-boot_image", "grub", "grub2_boot_info=on",
-		"-boot_image", "any", "partition_offset=16",
-		"-boot_image", "any", fmt.Sprintf("cat_path=%s", isoBootCatalog),
-		"-boot_image", "any", "cat_hidden=on",
-		"-boot_image", "any", "boot_info_table=on",
-		"-boot_image", "any", "platform_id=0x00",
-		"-boot_image", "any", "emul_type=no_emulation",
-		"-boot_image", "any", "load_size=2048",
-		"-append_partition", "2", "0xef", filepath.Join(root, isoEFIPath),
-		"-boot_image", "any", "next",
-		"-boot_image", "any", "efi_path=--interval:appended_partition_2:all::",
-		"-boot_image", "any", "platform_id=0xef",
-		"-boot_image", "any", "emul_type=no_emulation",
+func XorrisoBooloaderArgs(root, efiImg, firmware string) []string {
+	switch firmware {
+	case v1.EFI:
+		args := []string{
+			"-append_partition", "2", "0xef", efiImg,
+			"-boot_image", "any", fmt.Sprintf("cat_path=%s", isoBootCatalog),
+			"-boot_image", "any", "cat_hidden=on",
+			"-boot_image", "any", "efi_path=--interval:appended_partition_2:all::",
+			"-boot_image", "any", "platform_id=0xef",
+			"-boot_image", "any", "appended_part_as=gpt",
+			"-boot_image", "any", "partition_offset=16",
+			"-compliance", "no_emul_toc",
+		}
+		return args
+	case v1.BIOS:
+		args := []string{
+			"-boot_image", "grub", fmt.Sprintf("bin_path=%s", isoBootFile),
+			"-boot_image", "grub", fmt.Sprintf("grub2_mbr=%s/%s", root, isoHybridMBR),
+			"-boot_image", "grub", "grub2_boot_info=on",
+			"-boot_image", "any", "partition_offset=16",
+			"-boot_image", "any", fmt.Sprintf("cat_path=%s", isoBootCatalog),
+			"-boot_image", "any", "cat_hidden=on",
+			"-boot_image", "any", "boot_info_table=on",
+			"-boot_image", "any", "platform_id=0x00",
+			"-boot_image", "any", "emul_type=no_emulation",
+			"-boot_image", "any", "load_size=2048",
+		}
+		return args
+	default:
+		return []string{}
 	}
-	return args
 }

--- a/pkg/live/common.go
+++ b/pkg/live/common.go
@@ -25,19 +25,17 @@ import (
 
 const (
 	efiBootPath           = "/EFI/BOOT"
-	isoLoaderPathX86      = "/boot/x86_64/loader"
-	isoLoaderPathArm64    = "/boot/arm64/loader"
-	grubArm64Path         = grubPrefixDir + "/arm64-efi"
 	grubEfiImagex86Dest   = efiBootPath + "/bootx64.efi"
 	grubEfiImageArm64Dest = efiBootPath + "/bootaa64.efi"
 	grubCfg               = "grub.cfg"
 	grubPrefixDir         = "/boot/grub2"
+	isoBootCatalog        = "/boot/boot.catalog"
 
 	// TODO document any custom BIOS bootloader must match this setup as these are not configurable
 	// and coupled with the xorriso call
-	isoHybridMBR   = "/boot/x86_64/loader/boot_hybrid.img"
-	isoBootCatalog = "/boot/x86_64/boot.catalog"
-	isoBootFile    = "/boot/x86_64/loader/eltorito.img"
+	isoLoaderPath = "/boot/x86_64/loader"
+	isoHybridMBR  = isoLoaderPath + "/boot_hybrid.img"
+	isoBootFile   = isoLoaderPath + "/eltorito.img"
 
 	//TODO use some identifer known to be unique
 	grubEfiCfg = "search --no-floppy --file --set=root " + constants.IsoKernelPath +
@@ -62,14 +60,10 @@ const (
 	if [ "${grub_platform}" = "efi" ]; then
 		echo "Please press 't' to show the boot menu on this console"
 	fi
-	set font=($root)/boot/${grub_cpu}/loader/grub2/fonts/unicode.pf2
-	if [ -f ${font} ];then
-		loadfont ${font}
-	fi
 
 	menuentry "%s" --class os --unrestricted {
 		echo Loading kernel...
-		$linux ($root)` + constants.IsoKernelPath + `cdroot root=live:CDLABEL=%s rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0 rd.cos.disable
+		$linux ($root)` + constants.IsoKernelPath + ` cdroot root=live:CDLABEL=%s rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0 rd.cos.disable
 		echo Loading initrd...
 		$initrd ($root)` + constants.IsoInitrdPath + `
 	}                                                                               
@@ -93,7 +87,6 @@ func XorrisoBooloaderArgs(root, efiImg, firmware string) []string {
 			"-boot_image", "any", "platform_id=0xef",
 			"-boot_image", "any", "appended_part_as=gpt",
 			"-boot_image", "any", "partition_offset=16",
-			"-compliance", "no_emul_toc",
 		}
 		return args
 	case v1.BIOS:
@@ -106,8 +99,6 @@ func XorrisoBooloaderArgs(root, efiImg, firmware string) []string {
 			"-boot_image", "any", "cat_hidden=on",
 			"-boot_image", "any", "boot_info_table=on",
 			"-boot_image", "any", "platform_id=0x00",
-			"-boot_image", "any", "emul_type=no_emulation",
-			"-boot_image", "any", "load_size=2048",
 		}
 		return args
 	default:

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -458,6 +458,7 @@ type LiveISO struct {
 	Label              string         `yaml:"label,omitempty" mapstructure:"label"`
 	GrubEntry          string         `yaml:"grub-entry-name,omitempty" mapstructure:"grub-entry-name"`
 	BootloaderInRootFs bool           `yaml:"bootloader-in-rootfs" mapstructure:"bootloader-in-rootfs"`
+	Firmware           string         `yaml:"firmware,omitempty" mapstructure:"firmware"`
 }
 
 // Sanitize checks the consistency of the struct, returns error


### PR DESCRIPTION
This commit adds a firmware flag in build-iso to choose BIOS or EFI builds. ISOs supporting both are not longer possible.

'firmware' is added as deprecated since BIOS support is deprecated leaving EFI as the only option.

Firmware is set to EFI by default

Signed-off-by: David Cassany <dcassany@suse.com>