### PR TITLE
Fill persistent mountpoint on upgrade

### DIFF
--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -164,9 +164,7 @@ func (u *UpgradeAction) Run() (err error) {
 			tmpdir := utils.GetTempDir(&u.config.Config, "")
 			u.config.Luet.SetTempDir(tmpdir)
 			// Remove the tmpdir before unmounting
-			cleanup.Push(func() error {
-				return u.config.Fs.RemoveAll(filepath.Join(persistentPart.MountPoint, "tmp"))
-			})
+			cleanup.Push(func() error { return u.config.Fs.RemoveAll(tmpdir) })
 			cleanup.Push(umount)
 		}
 	}

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -150,15 +150,21 @@ func (u *UpgradeAction) Run() (err error) {
 	// Cleanup transition image file before leaving
 	cleanup.Push(func() error { return u.remove(upgradeImg.File) })
 
-	// Recovery does not mount persistent, so try to mount it. Ignore errors, as its not mandatory.
+	// Recovery does not mount persistent, so try to mount it. Ignore errors, as it's not mandatory.
 	persistentPart := u.spec.Partitions.Persistent
+	// Create the dir otherwise the check for mounted dir fails
+	_ = utils.MkdirAll(u.config.Fs, persistentPart.MountPoint, constants.DirPerm)
 	if mnt, err := utils.IsMounted(&u.config.Config, persistentPart); !mnt && err == nil {
 		u.Debug("mounting persistent partition")
-		err := e.MountPartition(persistentPart, "rw")
+		umount, err = e.MountRWPartition(persistentPart)
 		if err != nil {
-			u.config.Logger.Warn("could not mount persistent partition")
+			u.config.Logger.Warn("could not mount persistent partition: %s", err.Error())
 		} else {
-			cleanup.Push(func() error { return e.UnmountPartition(persistentPart) })
+			// Remove the tmpdir before unmounting
+			cleanup.Push(func() error {
+				return u.config.Fs.RemoveAll(filepath.Join(persistentPart.MountPoint, "tmp"))
+			})
+			cleanup.Push(umount)
 		}
 	}
 

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -160,6 +160,9 @@ func (u *UpgradeAction) Run() (err error) {
 		if err != nil {
 			u.config.Logger.Warn("could not mount persistent partition: %s", err.Error())
 		} else {
+			// Set luet tempdir
+			tmpdir := utils.GetTempDir(&u.config.Config, "")
+			u.config.Luet.SetTempDir(tmpdir)
 			// Remove the tmpdir before unmounting
 			cleanup.Push(func() error {
 				return u.config.Fs.RemoveAll(filepath.Join(persistentPart.MountPoint, "tmp"))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -336,6 +336,15 @@ func NewUpgradeSpec(cfg v1.Config) (*v1.UpgradeSpec, error) {
 		}
 	}
 
+	// This is needed if we want to use the persistent as tmpdir for the upgrade images
+	// as tmpfs is 25% of the total RAM, we cannot rely on the tmp dir having enough space for our image
+	// This enables upgrades on low ram devices
+	if ep.Persistent != nil {
+		if ep.Persistent.MountPoint == "" {
+			ep.Persistent.MountPoint = constants.PersistentDir
+		}
+	}
+
 	return &v1.UpgradeSpec{
 		Active:     active,
 		Recovery:   recovery,

--- a/pkg/luet/luet.go
+++ b/pkg/luet/luet.go
@@ -20,6 +20,7 @@ import (
 	"crypto/md5"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -27,6 +28,7 @@ import (
 	"github.com/docker/go-units"
 	"github.com/mudler/luet/pkg/api/core/bus"
 	"github.com/mudler/luet/pkg/api/core/context"
+	gc "github.com/mudler/luet/pkg/api/core/garbagecollector"
 	luetTypes "github.com/mudler/luet/pkg/api/core/types"
 	"github.com/mudler/luet/pkg/database"
 	"github.com/mudler/luet/pkg/helpers/docker"
@@ -385,4 +387,13 @@ func (l Luet) createLuetConfig() *luetTypes.LuetConfig {
 		config.System.DatabasePath = l.TmpDir
 	}
 	return config
+}
+
+// SetTempDir re-sets the temp dir for all the luet stuff
+func (l *Luet) SetTempDir(tmpdir string) {
+	l.TmpDir = tmpdir
+	l.context.Config.System.TmpDirBase = l.TmpDir
+	l.context.Config.System.PkgsCachePath = l.TmpDir
+	l.context.Config.System.DatabasePath = l.TmpDir
+	l.context.GarbageCollector = gc.GarbageCollector(filepath.Join(tmpdir, "tmpluet"))
 }

--- a/pkg/types/v1/luet.go
+++ b/pkg/types/v1/luet.go
@@ -22,4 +22,5 @@ type LuetInterface interface {
 	SetPlugins(...string)
 	GetPlugins() []string
 	SetArch(string)
+	SetTempDir(string)
 }

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -362,10 +362,12 @@ func GetTempDir(config *v1.Config, suffix string) string {
 	elementalTmpDir := fmt.Sprintf("elemental-%s", suffix)
 	dir := os.Getenv("TMPDIR")
 	if dir != "" {
+		config.Logger.Debugf("Got tmpdir from TMPDIR var: %s", dir)
 		return filepath.Join(dir, elementalTmpDir)
 	}
 	parts, err := GetAllPartitions()
 	if err != nil {
+		config.Logger.Debug("Could not get partitions, defaulting to /tmp")
 		return filepath.Join("/", "tmp", elementalTmpDir)
 	}
 	// Check persistent and if its mounted
@@ -373,9 +375,11 @@ func GetTempDir(config *v1.Config, suffix string) string {
 	persistent := ep.Persistent
 	if persistent != nil {
 		if mnt, _ := IsMounted(config, persistent); mnt {
-			return filepath.Join(persistent.MountPoint, elementalTmpDir)
+			config.Logger.Debugf("Using tmpdir on persistent volume: %s", persistent.MountPoint)
+			return filepath.Join(persistent.MountPoint, "tmp", elementalTmpDir)
 		}
 	}
+	config.Logger.Debug("Could not get any valid tmpdir, defaulting to /tmp")
 	return filepath.Join("/", "tmp", elementalTmpDir)
 }
 

--- a/tests/mocks/luet_mock.go
+++ b/tests/mocks/luet_mock.go
@@ -81,3 +81,5 @@ func (l *FakeLuet) GetPlugins() []string {
 func (l *FakeLuet) SetArch(arch string) {
 	l.arch = arch
 }
+
+func (l *FakeLuet) SetTempDir(s string) {}


### PR DESCRIPTION
Upgrade tries to mount the persistent partition during the upgrade in order to use it as tmp dir to store and decompress images. Unfortunately as the mountpoint is empty, this fails and it always falls back to the /tmp dir which is a tmpfs dir with 25% of the RAM as space. This means that in a 4Gb device we get a /tmp dir of 1Gb, which is not enough to download and decompress a single image.

This used to work before so we probably introduced this regression with some changes and never notice due our workers having 10Gb of RAM

This patch fills the persistent mountpoint on upgrade config load so we can temp mount it during upgrade and maintains the same fallback

Signed-off-by: itxaka <igarcia@suse.com>