### PR TITLE
upgrade: Skip the device which only has the same label name

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,12 +1,5 @@
 name: Docker build and push
 on:
-  pull_request:
-    paths:
-      - Dockerfile
-      - .github/workflows/docker.yaml
-  push:
-    branches:
-      - main
     tags:
       - 'v*'
 jobs:
@@ -17,10 +10,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Install qemu-tools
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y qemu-utils
       - name: Export tag
         id: export_tag
         run: |
@@ -32,7 +21,7 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: |
-            quay.io/costoolkit/elemental
+            quay.io/costoolkit/elemental-ci
           tags: |
             type=semver,pattern=v{{version}}
             type=sha,format=short,prefix=${{ steps.export_tag.outputs.elemental_tag }}-
@@ -40,48 +29,13 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to Quay
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v1
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
-      - name: Build image
+      - name: Push image
         uses: docker/build-push-action@v2
-        with:
-          context: .
-          tags: ${{ steps.meta.outputs.tags }}
-          load: true # loads it locally, so it can be used from docker client
-          # cache into GitHub actions cache, nice
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          target: elemental
-          build-args: |
-            ELEMENTAL_VERSION=${{ steps.export_tag.outputs.elemental_tag }}
-            ELEMENTAL_COMMIT=${{ github.sha }}
-      - name: Test elemental image version
-        run: docker run ${{ steps.meta.outputs.tags }} version --long
-      - name: Test elemental image install with --force-efi
-        run: |
-          # create a 30Gb file
-          qemu-img create -f raw disk-efi.img 30G
-          # mount loop device and get the device
-          LOOP=`sudo losetup -fP --show disk-efi.img`
-          docker run -v /dev/:/dev/ --privileged ${{ steps.meta.outputs.tags }} install --force-efi --debug -d quay.io/costoolkit/releases-green:cos-system-0.8.6 $LOOP
-          sudo losetup -D $LOOP
-          rm disk-efi.img
-      - name: Test elemental image install
-        run: |
-          # create a 30Gb file
-          qemu-img create -f raw disk.img 30G
-          # mount loop device and get the device
-          LOOP=`sudo losetup -fP --show disk.img`
-          docker run -v /dev/:/dev/ --privileged ${{ steps.meta.outputs.tags }} install --debug -d quay.io/costoolkit/releases-green:cos-system-0.8.6 $LOOP
-          sudo losetup -D $LOOP
-          rm disk.img
-      - name: Push image  # should be a free build as everything has been cached and loaded
-        uses: docker/build-push-action@v2
-        if: ${{ github.event_name != 'pull_request' }}
         with:
           context: .
           push: true

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -167,7 +167,7 @@ func (u *UpgradeAction) Run() (err error) { // nolint:gocyclo
 			upgradeStateDir = constants.RecoveryDir
 		} else { // We are updating active
 			// Remount state partition RW
-			statePart, _ := utils.GetFullDeviceByLabel(u.Config.Runner, u.Config.StateLabel, 2)
+			statePart, _ := utils.GetcOSActiveFullDeviceByLabel(u.Config.Runner, u.Config.StateLabel, 2)
 			err = u.Config.Mounter.Mount(statePart.Path, statePart.MountPoint, "auto", []string{"remount", "rw"})
 			if err != nil {
 				u.Error("Error mounting %s: %s", statePart.MountPoint, err)

--- a/pkg/http/client_test.go
+++ b/pkg/http/client_test.go
@@ -27,7 +27,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-const source = "https://github.com/rancher-sandbox/elemental/releases/download/v0.0.13/elemental-v0.0.13-Linux-x86_64.tar.gz"
+const source = "https://github.com/rancher/elemental-cli/releases/download/v0.0.13/elemental-v0.0.13-Linux-x86_64.tar.gz"
 
 var _ = Describe("HTTPClient", Label("http"), func() {
 	var client *http.Client

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -76,6 +76,25 @@ func GetFullDeviceByLabel(runner v1.Runner, label string, attempts int) (*v1.Par
 	return nil, errors.New("no device found")
 }
 
+// GetcOSActiveFullDeviceByLabel works like GetDeviceByLabel, but it will try to get as much info as possible from the existing
+// partition and make sure they are running(active)
+func GetcOSActiveFullDeviceByLabel(runner v1.Runner, label string, attempts int) (*v1.Partition, error) {
+	for tries := 0; tries < attempts; tries++ {
+		_, _ = runner.Run("udevadm", "settle")
+		parts, err := GetAllPartitions()
+		if err != nil {
+			return nil, err
+		}
+		for _, part := range parts {
+			if part.Label == label && part.MountPoint == cnst.RunningStateDir {
+				return part, nil
+			}
+		}
+		time.Sleep(1 * time.Second)
+	}
+	return nil, errors.New("no device found")
+}
+
 // CopyFile Copies source file to target file using Fs interface. If target
 // is  directory source is copied into that directory using source name file.
 func CopyFile(fs v1.FS, source string, target string) (err error) {


### PR DESCRIPTION
- when upgrading, we need find the related label name and
      upgrade with it. If we have many devices have the same
      label name, it would cause failure. To avoid this case,
      we need add more checking about the target disk should
      be the active cOS disk.

Fixes rancher/elemental-cli#348 

Signed-off-by: Vicente Cheng <vicente.cheng@suse.com>