### PR TITLE
[POC] Exit codes

### DIFF
--- a/cmd/build-disk.go
+++ b/cmd/build-disk.go
@@ -17,7 +17,8 @@ limitations under the License.
 package cmd
 
 import (
-	"fmt"
+	"github.com/rancher/elemental-cli/pkg/constants"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -54,7 +55,7 @@ func NewBuildDisk(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 
 			err = validateCosignFlags(cfg.Logger, flags)
 			if err != nil {
-				return err
+				os.Exit(constants.ExitCosignError)
 			}
 
 			// Set this after parsing of the flags, so it fails on parsing and prints usage properly
@@ -63,8 +64,7 @@ func NewBuildDisk(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 
 			spec, err := config.ReadBuildDisk(cfg, flags)
 			if err != nil {
-				cfg.Logger.Errorf("invalid install command setup %v", err)
-				return err
+				os.Exit(constants.ExitConfigError)
 			}
 
 			// Get the spec for the arch only
@@ -89,15 +89,10 @@ func NewBuildDisk(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 
 			if exists, _ := utils.Exists(cfg.Fs, output); exists {
 				cfg.Logger.Errorf("Output file %s exists, refusing to continue", output)
-				return fmt.Errorf("output file %s exists, refusing to continue", output)
+				os.Exit(constants.ExitFileExists)
 			}
 
-			err = action.BuildDiskRun(cfg, specArch, imgType, oemLabel, recoveryLabel, output)
-			if err != nil {
-				return err
-			}
-
-			return nil
+			return action.BuildDiskRun(cfg, specArch, imgType, oemLabel, recoveryLabel, output)
 		},
 	}
 	root.AddCommand(c)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"github.com/rancher/elemental-cli/pkg/constants"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -47,6 +48,6 @@ var rootCmd = NewRootCmd()
 func Execute() {
 	err := rootCmd.Execute()
 	if err != nil {
-		os.Exit(1)
+		os.Exit(constants.ExitUnknownError)
 	}
 }

--- a/pkg/constants/exit_codes.go
+++ b/pkg/constants/exit_codes.go
@@ -1,0 +1,23 @@
+package constants
+
+const (
+	ExitUnknownError = iota + 10
+	ExitCopyError
+	ExitTempdirError
+	ExitNoPackagesArchBuildDisk
+	ExitNoRepoConfiguredBuildDisk
+	ExitCreateDirError
+	ExitCreateFileError
+	ExitTruncateFileError
+	ExitFailedFileCloseError
+	ExitOpenFileError
+	ExitStatFileError
+	ExitTarError
+	ExitGzipError
+	ExitParseSourceError
+	ExitCosignError
+	ExitConfigError
+	ExitFileExists
+	ExitFailedCratingPart
+	ExitFailedRunningCmd
+)

--- a/pkg/error/elementalError.go
+++ b/pkg/error/elementalError.go
@@ -1,0 +1,22 @@
+package error
+
+// ElementalError is our enhanced error that brings an error string + exit code
+type ElementalError struct {
+	s    string
+	code int
+}
+
+func (e ElementalError) ExitCode() int {
+	return e.code
+}
+
+func (e ElementalError) Error() string {
+	return e.s
+}
+
+func New(err error, code int) *ElementalError {
+	return &ElementalError{
+		s:    err.Error(),
+		code: code,
+	}
+}


### PR DESCRIPTION
This is an example on how to tag and propagate the exit codes from different parts of the code into the final cmd and how to exit properly from different parts of the code.

 - Introduces an enhanced Error that also brings the code inside it so we can propagate the errors along the code for functions that support it, i.e. if CreateImage has several parts where it could fail we have to return an ElementalError so we can cleanup and then os.exit with the proper error code.
 - introduces exit_codes list under the constants dir. Did not bother to make specific numbers associated with them and just used an iota. Not sure about this as when the list grows the codes migth change if we change the order, maybe it would be nicer to have some specific codes attached to specific errors and they are frozen for life?


So putting it out there for consideration. I tried several approaches with this, but unfortunately os.exit DOES NOT call any defer calls, so in our case its very important that on failure we try to cleanup as much as possible, removing temp dirs, remounting/unmounting partitions, etc... so we cannot blindly just call that. And making everything use our elementalError is a bit of pita as there is a lot of places we pass the errors from one function to other before we can really exit due to the cleanup....


Not sure if a better way is possible? Maybe we could use go channels to have a channel that runs the cleanup and exits with an exit code and we then can call that from anywhere? No idea, seems more complex.

Anyway, putting this up for comments, ideas, new approaches, etc..

Signed-off-by: itxaka <igarcia@suse.com>