### PR TITLE
Add binary signatures

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,8 @@ jobs:
     permissions:
       id-token: write  # undocumented OIDC support.
       contents: write
+    env:
+      COSIGN_EXPERIMENTAL: 1
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -22,8 +24,6 @@ jobs:
           go-version: 1.17
       - name: Set up cosign
         uses: sigstore/cosign-installer@main
-        with:
-          cosign-release: 'v1.7.1' # optional
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,6 +15,12 @@ builds:
     goarm:
       - 6
       - 7
+signs:
+  - cmd: cosign
+    signature: "${artifact}.sig"
+    certificate: "${artifact}.pem"
+    args: ["sign-blob", "--oidc-issuer=https://token.actions.githubusercontent.com", "--output-certificate=${certificate}", "--output-signature=${signature}", "${artifact}"]
+    artifacts: all
 source:
   enabled: true
   name_template: '{{ .ProjectName }}-{{ .Tag }}-source'


### PR DESCRIPTION
Seems like a bad mix of an older cosign + newer goreleaser was causing the issues. Tested in a different repo and all artifacts were properly signed with no issues

Signed-off-by: Itxaka <igarcia@suse.com>