### PR TITLE
Remove sanity check for SUSE based systems on efi installation

### DIFF
--- a/pkg/utils/grub.go
+++ b/pkg/utils/grub.go
@@ -208,11 +208,6 @@ func (g Grub) Install(target, rootDir, bootDir, grubConf, tty string, efi bool, 
 				}
 
 				if d.Name() == f {
-					// On suse systems check if the path contains the proper arch
-					if system == cnst.Suse && !strings.Contains(path, g.config.Arch) {
-						return nil
-					}
-
 					fileContent, err := g.config.Fs.ReadFile(path)
 					if err != nil {
 						return fmt.Errorf("error reading %s: %s", path, err)


### PR DESCRIPTION
Shim images are under /usr/share/efi/aarch64/shim.efi in arm64 hence the architecture string is not included within the path. Same happens with the grub.efi image.

Signed-off-by: David Cassany <dcassany@suse.com>