### PR TITLE
Ensure the manifest.yaml exist before attempting to read it

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -114,11 +114,18 @@ func ReadConfigBuild(configDir string, flags *pflag.FlagSet, mounter mount.Inter
 		cfg.Logger.Info("reading configuration form '%s'", configDir)
 	}
 
-	viper.AddConfigPath(configDir)
-	viper.SetConfigType("yaml")
-	viper.SetConfigName("manifest.yaml")
-	// If a config file is found, read it in.
-	_ = viper.MergeInConfig()
+	// merge yaml config files on top of default runconfig
+	if exists, _ := utils.Exists(cfg.Fs, filepath.Join(configDir, "manifest.yaml")); exists {
+		viper.AddConfigPath(configDir)
+		viper.SetConfigType("yaml")
+		viper.SetConfigName("manifest")
+		// If a config file is found, read it in.
+		err := viper.MergeInConfig()
+		if err != nil {
+			cfg.Logger.Error("error merging config files: %s", err)
+			return cfg, err
+		}
+	}
 
 	// Bind buildconfig flags
 	bindGivenFlags(viper.GetViper(), flags)

--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -101,6 +101,10 @@ var _ = Describe("Config", Label("config"), func() {
 			Expect(err).To(BeNil())
 			Expect(cfg.Name).To(Equal("randomname"))
 		})
+		It("fails on bad yaml manifest file", func() {
+			_, err := ReadConfigBuild("../../tests/fixtures/badconfig/", nil, mounter)
+			Expect(err).Should(HaveOccurred())
+		})
 	})
 	Describe("Read build specs", Label("build"), func() {
 		var cfg *v1.BuildConfig
@@ -146,7 +150,6 @@ var _ = Describe("Config", Label("config"), func() {
 		AfterEach(func() {
 			cleanup()
 		})
-
 		Describe("LiveISO spec", Label("iso"), func() {
 			It("initiates a LiveISO spec", func() {
 				iso, err := ReadBuildISO(cfg, nil)

--- a/tests/fixtures/badconfig/manifest.yaml
+++ b/tests/fixtures/badconfig/manifest.yaml
@@ -1,0 +1,1 @@
+config.yaml


### PR DESCRIPTION
This commit instead of swallowing viper errors when loading config files it reports back the error for build commands. This is the same criteria as it is for the run time commands.

Signed-off-by: David Cassany <dcassany@suse.com>