### PR TITLE
[ci] Do not go mod download on test deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,6 @@ else
 endif
 
 test_deps:
-	go mod download
 	go get github.com/onsi/gomega/...
 	go get github.com/onsi/ginkgo/v2/ginkgo/internal@v2.1.4
 	go get github.com/onsi/ginkgo/v2/ginkgo/generators@v2.1.4

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -408,8 +408,6 @@ github.com/go-logr/logr
 ## explicit; go 1.12
 github.com/go-ole/go-ole
 github.com/go-ole/go-ole/oleutil
-# github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0
-## explicit; go 1.13
 # github.com/godbus/dbus v4.1.0+incompatible
 ## explicit
 github.com/godbus/dbus
@@ -468,8 +466,6 @@ github.com/google/go-containerregistry/pkg/v1/remote/transport
 github.com/google/go-containerregistry/pkg/v1/stream
 github.com/google/go-containerregistry/pkg/v1/tarball
 github.com/google/go-containerregistry/pkg/v1/types
-# github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1
-## explicit; go 1.14
 # github.com/google/renameio v1.0.0
 ## explicit; go 1.13
 github.com/google/renameio
@@ -1064,8 +1060,6 @@ golang.org/x/text/secure/bidirule
 golang.org/x/text/transform
 golang.org/x/text/unicode/bidi
 golang.org/x/text/unicode/norm
-# golang.org/x/tools v0.1.12
-## explicit; go 1.18
 # golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2
 ## explicit; go 1.17
 golang.org/x/xerrors


### PR DESCRIPTION
There is no need as we already have the vendor folder, test deps should only include the test dependencies

Signed-off-by: Itxaka <igarcia@suse.com>