### PR TITLE
Use state in upgrade

### DIFF
--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -301,7 +301,7 @@ var _ = Describe("Config", Label("config"), func() {
 			var ghwTest v1mock.GhwMock
 
 			BeforeEach(func() {
-				bootedFrom = constants.SystemLabel
+				bootedFrom = constants.RecoveryImgFile
 				flags = pflag.NewFlagSet("testflags", 1)
 				flags.String("system.uri", "", "testing flag")
 				flags.Set("system.uri", "docker:image/from:flag")

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -99,6 +99,11 @@ func (i *InstallAction) createInstallStateYaml(sysMeta, recMeta interface{}) err
 			FSLabel: i.spec.Partitions.Persistent.FilesystemLabel,
 		}
 	}
+	if i.spec.Partitions.EFI != nil {
+		installState.Partitions[cnst.EfiPartName] = &v1.PartitionState{
+			FSLabel: i.spec.Partitions.EFI.FilesystemLabel,
+		}
+	}
 
 	return i.cfg.WriteInstallState(
 		installState,

--- a/pkg/action/reset_test.go
+++ b/pkg/action/reset_test.go
@@ -122,7 +122,7 @@ var _ = Describe("Reset action tests", func() {
 			ghwTest.CreateDevices()
 
 			fs.Create(constants.EfiDevice)
-			bootedFrom = constants.SystemLabel
+			bootedFrom = constants.RecoveryImgFile
 			runner.SideEffect = func(cmd string, args ...string) ([]byte, error) {
 				if cmd == cmdFail {
 					return []byte{}, errors.New("Command failed")

--- a/pkg/action/upgrade_test.go
+++ b/pkg/action/upgrade_test.go
@@ -459,7 +459,22 @@ var _ = Describe("Runtime Actions", func() {
 				BeforeEach(func() {
 					// Mount recovery partition as it is expected to be mounted when booting from recovery
 					mounter.Mount("device5", constants.LiveDir, "auto", []string{"ro"})
-					// Create recoveryImgSquash so ti identifies that we are using squash recovery
+					// Create installState with squashed recovery
+					statePath := filepath.Join(constants.RunningStateDir, constants.InstallStateFile)
+					installState := &v1.InstallState{
+						Partitions: map[string]*v1.PartitionState{
+							constants.RecoveryPartName: {
+								FSLabel: constants.RecoveryLabel,
+								Images: map[string]*v1.ImageState{
+									constants.RecoveryImgName: {
+										FS: constants.SquashFs,
+									},
+								},
+							},
+						},
+					}
+					err = config.WriteInstallState(installState, statePath, statePath)
+					Expect(err).ShouldNot(HaveOccurred())
 					err = fs.WriteFile(recoveryImgSquash, []byte("recovery"), constants.FilePerm)
 					Expect(err).ShouldNot(HaveOccurred())
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -215,7 +215,7 @@ var _ = Describe("Types", Label("types", "config"), func() {
 					runner.SideEffect = func(cmd string, args ...string) ([]byte, error) {
 						switch cmd {
 						case "cat":
-							return []byte(constants.SystemLabel), nil
+							return []byte(constants.RecoveryImgFile), nil
 						default:
 							return []byte{}, nil
 						}
@@ -298,7 +298,7 @@ var _ = Describe("Types", Label("types", "config"), func() {
 					Expect(err.Error()).To(ContainSubstring("reset can only be called from the recovery system"))
 				})
 				It("fails to set defaults if no recovery partition detected", func() {
-					bootedFrom = constants.SystemLabel
+					bootedFrom = constants.RecoveryImgFile
 					_, err := config.NewResetSpec(*c)
 					Expect(err).Should(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("recovery partition not found"))
@@ -313,7 +313,7 @@ var _ = Describe("Types", Label("types", "config"), func() {
 					ghwTest.CreateDevices()
 					defer ghwTest.Clean()
 
-					bootedFrom = constants.SystemLabel
+					bootedFrom = constants.RecoveryImgFile
 					_, err := config.NewResetSpec(*c)
 					Expect(err).Should(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("state partition not found"))
@@ -325,7 +325,7 @@ var _ = Describe("Types", Label("types", "config"), func() {
 					_, err = fs.Create(constants.EfiDevice)
 					Expect(err).ShouldNot(HaveOccurred())
 
-					bootedFrom = constants.SystemLabel
+					bootedFrom = constants.RecoveryImgFile
 					_, err := config.NewResetSpec(*c)
 					Expect(err).Should(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("EFI partition not found"))
@@ -387,11 +387,22 @@ var _ = Describe("Types", Label("types", "config"), func() {
 				})
 				It("sets upgrade defaults for squashed recovery upgrade", func() {
 					//Set squashed recovery detection
-					mounter.Mount("device3", constants.LiveDir, "auto", []string{})
-					img := filepath.Join(constants.LiveDir, "cOS", constants.RecoverySquashFile)
-					err = utils.MkdirAll(fs, filepath.Dir(img), constants.DirPerm)
-					Expect(err).ShouldNot(HaveOccurred())
-					_, err = fs.Create(img)
+					// Create installState with squashed recovery
+					Expect(utils.MkdirAll(c.Fs, constants.RunningStateDir, constants.DirPerm)).To(Succeed())
+					statePath := filepath.Join(constants.RunningStateDir, constants.InstallStateFile)
+					installState := &v1.InstallState{
+						Partitions: map[string]*v1.PartitionState{
+							constants.RecoveryPartName: {
+								FSLabel: constants.RecoveryLabel,
+								Images: map[string]*v1.ImageState{
+									constants.RecoveryImgName: {
+										FS: constants.SquashFs,
+									},
+								},
+							},
+						},
+					}
+					err = c.WriteInstallState(installState, statePath, statePath)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					spec, err := config.NewUpgradeSpec(*c)

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -357,7 +357,7 @@ func NewElementalPartitionsFromList(pl PartitionList, state *InstallState) Eleme
 		constants.PersistentPartName: constants.PersistentLabel,
 	}
 	if state != nil {
-		for k, _ := range lm {
+		for k := range lm {
 			if state.Partitions[k] != nil {
 				lm[k] = state.Partitions[k].FSLabel
 			}

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -292,6 +292,15 @@ func (pl PartitionList) GetByLabel(label string) *Partition {
 	return part
 }
 
+// GetByNameOrLabel gets a partition by its name or label. It tries by name first
+func (pl PartitionList) GetByNameOrLabel(name, label string) *Partition {
+	part := pl.GetByName(name)
+	if part == nil {
+		part = pl.GetByLabel(label)
+	}
+	return part
+}
+
 type ElementalPartitions struct {
 	BIOS       *Partition
 	EFI        *Partition
@@ -336,31 +345,32 @@ func (ep *ElementalPartitions) SetFirmwarePartitions(firmware string, partTable 
 
 // NewElementalPartitionsFromList fills an ElementalPartitions instance from given
 // partitions list. First tries to match partitions by partition label, if not,
-// it tries to match partitions by default filesystem label
-// TODO find a way to map custom labels when partition labels are not available
-func NewElementalPartitionsFromList(pl PartitionList) ElementalPartitions {
+// it tries to match partitions by filesystem label
+func NewElementalPartitionsFromList(pl PartitionList, state *InstallState) ElementalPartitions {
 	ep := ElementalPartitions{}
+
+	lm := map[string]string{
+		constants.EfiPartName:        constants.EfiLabel,
+		constants.OEMPartName:        constants.OEMLabel,
+		constants.RecoveryPartName:   constants.RecoveryLabel,
+		constants.StatePartName:      constants.StateLabel,
+		constants.PersistentPartName: constants.PersistentLabel,
+	}
+	if state != nil {
+		for k, _ := range lm {
+			if state.Partitions[k] != nil {
+				lm[k] = state.Partitions[k].FSLabel
+			}
+		}
+	}
+
 	ep.BIOS = pl.GetByName(constants.BiosPartName)
-	ep.EFI = pl.GetByName(constants.EfiPartName)
-	if ep.EFI == nil {
-		ep.EFI = pl.GetByLabel(constants.EfiLabel)
-	}
-	ep.OEM = pl.GetByName(constants.OEMPartName)
-	if ep.OEM == nil {
-		ep.OEM = pl.GetByLabel(constants.OEMLabel)
-	}
-	ep.Recovery = pl.GetByName(constants.RecoveryPartName)
-	if ep.Recovery == nil {
-		ep.Recovery = pl.GetByLabel(constants.RecoveryLabel)
-	}
-	ep.State = pl.GetByName(constants.StatePartName)
-	if ep.State == nil {
-		ep.State = pl.GetByLabel(constants.StateLabel)
-	}
-	ep.Persistent = pl.GetByName(constants.PersistentPartName)
-	if ep.Persistent == nil {
-		ep.Persistent = pl.GetByLabel(constants.PersistentLabel)
-	}
+	ep.EFI = pl.GetByNameOrLabel(constants.EfiPartName, lm[constants.EfiPartName])
+	ep.OEM = pl.GetByNameOrLabel(constants.OEMPartName, lm[constants.OEMPartName])
+	ep.Recovery = pl.GetByNameOrLabel(constants.RecoveryPartName, lm[constants.RecoveryPartName])
+	ep.State = pl.GetByNameOrLabel(constants.StatePartName, lm[constants.StatePartName])
+	ep.Persistent = pl.GetByNameOrLabel(constants.PersistentPartName, lm[constants.PersistentLabel])
+
 	return ep
 }
 

--- a/pkg/types/v1/config_test.go
+++ b/pkg/types/v1/config_test.go
@@ -162,7 +162,7 @@ var _ = Describe("Types", Label("types", "config"), func() {
 				&v1.Partition{
 					FilesystemLabel: "SOMETHING",
 					Size:            0,
-					Name:            "somethingelse",
+					Name:            "somename",
 					FS:              "",
 					Flags:           nil,
 					MountPoint:      "",
@@ -197,13 +197,20 @@ var _ = Describe("Types", Label("types", "config"), func() {
 			Expect(err).Should(HaveOccurred())
 		})
 		It("initializes an ElementalPartitions from a PartitionList", func() {
-			ep := v1.NewElementalPartitionsFromList(p, nil)
+			// Use custom label for recovery partition
+			ep := v1.NewElementalPartitionsFromList(p, &v1.InstallState{
+				Partitions: map[string]*v1.PartitionState{
+					constants.RecoveryPartName: {
+						FSLabel: "SOMETHING",
+					},
+				},
+			})
 			Expect(ep.Persistent != nil).To(BeTrue())
 			Expect(ep.OEM != nil).To(BeTrue())
 			Expect(ep.BIOS == nil).To(BeTrue())
 			Expect(ep.EFI == nil).To(BeTrue())
 			Expect(ep.State == nil).To(BeTrue())
-			Expect(ep.Recovery == nil).To(BeTrue())
+			Expect(ep.Recovery != nil).To(BeTrue())
 		})
 		Describe("returns a partition list by install order", func() {
 			It("with no extra parts", func() {
@@ -214,18 +221,26 @@ var _ = Describe("Types", Label("types", "config"), func() {
 				Expect(lst[1].Name == "persistent").To(BeTrue())
 			})
 			It("with extra parts with size > 0", func() {
-				ep := v1.NewElementalPartitionsFromList(p, nil)
+				// Use custom label for state partition
+				ep := v1.NewElementalPartitionsFromList(p, &v1.InstallState{
+					Partitions: map[string]*v1.PartitionState{
+						constants.StatePartName: {
+							FSLabel: "SOMETHING",
+						},
+					},
+				})
 				var extraParts []*v1.Partition
 				extraParts = append(extraParts, &v1.Partition{Name: "extra", Size: 5})
 
 				lst := ep.PartitionsByInstallOrder(extraParts)
-				Expect(len(lst)).To(Equal(3))
+				Expect(len(lst)).To(Equal(4))
 				Expect(lst[0].Name == "oem").To(BeTrue())
-				Expect(lst[1].Name == "extra").To(BeTrue())
-				Expect(lst[2].Name == "persistent").To(BeTrue())
+				Expect(lst[1].Name == "somename").To(BeTrue())
+				Expect(lst[2].Name == "extra").To(BeTrue())
+				Expect(lst[3].Name == "persistent").To(BeTrue())
 			})
 			It("with extra part with size == 0 and persistent.Size == 0", func() {
-				ep := v1.NewElementalPartitionsFromList(p, nil)
+				ep := v1.NewElementalPartitionsFromList(p, &v1.InstallState{})
 				var extraParts []*v1.Partition
 				extraParts = append(extraParts, &v1.Partition{Name: "extra", Size: 0})
 				lst := ep.PartitionsByInstallOrder(extraParts)

--- a/pkg/types/v1/config_test.go
+++ b/pkg/types/v1/config_test.go
@@ -197,7 +197,7 @@ var _ = Describe("Types", Label("types", "config"), func() {
 			Expect(err).Should(HaveOccurred())
 		})
 		It("initializes an ElementalPartitions from a PartitionList", func() {
-			ep := v1.NewElementalPartitionsFromList(p)
+			ep := v1.NewElementalPartitionsFromList(p, nil)
 			Expect(ep.Persistent != nil).To(BeTrue())
 			Expect(ep.OEM != nil).To(BeTrue())
 			Expect(ep.BIOS == nil).To(BeTrue())
@@ -207,14 +207,14 @@ var _ = Describe("Types", Label("types", "config"), func() {
 		})
 		Describe("returns a partition list by install order", func() {
 			It("with no extra parts", func() {
-				ep := v1.NewElementalPartitionsFromList(p)
+				ep := v1.NewElementalPartitionsFromList(p, nil)
 				lst := ep.PartitionsByInstallOrder([]*v1.Partition{})
 				Expect(len(lst)).To(Equal(2))
 				Expect(lst[0].Name == "oem").To(BeTrue())
 				Expect(lst[1].Name == "persistent").To(BeTrue())
 			})
 			It("with extra parts with size > 0", func() {
-				ep := v1.NewElementalPartitionsFromList(p)
+				ep := v1.NewElementalPartitionsFromList(p, nil)
 				var extraParts []*v1.Partition
 				extraParts = append(extraParts, &v1.Partition{Name: "extra", Size: 5})
 
@@ -225,7 +225,7 @@ var _ = Describe("Types", Label("types", "config"), func() {
 				Expect(lst[2].Name == "persistent").To(BeTrue())
 			})
 			It("with extra part with size == 0 and persistent.Size == 0", func() {
-				ep := v1.NewElementalPartitionsFromList(p)
+				ep := v1.NewElementalPartitionsFromList(p, nil)
 				var extraParts []*v1.Partition
 				extraParts = append(extraParts, &v1.Partition{Name: "extra", Size: 0})
 				lst := ep.PartitionsByInstallOrder(extraParts)
@@ -235,7 +235,7 @@ var _ = Describe("Types", Label("types", "config"), func() {
 				Expect(lst[1].Name == "persistent").To(BeTrue())
 			})
 			It("with extra part with size == 0 and persistent.Size > 0", func() {
-				ep := v1.NewElementalPartitionsFromList(p)
+				ep := v1.NewElementalPartitionsFromList(p, nil)
 				ep.Persistent.Size = 10
 				var extraParts []*v1.Partition
 				extraParts = append(extraParts, &v1.Partition{Name: "extra", FilesystemLabel: "LABEL", Size: 0})
@@ -247,7 +247,7 @@ var _ = Describe("Types", Label("types", "config"), func() {
 				Expect(lst[2].Name == "extra").To(BeTrue())
 			})
 			It("with several extra parts with size == 0 and persistent.Size > 0", func() {
-				ep := v1.NewElementalPartitionsFromList(p)
+				ep := v1.NewElementalPartitionsFromList(p, nil)
 				ep.Persistent.Size = 10
 				var extraParts []*v1.Partition
 				extraParts = append(extraParts, &v1.Partition{Name: "extra1", Size: 0})
@@ -262,14 +262,14 @@ var _ = Describe("Types", Label("types", "config"), func() {
 		})
 
 		It("returns a partition list by mount order", func() {
-			ep := v1.NewElementalPartitionsFromList(p)
+			ep := v1.NewElementalPartitionsFromList(p, nil)
 			lst := ep.PartitionsByMountPoint(false)
 			Expect(len(lst)).To(Equal(2))
 			Expect(lst[0].Name == "persistent").To(BeTrue())
 			Expect(lst[1].Name == "oem").To(BeTrue())
 		})
 		It("returns a partition list by mount reverse order", func() {
-			ep := v1.NewElementalPartitionsFromList(p)
+			ep := v1.NewElementalPartitionsFromList(p, nil)
 			lst := ep.PartitionsByMountPoint(true)
 			Expect(len(lst)).To(Equal(2))
 			Expect(lst[0].Name == "oem").To(BeTrue())

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -322,32 +322,6 @@ func IsMounted(config *v1.Config, part *v1.Partition) (bool, error) {
 	return !notMnt, nil
 }
 
-// HasSquashedRecovery returns true if a squashed recovery image is found in the system
-func HasSquashedRecovery(config *v1.Config, recovery *v1.Partition) (squashed bool, err error) {
-	mountPoint := recovery.MountPoint
-	if mnt, _ := IsMounted(config, recovery); !mnt {
-		tmpMountDir, err := TempDir(config.Fs, "", "elemental")
-		if err != nil {
-			config.Logger.Errorf("failed creating temporary dir: %v", err)
-			return false, err
-		}
-		defer config.Fs.RemoveAll(tmpMountDir) // nolint:errcheck
-		err = config.Mounter.Mount(recovery.Path, tmpMountDir, "auto", []string{})
-		if err != nil {
-			config.Logger.Errorf("failed mounting recovery partition: %v", err)
-			return false, err
-		}
-		mountPoint = tmpMountDir
-		defer func() {
-			err = config.Mounter.Unmount(tmpMountDir)
-			if err != nil {
-				squashed = false
-			}
-		}()
-	}
-	return Exists(config.Fs, filepath.Join(mountPoint, "cOS", cnst.RecoverySquashFile))
-}
-
 // GetTempDir returns the dir for storing related temporal files
 // It will respect TMPDIR and use that if exists, fallback to try the persistent partition if its mounted
 // and finally the default /tmp/ dir

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -370,7 +370,8 @@ func GetTempDir(config *v1.Config, suffix string) string {
 		return filepath.Join("/", "tmp", elementalTmpDir)
 	}
 	// Check persistent and if its mounted
-	ep := v1.NewElementalPartitionsFromList(parts)
+	state, _ := config.LoadInstallState()
+	ep := v1.NewElementalPartitionsFromList(parts, state)
 	persistent := ep.Persistent
 	if persistent != nil {
 		if mnt, _ := IsMounted(config, persistent); mnt {

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1099,65 +1099,6 @@ var _ = Describe("Utils", Label("utils"), func() {
 			Expect(mnt).To(BeFalse())
 		})
 	})
-	Describe("HasSquashedRecovery", Label("squashedRec"), func() {
-		var squashedImg string
-		var part *v1.Partition
-		BeforeEach(func() {
-			squashedImg = filepath.Join(constants.LiveDir, "cOS", constants.RecoverySquashFile)
-			part = &v1.Partition{
-				MountPoint: constants.LiveDir,
-				Path:       "/some/device",
-			}
-		})
-		It("has squashed image from a mounted recovery", func() {
-			// mount recovery
-			err := mounter.Mount(part.Path, constants.LiveDir, "auto", []string{})
-			Expect(err).ShouldNot(HaveOccurred())
-
-			// create squashfs
-			err = utils.MkdirAll(config.Fs, filepath.Dir(squashedImg), constants.DirPerm)
-			Expect(err).ShouldNot(HaveOccurred())
-			_, err = config.Fs.Create(squashedImg)
-			Expect(err).ShouldNot(HaveOccurred())
-
-			squash, err := utils.HasSquashedRecovery(config, part)
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(squash).To(BeTrue())
-		})
-		It("does not have squashed image from a mounted recovery", func() {
-			// mount recovery
-			err := mounter.Mount(part.Path, constants.LiveDir, "auto", []string{})
-			Expect(err).ShouldNot(HaveOccurred())
-
-			squash, err := utils.HasSquashedRecovery(config, part)
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(squash).To(BeFalse())
-		})
-		It("has squashed image from a not mounted recovery", func() {
-			// squashed image on temp dir
-			squashedImg = filepath.Join("/tmp/elemental", "cOS", constants.RecoverySquashFile)
-			// create squashfs
-			err := utils.MkdirAll(config.Fs, filepath.Dir(squashedImg), constants.DirPerm)
-			Expect(err).ShouldNot(HaveOccurred())
-			_, err = config.Fs.Create(squashedImg)
-			Expect(err).ShouldNot(HaveOccurred())
-
-			squash, err := utils.HasSquashedRecovery(config, part)
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(squash).To(BeTrue())
-		})
-		It("does not have squashed image from a not mounted recovery", func() {
-			squash, err := utils.HasSquashedRecovery(config, part)
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(squash).To(BeFalse())
-		})
-		It("fails to mount recovery", func() {
-			mounter.ErrorOnMount = true
-			squash, err := utils.HasSquashedRecovery(config, part)
-			Expect(err).Should(HaveOccurred())
-			Expect(squash).To(BeFalse())
-		})
-	})
 	Describe("CleanStack", Label("CleanStack"), func() {
 		var cleaner *utils.CleanStack
 		BeforeEach(func() {


### PR DESCRIPTION
This PR is to make use of the installation state yaml file in ugrade/reset procedures, mainly for three reasons:

* This facilitates the change of configurable default values (e.g. partitition labels), as with the change, in upgrade/reset procedure the configuration is applied as (right max prio, stacked from left to right):
  `defaults <- install state <- configuration files <- environment variables`
  so we could change the default partition labels and in an upgrade elemental-cli would still use whatever it was installed on the system. This is also key for changes like the ones discussed in rancher/elemental-toolkit#1643
* This enables us to remove some heuristics to check former installation stats (e.g. checks around squashfs)
* Reading the state file is simple and, IMHO, safer than attempting to detect configuration based on heuristics

In addition it also changes the `BootedFrom` method calls to parse the image file path instead of the image label, again this is safer as the image path is not configurable, but the label is.