### PR TITLE
Fix configuration loading

### DIFF
--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -177,6 +177,13 @@ var _ = Describe("Config", Label("config"), func() {
 			flags.Set("cosign", "true")
 			flags.Set("cosign-key", "someOtherKey")
 		})
+		It("fails on bad yaml config file", func() {
+			_, err := ReadConfigRun("../../tests/fixtures/badconfig/", nil, mounter)
+			Expect(err).Should(HaveOccurred())
+
+			_, err = ReadConfigRun("../../tests/fixtures/badextraconfig/", nil, mounter)
+			Expect(err).Should(HaveOccurred())
+		})
 		It("uses defaults if no configs are provided", func() {
 			cfg, err := ReadConfigRun("", nil, mounter)
 			Expect(err).ShouldNot(HaveOccurred())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,7 +30,7 @@ func NewRootCmd() *cobra.Command {
 		Short: "Elemental",
 	}
 	cmd.PersistentFlags().Bool("debug", false, "Enable debug output")
-	cmd.PersistentFlags().String("config-dir", "/etc/elemental", "Set config dir (default is /etc/elemental)")
+	cmd.PersistentFlags().String("config-dir", "", "Set config dir")
 	cmd.PersistentFlags().String("logfile", "", "Set logfile")
 	cmd.PersistentFlags().Bool("quiet", false, "Do not output to stdout")
 	_ = viper.BindPFlag("debug", cmd.PersistentFlags().Lookup("debug"))

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -98,6 +98,7 @@ const (
 	BuildImgName           = "elemental"
 	UsrLocalPath           = "/usr/local"
 	OEMPath                = "/oem"
+	ConfigDir              = "/etc/elemental"
 
 	// SELinux targeted policy paths
 	SELinuxTargetedPath        = "/etc/selinux/targeted"

--- a/tests/fixtures/badconfig/config.yaml
+++ b/tests/fixtures/badconfig/config.yaml
@@ -1,0 +1,2 @@
+This is a bad yaml
+It is a very bad yaml

--- a/tests/fixtures/badextraconfig/config.d/bad-config.yaml
+++ b/tests/fixtures/badextraconfig/config.d/bad-config.yaml
@@ -1,0 +1,2 @@
+This is a bad yaml
+It is a very bad yaml


### PR DESCRIPTION
This commit ensures viper only tries to merge files that already exist.

In addition this commit properly sets default configuration directory for build commands.

Fixes #380

Signed-off-by: David Cassany <dcassany@suse.com>