### PR TITLE
upgrade: Skip the device which only has the same label name

### DIFF
--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -167,7 +167,7 @@ func (u *UpgradeAction) Run() (err error) { // nolint:gocyclo
 			upgradeStateDir = constants.RecoveryDir
 		} else { // We are updating active
 			// Remount state partition RW
-			statePart, _ := utils.GetFullDeviceByLabel(u.Config.Runner, u.Config.StateLabel, 2)
+			statePart, _ := utils.GetcOSActiveFullDeviceByLabel(u.Config.Runner, u.Config.StateLabel, 2)
 			err = u.Config.Mounter.Mount(statePart.Path, statePart.MountPoint, "auto", []string{"remount", "rw"})
 			if err != nil {
 				u.Error("Error mounting %s: %s", statePart.MountPoint, err)

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -76,6 +76,25 @@ func GetFullDeviceByLabel(runner v1.Runner, label string, attempts int) (*v1.Par
 	return nil, errors.New("no device found")
 }
 
+// GetcOSActiveFullDeviceByLabel works like GetDeviceByLabel, but it will try to get as much info as possible from the existing
+// partition and make sure they are running(active)
+func GetcOSActiveFullDeviceByLabel(runner v1.Runner, label string, attempts int) (*v1.Partition, error) {
+	for tries := 0; tries < attempts; tries++ {
+		_, _ = runner.Run("udevadm", "settle")
+		parts, err := GetAllPartitions()
+		if err != nil {
+			return nil, err
+		}
+		for _, part := range parts {
+			if part.Label == label && part.MountPoint == cnst.RunningStateDir {
+				return part, nil
+			}
+		}
+		time.Sleep(1 * time.Second)
+	}
+	return nil, errors.New("no device found")
+}
+
 // CopyFile Copies source file to target file using Fs interface. If target
 // is  directory source is copied into that directory using source name file.
 func CopyFile(fs v1.FS, source string, target string) (err error) {


### PR DESCRIPTION
    - when upgrading, we need find the related label name and
      upgrade with it. If we have many devices have the same
      label name, it would cause failure. To avoid this case,
      we need add more checking about the target disk should
      be the active cOS disk.

Fixes  #348 

Signed-off-by: Vicente Cheng <vicente.cheng@suse.com>