### PR TITLE
Set garbage collector temp dir for luet

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -152,7 +152,7 @@ func ReadConfigRun(configDir string, flags *pflag.FlagSet, mounter mount.Interfa
 	if configDir == "" {
 		configDir = constants.ConfigDir
 	}
-	cfg.Logger.Info("reading configuration form '%s'", configDir)
+	cfg.Logger.Infof("reading configuration form '%s'", configDir)
 
 	const cfgDefault = "/etc/os-release"
 	if exists, _ := utils.Exists(cfg.Fs, cfgDefault); exists {
@@ -161,7 +161,7 @@ func ReadConfigRun(configDir string, flags *pflag.FlagSet, mounter mount.Interfa
 
 		err := viper.MergeInConfig()
 		if err != nil {
-			cfg.Logger.Error("error merging os-release file: %s", err)
+			cfg.Logger.Errorf("error merging os-release file: %s", err)
 			return cfg, err
 		}
 	}
@@ -174,7 +174,7 @@ func ReadConfigRun(configDir string, flags *pflag.FlagSet, mounter mount.Interfa
 		// If a config file is found, read it in.
 		err := viper.MergeInConfig()
 		if err != nil {
-			cfg.Logger.Error("error merging config files: %s", err)
+			cfg.Logger.Errorf("error merging config files: %s", err)
 			return cfg, err
 		}
 	}
@@ -184,7 +184,6 @@ func ReadConfigRun(configDir string, flags *pflag.FlagSet, mounter mount.Interfa
 	if exists, _ := utils.Exists(cfg.Fs, cfgExtra); exists {
 		viper.AddConfigPath(cfgExtra)
 		err := filepath.WalkDir(cfgExtra, func(path string, d fs.DirEntry, err error) error {
-			fmt.Println(path)
 			if !d.IsDir() && filepath.Ext(d.Name()) == ".yaml" {
 				viper.SetConfigType("yaml")
 				viper.SetConfigName(strings.TrimSuffix(d.Name(), ".yaml"))
@@ -194,7 +193,7 @@ func ReadConfigRun(configDir string, flags *pflag.FlagSet, mounter mount.Interfa
 		})
 
 		if err != nil {
-			cfg.Logger.Error("error merging extra config files: %s", err)
+			cfg.Logger.Errorf("error merging extra config files: %s", err)
 			return cfg, err
 		}
 	}

--- a/pkg/luet/luet.go
+++ b/pkg/luet/luet.go
@@ -128,6 +128,9 @@ func NewLuet(opts ...Options) *Luet {
 	if luet.context == nil {
 		luetConfig := luet.createLuetConfig()
 		luet.context = context.NewContext(context.WithConfig(luetConfig), context.WithLogger(luet.log))
+		if luet.TmpDir != "" {
+			luet.context.GarbageCollector = gc.GarbageCollector(filepath.Join(luet.TmpDir, "tmpluet"))
+		}
 	}
 
 	if luet.auth == nil {
@@ -392,8 +395,12 @@ func (l Luet) createLuetConfig() *luetTypes.LuetConfig {
 // SetTempDir re-sets the temp dir for all the luet stuff
 func (l *Luet) SetTempDir(tmpdir string) {
 	l.TmpDir = tmpdir
-	l.context.Config.System.TmpDirBase = l.TmpDir
-	l.context.Config.System.PkgsCachePath = l.TmpDir
-	l.context.Config.System.DatabasePath = l.TmpDir
-	l.context.GarbageCollector = gc.GarbageCollector(filepath.Join(tmpdir, "tmpluet"))
+	if l.context != nil {
+		if l.context.Config != nil {
+			l.context.Config.System.TmpDirBase = l.TmpDir
+			l.context.Config.System.PkgsCachePath = l.TmpDir
+			l.context.Config.System.DatabasePath = l.TmpDir
+		}
+		l.context.GarbageCollector = gc.GarbageCollector(filepath.Join(tmpdir, "tmpluet"))
+	}
 }

--- a/pkg/utils/getpartitions.go
+++ b/pkg/utils/getpartitions.go
@@ -32,7 +32,7 @@ func ghwPartitionToInternalPartition(partition *block.Partition) *v1.Partition {
 	return &v1.Partition{
 		FilesystemLabel: partition.FilesystemLabel,
 		Size:            uint(partition.SizeBytes / (1024 * 1024)), // Converts B to MB
-		Name:            partition.Name,
+		Name:            partition.Label,
 		FS:              partition.Type,
 		Flags:           nil,
 		MountPoint:      partition.MountPoint,

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -249,13 +249,13 @@ var _ = Describe("Utils", Label("utils"), func() {
 		It("returns all found partitions", func() {
 			parts, err := utils.GetAllPartitions()
 			Expect(err).To(BeNil())
-			var partNames []string
+			var devices []string
 			for _, p := range parts {
-				partNames = append(partNames, p.Name)
+				devices = append(devices, p.Path)
 			}
-			Expect(partNames).To(ContainElement("sda1Test"))
-			Expect(partNames).To(ContainElement("sda1Test"))
-			Expect(partNames).To(ContainElement("sdb1Test"))
+			Expect(devices).To(ContainElement(ContainSubstring("sda1Test")))
+			Expect(devices).To(ContainElement(ContainSubstring("sda2Test")))
+			Expect(devices).To(ContainElement(ContainSubstring("sdb1Test")))
 		})
 	})
 	Describe("GetPartitionFS", Label("lsblk", "partitions"), func() {


### PR DESCRIPTION
This commit sets the temp dir for luet on start up.

It also fixes a bug on partitions detection, where the device name was used instead of the partition label. In elemental-cli partition names are partition labels, they are hardcoded and not configurable.

Finally fixes few log messages

Fixes #380

Signed-off-by: David Cassany <dcassany@suse.com>