### PR TITLE
upgrade: correct the target path about grub content

### DIFF
--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -522,7 +522,7 @@ func (c Elemental) SetDefaultGrubEntry() error {
 	part = c.config.Partitions.GetByName(cnst.StatePartName)
 	if part == nil {
 		// Try to fall back to get it via StateLabel
-		p, err := utils.GetFullDeviceByLabel(c.config.Runner, c.config.StateLabel, 5)
+		p, err := utils.GetcOSActiveFullDeviceByLabel(c.config.Runner, c.config.StateLabel, 5)
 		if err != nil {
 			return errors.New("state partition not found. Cannot set grub env file")
 		} else if p.MountPoint == "" {


### PR DESCRIPTION
    - ensure that the related disk label would present
      the correct disk to set the default grub entry

related issues: #356 
