### PR TITLE
Do not add partitions in EFI ISOs

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -104,8 +104,8 @@ const (
 	// Kernel and initrd paths are arbitrary and coupled to grub.cfg
 	IsoKernelPath = "/boot/kernel"
 	IsoInitrdPath = "/boot/initrd"
+	IsoEfiImg     = "/boot/uefi.img"
 	IsoRootFile   = "rootfs.squashfs"
-	IsoEFIImg     = "uefi.img"
 	ISOLabel      = "COS_LIVE"
 
 	// Default directory and file fileModes

--- a/pkg/live/common.go
+++ b/pkg/live/common.go
@@ -76,17 +76,13 @@ const (
 	fi`
 )
 
-func XorrisoBooloaderArgs(root, efiImg, firmware string) []string {
+func XorrisoBooloaderArgs(root, firmware string) []string {
 	switch firmware {
 	case v1.EFI:
 		args := []string{
-			"-append_partition", "2", "0xef", efiImg,
 			"-boot_image", "any", fmt.Sprintf("cat_path=%s", isoBootCatalog),
 			"-boot_image", "any", "cat_hidden=on",
-			"-boot_image", "any", "efi_path=--interval:appended_partition_2:all::",
-			"-boot_image", "any", "platform_id=0xef",
-			"-boot_image", "any", "appended_part_as=gpt",
-			"-boot_image", "any", "partition_offset=16",
+			"-boot_image", "any", fmt.Sprintf("efi_path=%s", constants.IsoEfiImg),
 		}
 		return args
 	case v1.BIOS:


### PR DESCRIPTION
There is no need of adding partition headers in EFI ISOs as they can still be dded to a USB and boot from there.

related to rancher/elemental#365

Signed-off-by: David Cassany <dcassany@suse.com>