### PR TITLE
More exit codes

### DIFF
--- a/cmd/build-iso.go
+++ b/cmd/build-iso.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
 	"os/exec"
 
 	"github.com/spf13/cobra"
@@ -87,7 +88,7 @@ func NewBuildISO(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 			} else if len(spec.RootFS) == 0 {
 				errmsg := "rootfs source image for building ISO was not provided"
 				cfg.Logger.Errorf(errmsg)
-				return elementalError.NewFromError(err, elementalError.NoSourceProvided)
+				return elementalError.New(errmsg, elementalError.NoSourceProvided)
 			}
 
 			// Repos and overlays can't be unmarshaled directly as they require
@@ -101,24 +102,27 @@ func NewBuildISO(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 				if ok, err := utils.Exists(cfg.Fs, oRootfs); ok {
 					spec.RootFS = append(spec.RootFS, v1.NewDirSrc(oRootfs))
 				} else {
-					cfg.Logger.Errorf("Invalid RootFS overlay path '%s': %v", oRootfs, err)
-					return elementalError.NewFromError(err, elementalError.StatFile)
+					msg := fmt.Sprintf("Invalid path '%s': %v", oRootfs, err)
+					cfg.Logger.Errorf(msg)
+					return elementalError.New(msg, elementalError.StatFile)
 				}
 			}
 			if oUEFI != "" {
 				if ok, err := utils.Exists(cfg.Fs, oUEFI); ok {
 					spec.UEFI = append(spec.UEFI, v1.NewDirSrc(oUEFI))
 				} else {
-					cfg.Logger.Errorf("Invalid UEFI overlay path '%s': %v", oUEFI, err)
-					return elementalError.NewFromError(err, elementalError.StatFile)
+					msg := fmt.Sprintf("Invalid path '%s': %v", oUEFI, err)
+					cfg.Logger.Errorf(msg)
+					return elementalError.New(msg, elementalError.StatFile)
 				}
 			}
 			if oISO != "" {
 				if ok, err := utils.Exists(cfg.Fs, oISO); ok {
 					spec.Image = append(spec.Image, v1.NewDirSrc(oISO))
 				} else {
-					cfg.Logger.Errorf("Invalid ISO overlay path '%s': %v", oISO, err)
-					return elementalError.NewFromError(err, elementalError.StatFile)
+					msg := fmt.Sprintf("Invalid path '%s': %v", oISO, err)
+					cfg.Logger.Errorf(msg)
+					return elementalError.New(msg, elementalError.StatFile)
 				}
 			}
 

--- a/cmd/build-iso.go
+++ b/cmd/build-iso.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cmd
 
 import (
-	"fmt"
 	"os/exec"
 
 	"github.com/spf13/cobra"
@@ -27,6 +26,7 @@ import (
 	"github.com/rancher/elemental-cli/cmd/config"
 	"github.com/rancher/elemental-cli/pkg/action"
 	"github.com/rancher/elemental-cli/pkg/constants"
+	elementalError "github.com/rancher/elemental-cli/pkg/error"
 	v1 "github.com/rancher/elemental-cli/pkg/types/v1"
 	"github.com/rancher/elemental-cli/pkg/utils"
 )
@@ -52,19 +52,20 @@ func NewBuildISO(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			path, err := exec.LookPath("mount")
 			if err != nil {
-				return err
+				return elementalError.NewFromError(err, elementalError.StatFile)
 			}
 			mounter := mount.New(path)
 
 			cfg, err := config.ReadConfigBuild(viper.GetString("config-dir"), cmd.Flags(), mounter)
 			if err != nil {
 				cfg.Logger.Errorf("Error reading config: %s\n", err)
+				return elementalError.NewFromError(err, elementalError.ReadingBuildConfig)
 			}
 
 			flags := cmd.Flags()
 			err = validateCosignFlags(cfg.Logger, flags)
 			if err != nil {
-				return err
+				return elementalError.NewFromError(err, elementalError.CosignWrongFlags)
 			}
 
 			// Set this after parsing of the flags, so it fails on parsing and prints usage properly
@@ -73,20 +74,20 @@ func NewBuildISO(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 			spec, err := config.ReadBuildISO(cfg, flags)
 			if err != nil {
 				cfg.Logger.Errorf("invalid install command setup %v", err)
-				return err
+				return elementalError.NewFromError(err, elementalError.ReadingSpecConfig)
 			}
 
 			if len(args) == 1 {
 				imgSource, err := v1.NewSrcFromURI(args[0])
 				if err != nil {
 					cfg.Logger.Errorf("not a valid rootfs source image argument: %s", args[0])
-					return err
+					return elementalError.NewFromError(err, elementalError.IdentifySource)
 				}
 				spec.RootFS = []*v1.ImageSource{imgSource}
 			} else if len(spec.RootFS) == 0 {
 				errmsg := "rootfs source image for building ISO was not provided"
 				cfg.Logger.Errorf(errmsg)
-				return fmt.Errorf(errmsg)
+				return elementalError.NewFromError(err, elementalError.NoSourceProvided)
 			}
 
 			// Repos and overlays can't be unmarshaled directly as they require
@@ -100,24 +101,24 @@ func NewBuildISO(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 				if ok, err := utils.Exists(cfg.Fs, oRootfs); ok {
 					spec.RootFS = append(spec.RootFS, v1.NewDirSrc(oRootfs))
 				} else {
-					cfg.Logger.Errorf("Invalid value for overlay-rootfs")
-					return fmt.Errorf("Invalid path '%s': %v", oRootfs, err)
+					cfg.Logger.Errorf("Invalid RootFS overlay path '%s': %v", oRootfs, err)
+					return elementalError.NewFromError(err, elementalError.StatFile)
 				}
 			}
 			if oUEFI != "" {
 				if ok, err := utils.Exists(cfg.Fs, oUEFI); ok {
 					spec.UEFI = append(spec.UEFI, v1.NewDirSrc(oUEFI))
 				} else {
-					cfg.Logger.Errorf("Invalid value for overlay-uefi")
-					return fmt.Errorf("Invalid path '%s': %v", oUEFI, err)
+					cfg.Logger.Errorf("Invalid UEFI overlay path '%s': %v", oUEFI, err)
+					return elementalError.NewFromError(err, elementalError.StatFile)
 				}
 			}
 			if oISO != "" {
 				if ok, err := utils.Exists(cfg.Fs, oISO); ok {
 					spec.Image = append(spec.Image, v1.NewDirSrc(oISO))
 				} else {
-					cfg.Logger.Errorf("Invalid value for overlay-iso")
-					return fmt.Errorf("Invalid path '%s': %v", oISO, err)
+					cfg.Logger.Errorf("Invalid ISO overlay path '%s': %v", oISO, err)
+					return elementalError.NewFromError(err, elementalError.StatFile)
 				}
 			}
 
@@ -126,13 +127,7 @@ func NewBuildISO(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 			}
 
 			buildISO := action.NewBuildISOAction(cfg, spec)
-			err = buildISO.ISORun()
-			if err != nil {
-				cfg.Logger.Errorf(err.Error())
-				return err
-			}
-
-			return nil
+			return buildISO.ISORun()
 		},
 	}
 

--- a/cmd/pull-image.go
+++ b/cmd/pull-image.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/mount-utils"
 
 	"github.com/rancher/elemental-cli/cmd/config"
+	elementalError "github.com/rancher/elemental-cli/pkg/error"
 	"github.com/rancher/elemental-cli/pkg/luet"
 )
 
@@ -41,16 +42,16 @@ func NewPullImageCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := config.ReadConfigRun(viper.GetString("config-dir"), cmd.Flags(), &mount.FakeMounter{})
-
 			if err != nil {
 				cfg.Logger.Errorf("Error reading config: %s\n", err)
+				return elementalError.NewFromError(err, elementalError.ReadingRunConfig)
 			}
 
 			image := args[0]
 			destination, err := filepath.Abs(args[1])
 			if err != nil {
 				cfg.Logger.Errorf("Invalid path %s", destination)
-				return err
+				return elementalError.NewFromError(err, elementalError.StatFile)
 			}
 
 			// Set this after parsing of the flags, so it fails on parsing and prints usage properly
@@ -82,7 +83,7 @@ func NewPullImageCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 
 			if err != nil {
 				cfg.Logger.Error(err.Error())
-				return err
+				return elementalError.NewFromError(err, elementalError.UnpackImage)
 			}
 
 			return nil

--- a/cmd/run-stage.go
+++ b/cmd/run-stage.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/mount-utils"
 
 	"github.com/rancher/elemental-cli/cmd/config"
+	elementalError "github.com/rancher/elemental-cli/pkg/error"
 	"github.com/rancher/elemental-cli/pkg/utils"
 )
 
@@ -35,12 +36,13 @@ func NewRunStage(root *cobra.Command) *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := config.ReadConfigRun(viper.GetString("config-dir"), cmd.Flags(), &mount.FakeMounter{})
-
 			if err != nil {
 				cfg.Logger.Errorf("Error reading config: %s\n", err)
+				return elementalError.NewFromError(err, elementalError.ReadingRunConfig)
 			}
 
-			return utils.RunStage(&cfg.Config, args[0], cfg.Strict)
+			err = utils.RunStage(&cfg.Config, args[0], cfg.Strict)
+			return elementalError.NewFromError(err, elementalError.CloudInitRunStage)
 		},
 	}
 	root.AddCommand(c)

--- a/docs/elemental_exit-codes.md
+++ b/docs/elemental_exit-codes.md
@@ -37,7 +37,6 @@
 | 41 | Error occurred during cleanup|
 | 42 | Error occurred trying to reboot|
 | 43 | Error occurred trying to shutdown|
-| 44 | Error occurred when unmounting image|
 | 44 | Error occurred when labeling partition|
 | 45 | Error setting default grub entry|
 | 46 | Error occurred during selinux relabeling|
@@ -65,4 +64,5 @@
 | 68 | No source was provided for the command|
 | 69 | Error removing a file|
 | 70 | Error calculating checksum|
+| 71 | Error occurred when unmounting image|
 | 255 | Unknown error|

--- a/docs/elemental_exit-codes.md
+++ b/docs/elemental_exit-codes.md
@@ -37,8 +37,8 @@
 | 41 | Error occurred during cleanup|
 | 42 | Error occurred trying to reboot|
 | 43 | Error occurred trying to shutdown|
-| 44 | Error occurred when labeling partition|
 | 44 | Error occurred when unmounting image|
+| 44 | Error occurred when labeling partition|
 | 45 | Error setting default grub entry|
 | 46 | Error occurred during selinux relabeling|
 | 47 | Error invalid device specified|
@@ -58,4 +58,11 @@
 | 61 | Error during before-reset hook|
 | 62 | Error during after-reset-chroot hook|
 | 63 | Error during after-reset hook|
+| 64 | Unsupported flavor|
+| 65 | Error encountered during cloud-init run-stage|
+| 66 | Error unpacking image|
+| 67 | Error reading file|
+| 68 | No source was provided for the command|
+| 69 | Error removing a file|
+| 70 | Error calculating checksum|
 | 255 | Unknown error|

--- a/pkg/action/build-iso.go
+++ b/pkg/action/build-iso.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/rancher/elemental-cli/pkg/constants"
 	"github.com/rancher/elemental-cli/pkg/elemental"
+	elementalError "github.com/rancher/elemental-cli/pkg/error"
 	"github.com/rancher/elemental-cli/pkg/live"
 	v1 "github.com/rancher/elemental-cli/pkg/types/v1"
 	"github.com/rancher/elemental-cli/pkg/utils"
@@ -68,33 +69,36 @@ func (b *BuildISOAction) ISORun() (err error) {
 
 	isoTmpDir, err := utils.TempDir(b.cfg.Fs, "", "elemental-iso")
 	if err != nil {
-		return err
+		return elementalError.NewFromError(err, elementalError.CreateTempDir)
 	}
 	cleanup.Push(func() error { return b.cfg.Fs.RemoveAll(isoTmpDir) })
 
 	rootDir := filepath.Join(isoTmpDir, "rootfs")
 	err = utils.MkdirAll(b.cfg.Fs, rootDir, constants.DirPerm)
 	if err != nil {
-		return err
+		b.cfg.Logger.Errorf("Failed creating rootfs dir: %s", rootDir)
+		return elementalError.NewFromError(err, elementalError.CreateDir)
 	}
 
 	uefiDir := filepath.Join(isoTmpDir, "uefi")
 	err = utils.MkdirAll(b.cfg.Fs, uefiDir, constants.DirPerm)
 	if err != nil {
-		return err
+		b.cfg.Logger.Errorf("Failed creating uefi dir: %s", uefiDir)
+		return elementalError.NewFromError(err, elementalError.CreateDir)
 	}
 
 	isoDir := filepath.Join(isoTmpDir, "iso")
 	err = utils.MkdirAll(b.cfg.Fs, isoDir, constants.DirPerm)
 	if err != nil {
-		return err
+		b.cfg.Logger.Errorf("Failed creating iso dir: %s", isoDir)
+		return elementalError.NewFromError(err, elementalError.CreateDir)
 	}
 
 	if b.cfg.OutDir != "" {
 		err = utils.MkdirAll(b.cfg.Fs, b.cfg.OutDir, constants.DirPerm)
 		if err != nil {
-			b.cfg.Logger.Errorf("Failed creating output folder: %s", b.cfg.OutDir)
-			return err
+			b.cfg.Logger.Errorf("Failed creating output dir: %s", b.cfg.OutDir)
+			return elementalError.NewFromError(err, elementalError.CreateDir)
 		}
 	}
 
@@ -107,7 +111,7 @@ func (b *BuildISOAction) ISORun() (err error) {
 	err = utils.CreateDirStructure(b.cfg.Fs, rootDir)
 	if err != nil {
 		b.cfg.Logger.Errorf("Failed creating root directory structure: %v", err)
-		return err
+		return elementalError.NewFromError(err, elementalError.CreateDir)
 	}
 
 	if b.spec.Firmware == v1.EFI {
@@ -116,7 +120,7 @@ func (b *BuildISOAction) ISORun() (err error) {
 			err = b.liveBoot.PrepareEFI(rootDir, uefiDir)
 			if err != nil {
 				b.cfg.Logger.Errorf("Failed fetching EFI data: %v", err)
-				return err
+				return elementalError.NewFromError(err, elementalError.CopyData)
 			}
 		}
 		err = b.applySources(uefiDir, b.spec.UEFI...)
@@ -131,7 +135,7 @@ func (b *BuildISOAction) ISORun() (err error) {
 		err = b.liveBoot.PrepareISO(rootDir, isoDir)
 		if err != nil {
 			b.cfg.Logger.Errorf("Failed fetching bootloader binaries: %v", err)
-			return err
+			return elementalError.NewFromError(err, elementalError.CreateFile)
 		}
 	}
 	err = b.applySources(isoDir, b.spec.Image...)
@@ -168,33 +172,29 @@ func (b BuildISOAction) prepareISORoot(isoDir string, rootDir string) error {
 	kernel, initrd, err := b.e.FindKernelInitrd(rootDir)
 	if err != nil {
 		b.cfg.Logger.Error("Could not find kernel and/or initrd")
-		return err
+		return elementalError.NewFromError(err, elementalError.StatFile)
 	}
 	err = utils.MkdirAll(b.cfg.Fs, filepath.Join(isoDir, "boot"), constants.DirPerm)
 	if err != nil {
-		return err
+		return elementalError.NewFromError(err, elementalError.CreateDir)
 	}
 	//TODO document boot/kernel and boot/initrd expectation in bootloader config
 	b.cfg.Logger.Debugf("Copying Kernel file %s to iso root tree", kernel)
 	err = utils.CopyFile(b.cfg.Fs, kernel, filepath.Join(isoDir, constants.IsoKernelPath))
 	if err != nil {
-		return err
+		return elementalError.NewFromError(err, elementalError.CopyFile)
 	}
 
 	b.cfg.Logger.Debugf("Copying initrd file %s to iso root tree", initrd)
 	err = utils.CopyFile(b.cfg.Fs, initrd, filepath.Join(isoDir, constants.IsoInitrdPath))
 	if err != nil {
-		return err
+		return elementalError.NewFromError(err, elementalError.CopyFile)
 	}
 
 	b.cfg.Logger.Info("Creating squashfs...")
 	squashOptions := append(constants.GetDefaultSquashfsOptions(), b.cfg.SquashFsCompressionConfig...)
 	err = utils.CreateSquashFS(b.cfg.Runner, b.cfg.Logger, rootDir, filepath.Join(isoDir, constants.IsoRootFile), squashOptions)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return elementalError.NewFromError(err, elementalError.MKFSCall)
 }
 
 func (b BuildISOAction) createEFI(root string, img string) error {
@@ -253,7 +253,7 @@ func (b BuildISOAction) burnISO(root, efiImg string) error {
 		b.cfg.Logger.Warnf("Overwriting already existing %s", outputFile)
 		err := b.cfg.Fs.Remove(outputFile)
 		if err != nil {
-			return err
+			return elementalError.NewFromError(err, elementalError.RemoveFile)
 		}
 	}
 
@@ -266,16 +266,18 @@ func (b BuildISOAction) burnISO(root, efiImg string) error {
 	out, err := b.cfg.Runner.Run(cmd, args...)
 	b.cfg.Logger.Debugf("Xorriso: %s", string(out))
 	if err != nil {
-		return err
+		return elementalError.NewFromError(err, elementalError.CommandRun)
 	}
 
 	checksum, err := utils.CalcFileChecksum(b.cfg.Fs, outputFile)
 	if err != nil {
-		return fmt.Errorf("checksum computation failed: %w", err)
+		b.cfg.Logger.Errorf("checksum computation failed: %v", err)
+		return elementalError.NewFromError(err, elementalError.CalculateChecksum)
 	}
 	err = b.cfg.Fs.WriteFile(fmt.Sprintf("%s.sha256", outputFile), []byte(fmt.Sprintf("%s %s\n", checksum, isoFileName)), 0644)
 	if err != nil {
-		return fmt.Errorf("cannot write checksum file: %w", err)
+		b.cfg.Logger.Errorf("cannot write checksum file: %v", err)
+		return elementalError.NewFromError(err, elementalError.CreateFile)
 	}
 
 	return nil
@@ -285,7 +287,7 @@ func (b BuildISOAction) applySources(target string, sources ...*v1.ImageSource) 
 	for _, src := range sources {
 		_, err := b.e.DumpSource(target, src)
 		if err != nil {
-			return err
+			return elementalError.NewFromError(err, elementalError.DumpSource)
 		}
 	}
 	return nil

--- a/pkg/action/build-iso.go
+++ b/pkg/action/build-iso.go
@@ -63,8 +63,9 @@ func NewBuildISOAction(cfg *v1.BuildConfig, spec *v1.LiveISO, opts ...BuildISOAc
 }
 
 // BuildISORun will install the system from a given configuration
-func (b *BuildISOAction) ISORun() (err error) {
+func (b *BuildISOAction) ISORun() error {
 	cleanup := utils.NewCleanStack()
+	var err error
 	defer func() { err = cleanup.Cleanup(err) }()
 
 	isoTmpDir, err := utils.TempDir(b.cfg.Fs, "", "elemental-iso")

--- a/pkg/error/exit-codes.go
+++ b/pkg/error/exit-codes.go
@@ -202,5 +202,8 @@ const CloudInitRunStage = 65
 // Error unpacking image
 const UnpackImage = 66
 
+// Error reading file
+const ReadFile = 67
+
 // Unknown error
 const Unknown int = 255

--- a/pkg/error/exit-codes.go
+++ b/pkg/error/exit-codes.go
@@ -193,5 +193,8 @@ const HookAfterResetChroot = 62
 // Error during after-reset hook
 const HookAfterReset = 63
 
+// Unsupported flavor
+const UnsupportedFlavor = 64
+
 // Unknown error
 const Unknown int = 255

--- a/pkg/error/exit-codes.go
+++ b/pkg/error/exit-codes.go
@@ -196,5 +196,8 @@ const HookAfterReset = 63
 // Unsupported flavor
 const UnsupportedFlavor = 64
 
+// Error encountered during cloud-init run-stage
+const CloudInitRunStage = 65
+
 // Unknown error
 const Unknown int = 255

--- a/pkg/error/exit-codes.go
+++ b/pkg/error/exit-codes.go
@@ -205,5 +205,14 @@ const UnpackImage = 66
 // Error reading file
 const ReadFile = 67
 
+// No source was provided for the command
+const NoSourceProvided = 68
+
+// Error removing a file
+const RemoveFile = 69
+
+// Error calculating checksum
+const CalculateChecksum = 70
+
 // Unknown error
 const Unknown int = 255

--- a/pkg/error/exit-codes.go
+++ b/pkg/error/exit-codes.go
@@ -133,9 +133,6 @@ const PowerOff = 43
 // Error occurred when labeling partition
 const LabelImage = 44
 
-// Error occurred when unmounting image
-const UnmountImage = 44
-
 // Error setting default grub entry
 const SetDefaultGrubEntry = 45
 
@@ -213,6 +210,9 @@ const RemoveFile = 69
 
 // Error calculating checksum
 const CalculateChecksum = 70
+
+// Error occurred when unmounting image
+const UnmountImage = 71
 
 // Unknown error
 const Unknown int = 255

--- a/pkg/error/exit-codes.go
+++ b/pkg/error/exit-codes.go
@@ -199,5 +199,8 @@ const UnsupportedFlavor = 64
 // Error encountered during cloud-init run-stage
 const CloudInitRunStage = 65
 
+// Error unpacking image
+const UnpackImage = 66
+
 // Unknown error
 const Unknown int = 255


### PR DESCRIPTION
Use elemental-error in new, run-stage, pull-image, cloud-init, convert-disk and build-iso commands.

Fixes #366, #369, #367, #363, #364, #361

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>