### PR TITLE
Make build-iso logging consistent

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -146,7 +146,7 @@ func NewConfig(opts ...GenericOptions) *v1.Config {
 
 	if c.Luet == nil {
 		tmpDir := utils.GetTempDir(c, "")
-		c.Luet = luet.NewLuet(luet.WithFs(c.Fs), luet.WithLogger(log), luet.WithLuetTempDir(tmpDir))
+		c.Luet = luet.NewLuet(luet.WithFs(c.Fs), luet.WithLogger(c.Logger), luet.WithLuetTempDir(tmpDir))
 	}
 	return c
 }


### PR DESCRIPTION
When running `elemental build-iso` the log looks like this:

```
INFO[2022-11-18T13:37:24+01:00] Copying rancher/elemental:v0.9.5 source...
INFO[0000] Unpacking a container image: rancher/elemental:v0.9.5
INFO[0000] Using an image from local cache
INFO[0010] Size: 733MiB
INFO[2022-11-18T13:37:34+01:00] Finished copying rancher/elemental:v0.9.5 into /tmp/elemental-iso661155325/rootfs
```

This change adds timestamping for all logs:

```
INFO[2022-11-18T13:49:18+01:00] Starting elemental version v0.1.2
INFO[2022-11-18T13:49:18+01:00] Preparing squashfs root...
INFO[2022-11-18T13:49:18+01:00] Copying rancher/elemental:v0.9.5 source...
INFO[2022-11-18T13:49:18+01:00] Unpacking a container image: rancher/elemental:v0.9.5
INFO[2022-11-18T13:49:18+01:00] Using an image from local cache
INFO[2022-11-18T13:49:28+01:00] Size: 733MiB
INFO[2022-11-18T13:49:28+01:00] Finished copying rancher/elemental:v0.9.5 into /tmp/elemental-iso217612049/rootfs
```

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>