### PR TITLE
[ci] Drop reviewers from cmd docs auto PR

### DIFF
--- a/.github/workflows/update-cmd-docs.yaml
+++ b/.github/workflows/update-cmd-docs.yaml
@@ -26,8 +26,3 @@ jobs:
           signoff: true
           title: "[auto] Update cmd docs"
           delete-branch: true
-          reviewers: |
-            itxaka
-            davidcassany
-            mudler
-            mjura


### PR DESCRIPTION
Not supported as you need admin privs to assign a PR to people and the bot is using forks to create the PR

Signed-off-by: Itxaka <igarcia@suse.com>