### PR TITLE
Refactor elemental

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -28,20 +28,21 @@ import (
 	"github.com/rancher/elemental-cli/pkg/utils"
 )
 
-func (i *InstallAction) installHook(hook string, chroot bool) error {
-	if chroot {
-		extraMounts := map[string]string{}
-		persistent := i.spec.Partitions.Persistent
-		if persistent != nil && persistent.MountPoint != "" {
-			extraMounts[persistent.MountPoint] = cnst.UsrLocalPath
-		}
-		oem := i.spec.Partitions.OEM
-		if oem != nil && oem.MountPoint != "" {
-			extraMounts[oem.MountPoint] = cnst.OEMPath
-		}
-		return ChrootHook(&i.cfg.Config, hook, i.cfg.Strict, i.spec.Active.MountPoint, extraMounts, i.cfg.CloudInitPaths...)
-	}
+func (i *InstallAction) installHook(hook string) error {
 	return Hook(&i.cfg.Config, hook, i.cfg.Strict, i.cfg.CloudInitPaths...)
+}
+
+func (i *InstallAction) installChrootHook(hook string, root string) error {
+	extraMounts := map[string]string{}
+	persistent := i.spec.Partitions.Persistent
+	if persistent != nil && persistent.MountPoint != "" {
+		extraMounts[persistent.MountPoint] = cnst.UsrLocalPath
+	}
+	oem := i.spec.Partitions.OEM
+	if oem != nil && oem.MountPoint != "" {
+		extraMounts[oem.MountPoint] = cnst.OEMPath
+	}
+	return ChrootHook(&i.cfg.Config, hook, i.cfg.Strict, root, extraMounts, i.cfg.CloudInitPaths...)
 }
 
 func (i *InstallAction) createInstallStateYaml(sysMeta, recMeta interface{}) error {
@@ -140,24 +141,10 @@ func (i InstallAction) Run() (err error) {
 		}
 	}
 
-	// Check no-format flag
-	if i.spec.NoFormat {
-		// Check force flag against current device
-		labels := []string{i.spec.Active.Label, i.spec.Recovery.Label}
-		if e.CheckActiveDeployment(labels) && !i.spec.Force {
-			return elementalError.New("use `force` flag to run an installation over the current running deployment", elementalError.AlreadyInstalled)
-		}
-	} else {
-		// Deactivate any active volume on target
-		err = e.DeactivateDevices()
-		if err != nil {
-			return elementalError.NewFromError(err, elementalError.DeactivatingDevices)
-		}
-		// Partition device
-		err = e.PartitionAndFormatDevice(i.spec)
-		if err != nil {
-			return elementalError.NewFromError(err, elementalError.PartitioningDevice)
-		}
+	// Partition and format device if needed
+	err = i.prepareDevice(e)
+	if err != nil {
+		return err
 	}
 
 	err = e.MountPartitions(i.spec.Partitions.PartitionsByMountPoint(false))
@@ -169,17 +156,17 @@ func (i InstallAction) Run() (err error) {
 	})
 
 	// Before install hook happens after partitioning but before the image OS is applied
-	err = i.installHook(cnst.BeforeInstallHook, false)
+	err = i.installHook(cnst.BeforeInstallHook)
 	if err != nil {
 		return elementalError.NewFromError(err, elementalError.HookBeforeInstall)
 	}
 
 	// Deploy active image
-	systemMeta, err := e.DeployImage(&i.spec.Active, true)
+	systemMeta, treeCleaner, err := e.DeployImgTree(&i.spec.Active, cnst.WorkingImgDir)
 	if err != nil {
-		return elementalError.NewFromError(err, elementalError.DeployImage)
+		return elementalError.NewFromError(err, elementalError.DeployImgTree)
 	}
-	cleanup.Push(func() error { return e.UnmountImage(&i.spec.Active) })
+	cleanup.Push(func() error { return treeCleaner() })
 
 	// Copy cloud-init if any
 	err = e.CopyCloudConfig(i.spec.CloudInit)
@@ -190,7 +177,7 @@ func (i InstallAction) Run() (err error) {
 	grub := utils.NewGrub(&i.cfg.Config)
 	err = grub.Install(
 		i.spec.Target,
-		i.spec.Active.MountPoint,
+		cnst.WorkingImgDir,
 		i.spec.Partitions.State.MountPoint,
 		i.spec.GrubConf,
 		i.spec.Tty,
@@ -204,25 +191,16 @@ func (i InstallAction) Run() (err error) {
 	}
 
 	// Relabel SELinux
-	binds := map[string]string{}
-	if mnt, _ := utils.IsMounted(&i.cfg.Config, i.spec.Partitions.Persistent); mnt {
-		binds[i.spec.Partitions.Persistent.MountPoint] = cnst.UsrLocalPath
-	}
-	if mnt, _ := utils.IsMounted(&i.cfg.Config, i.spec.Partitions.OEM); mnt {
-		binds[i.spec.Partitions.OEM.MountPoint] = cnst.OEMPath
-	}
-	err = utils.ChrootedCallback(
-		&i.cfg.Config, i.spec.Active.MountPoint, binds, func() error { return e.SelinuxRelabel("/", true) },
-	)
+	err = i.applySelinuxLabels(e)
 	if err != nil {
 		return elementalError.NewFromError(err, elementalError.SelinuxRelabel)
 	}
 
-	err = i.installHook(cnst.AfterInstallChrootHook, true)
+	err = i.installChrootHook(cnst.AfterInstallChrootHook, cnst.WorkingImgDir)
 	if err != nil {
 		return elementalError.NewFromError(err, elementalError.HookAfterInstallChroot)
 	}
-	err = i.installHook(cnst.AfterInstallHook, false)
+	err = i.installHook(cnst.AfterInstallHook)
 	if err != nil {
 		return elementalError.NewFromError(err, elementalError.HookAfterInstall)
 	}
@@ -230,30 +208,40 @@ func (i InstallAction) Run() (err error) {
 	// Installation rebrand (only grub for now)
 	err = e.SetDefaultGrubEntry(
 		i.spec.Partitions.State.MountPoint,
-		i.spec.Active.MountPoint,
+		cnst.WorkingImgDir,
 		i.spec.GrubDefEntry,
 	)
 	if err != nil {
 		return elementalError.NewFromError(err, elementalError.SetDefaultGrubEntry)
 	}
 
-	// Unmount active image
-	err = e.UnmountImage(&i.spec.Active)
+	err = e.CreateImgFromTree(cnst.WorkingImgDir, &i.spec.Active, treeCleaner)
 	if err != nil {
-		return elementalError.NewFromError(err, elementalError.UnmountImage)
+		return elementalError.NewFromError(err, elementalError.CreateImgFromTree)
 	}
+
 	// Install Recovery
-	recoveryMeta, err := e.DeployImage(&i.spec.Recovery, false)
-	if err != nil {
-		return elementalError.NewFromError(err, elementalError.DeployImage)
+	var recoveryMeta interface{}
+	if i.spec.Recovery.Source.IsFile() && i.spec.Active.File == i.spec.Recovery.Source.Value() && i.spec.Active.FS == i.spec.Recovery.FS {
+		// Reuse image file from active image
+		err := e.CopyFileImg(&i.spec.Recovery)
+		if err != nil {
+			return elementalError.NewFromError(err, elementalError.CopyFileImg)
+		}
+	} else {
+		recoveryMeta, err = e.DeployImage(&i.spec.Recovery)
+		if err != nil {
+			return elementalError.NewFromError(err, elementalError.DeployImage)
+		}
 	}
+
 	// Install Passive
-	_, err = e.DeployImage(&i.spec.Passive, false)
+	err = e.CopyFileImg(&i.spec.Passive)
 	if err != nil {
 		return elementalError.NewFromError(err, elementalError.DeployImage)
 	}
 
-	err = i.installHook(cnst.PostInstallHook, false)
+	err = i.installHook(cnst.PostInstallHook)
 	if err != nil {
 		return elementalError.NewFromError(err, elementalError.HookPostInstall)
 	}
@@ -280,4 +268,40 @@ func (i InstallAction) Run() (err error) {
 	}
 
 	return PowerAction(i.cfg)
+}
+
+// applySelinuxLabels sets SELinux extended attributes to the root-tree being installed
+func (i *InstallAction) applySelinuxLabels(e *elemental.Elemental) error {
+	binds := map[string]string{}
+	if mnt, _ := utils.IsMounted(&i.cfg.Config, i.spec.Partitions.Persistent); mnt {
+		binds[i.spec.Partitions.Persistent.MountPoint] = cnst.UsrLocalPath
+	}
+	if mnt, _ := utils.IsMounted(&i.cfg.Config, i.spec.Partitions.OEM); mnt {
+		binds[i.spec.Partitions.OEM.MountPoint] = cnst.OEMPath
+	}
+	return utils.ChrootedCallback(
+		&i.cfg.Config, cnst.WorkingImgDir, binds, func() error { return e.SelinuxRelabel("/", true) },
+	)
+}
+
+func (i *InstallAction) prepareDevice(e *elemental.Elemental) error {
+	if i.spec.NoFormat {
+		// Check force flag against current device
+		labels := []string{i.spec.Active.Label, i.spec.Recovery.Label}
+		if e.CheckActiveDeployment(labels) && !i.spec.Force {
+			return elementalError.New("use `force` flag to run an installation over the current running deployment", elementalError.AlreadyInstalled)
+		}
+	} else {
+		// Deactivate any active volume on target
+		err := e.DeactivateDevices()
+		if err != nil {
+			return elementalError.NewFromError(err, elementalError.DeactivatingDevices)
+		}
+		// Partition device
+		err = e.PartitionAndFormatDevice(i.spec)
+		if err != nil {
+			return elementalError.NewFromError(err, elementalError.PartitioningDevice)
+		}
+	}
+	return nil
 }

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -145,7 +145,7 @@ var _ = Describe("Install action tests", func() {
 			spec = conf.NewInstallSpec(config.Config)
 			spec.Active.Size = 16
 
-			grubCfg := filepath.Join(spec.Active.MountPoint, constants.GrubConf)
+			grubCfg := filepath.Join(constants.WorkingImgDir, constants.GrubConf)
 			err = utils.MkdirAll(fs, filepath.Dir(grubCfg), constants.DirPerm)
 			Expect(err).To(BeNil())
 			_, err = fs.Create(grubCfg)

--- a/pkg/action/reset_test.go
+++ b/pkg/action/reset_test.go
@@ -141,7 +141,7 @@ var _ = Describe("Reset action tests", func() {
 
 			spec.Active.Size = 16
 
-			grubCfg := filepath.Join(spec.Active.MountPoint, spec.GrubConf)
+			grubCfg := filepath.Join(constants.WorkingImgDir, spec.GrubConf)
 			err = utils.MkdirAll(fs, filepath.Dir(grubCfg), constants.DirPerm)
 			Expect(err).To(BeNil())
 			_, err = fs.Create(grubCfg)

--- a/pkg/action/upgrade_test.go
+++ b/pkg/action/upgrade_test.go
@@ -143,11 +143,11 @@ var _ = Describe("Runtime Actions", func() {
 				spec.Active.Source = v1.NewChannelSrc("system/cos-config")
 				spec.Active.Size = 16
 
-				err = utils.MkdirAll(config.Fs, filepath.Join(spec.Active.MountPoint, "etc"), constants.DirPerm)
+				err = utils.MkdirAll(config.Fs, filepath.Join(constants.WorkingImgDir, "etc"), constants.DirPerm)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				err = fs.WriteFile(
-					filepath.Join(spec.Active.MountPoint, "etc", "os-release"),
+					filepath.Join(constants.WorkingImgDir, "etc", "os-release"),
 					[]byte("GRUB_ENTRY_NAME=TESTOS"),
 					constants.FilePerm,
 				)
@@ -443,11 +443,11 @@ var _ = Describe("Runtime Actions", func() {
 				spec.Active.Source = v1.NewChannelSrc("system/cos-config")
 				spec.Active.Size = 16
 
-				err = utils.MkdirAll(config.Fs, filepath.Join(spec.Active.MountPoint, "etc"), constants.DirPerm)
+				err = utils.MkdirAll(config.Fs, filepath.Join(constants.WorkingImgDir, "etc"), constants.DirPerm)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				err = fs.WriteFile(
-					filepath.Join(spec.Active.MountPoint, "etc", "os-release"),
+					filepath.Join(constants.WorkingImgDir, "etc", "os-release"),
 					[]byte("GRUB_ENTRY_NAME=TESTOS"),
 					constants.FilePerm,
 				)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -452,10 +452,11 @@ func NewResetSpec(cfg v1.Config) (*v1.ResetSpec, error) {
 	}
 
 	recoveryImg := filepath.Join(constants.RunningStateDir, "cOS", constants.RecoveryImgFile)
+	recoverySquashImg := filepath.Join(constants.RunningStateDir, "cOS", constants.RecoverySquashFile)
 	if exists, _ := utils.Exists(cfg.Fs, recoveryImg); exists {
 		imgSource = v1.NewFileSrc(recoveryImg)
-	} else if exists, _ = utils.Exists(cfg.Fs, constants.IsoBaseTree); exists {
-		imgSource = v1.NewDirSrc(constants.IsoBaseTree)
+	} else if exists, _ = utils.Exists(cfg.Fs, recoverySquashImg); exists {
+		imgSource = v1.NewFileSrc(recoverySquashImg)
 	} else {
 		imgSource = v1.NewEmptySrc()
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -239,7 +239,6 @@ var _ = Describe("Types", Label("types", "config"), func() {
 
 					spec, err := config.NewResetSpec(*c)
 					Expect(err).ShouldNot(HaveOccurred())
-					Expect(spec.Active.Source.Value()).To(Equal(constants.IsoBaseTree))
 					Expect(spec.Partitions.EFI.MountPoint).To(Equal(constants.EfiDir))
 				})
 				It("sets reset defaults on bios from non-squashed recovery", func() {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -22,55 +22,76 @@ import (
 )
 
 const (
-	GrubConf               = "/etc/cos/grub.cfg"
-	GrubOEMEnv             = "grub_oem_env"
-	GrubDefEntry           = "cOS"
-	DefaultTty             = "tty1"
-	BiosPartName           = "bios"
-	EfiLabel               = "COS_GRUB"
-	EfiPartName            = "efi"
-	ActiveLabel            = "COS_ACTIVE"
-	PassiveLabel           = "COS_PASSIVE"
-	SystemLabel            = "COS_SYSTEM"
-	RecoveryLabel          = "COS_RECOVERY"
-	RecoveryPartName       = "recovery"
-	StateLabel             = "COS_STATE"
-	StatePartName          = "state"
-	InstallStateFile       = "state.yaml"
-	PersistentLabel        = "COS_PERSISTENT"
-	PersistentPartName     = "persistent"
-	OEMLabel               = "COS_OEM"
-	OEMPartName            = "oem"
-	MountBinary            = "/usr/bin/mount"
-	EfiDevice              = "/sys/firmware/efi"
-	LinuxFs                = "ext4"
-	LinuxImgFs             = "ext2"
-	SquashFs               = "squashfs"
-	EfiFs                  = "vfat"
-	BiosFs                 = ""
-	EfiSize                = uint(64)
-	OEMSize                = uint(64)
-	StateSize              = uint(15360)
-	RecoverySize           = uint(8192)
-	PersistentSize         = uint(0)
-	BiosSize               = uint(1)
-	ImgSize                = uint(3072)
-	HTTPTimeout            = 60
-	PartStage              = "partitioning"
-	LiveDir                = "/run/initramfs/live"
-	RecoveryDir            = "/run/cos/recovery"
-	StateDir               = "/run/cos/state"
-	OEMDir                 = "/run/cos/oem"
-	PersistentDir          = "/run/cos/persistent"
-	ActiveDir              = "/run/cos/active"
-	TransitionDir          = "/run/cos/transition"
-	EfiDir                 = "/run/cos/efi"
-	RecoverySquashFile     = "recovery.squashfs"
-	ActiveImgFile          = "active.img"
-	PassiveImgFile         = "passive.img"
-	RecoveryImgFile        = "recovery.img"
-	IsoBaseTree            = "/run/rootfsbase"
-	CosSetup               = "/usr/bin/cos-setup"
+	GrubConf           = "/etc/cos/grub.cfg"
+	GrubOEMEnv         = "grub_oem_env"
+	GrubDefEntry       = "cOS"
+	DefaultTty         = "tty1"
+	BiosPartName       = "bios"
+	EfiLabel           = "COS_GRUB"
+	EfiPartName        = "efi"
+	ActiveLabel        = "COS_ACTIVE"
+	PassiveLabel       = "COS_PASSIVE"
+	SystemLabel        = "COS_SYSTEM"
+	RecoveryLabel      = "COS_RECOVERY"
+	RecoveryPartName   = "recovery"
+	StateLabel         = "COS_STATE"
+	StatePartName      = "state"
+	InstallStateFile   = "state.yaml"
+	PersistentLabel    = "COS_PERSISTENT"
+	PersistentPartName = "persistent"
+	OEMLabel           = "COS_OEM"
+	OEMPartName        = "oem"
+	ActiveImgName      = "active"
+	PassiveImgName     = "passive"
+	RecoveryImgName    = "recovery"
+	MountBinary        = "/usr/bin/mount"
+	EfiDevice          = "/sys/firmware/efi"
+	LinuxFs            = "ext4"
+	LinuxImgFs         = "ext2"
+	SquashFs           = "squashfs"
+	EfiFs              = "vfat"
+	BiosFs             = ""
+	EfiSize            = uint(64)
+	OEMSize            = uint(64)
+	StateSize          = uint(15360)
+	RecoverySize       = uint(8192)
+	PersistentSize     = uint(0)
+	BiosSize           = uint(1)
+	ImgSize            = uint(0)
+	ImgOverhead        = uint(256)
+	HTTPTimeout        = 60
+	CosSetup           = "/usr/bin/cos-setup"
+	GPT                = "gpt"
+	BuildImgName       = "elemental"
+	UsrLocalPath       = "/usr/local"
+	OEMPath            = "/oem"
+	ConfigDir          = "/etc/elemental"
+
+	// Mountpoints of images and partitions
+	RecoveryDir     = "/run/cos/recovery"
+	StateDir        = "/run/cos/state"
+	OEMDir          = "/run/cos/oem"
+	PersistentDir   = "/run/cos/persistent"
+	ActiveDir       = "/run/cos/active"
+	TransitionDir   = "/run/cos/transition"
+	EfiDir          = "/run/cos/efi"
+	ImgSrcDir       = "/run/cos/imgsrc"
+	WorkingImgDir   = "/run/cos/workingtree"
+	RunningStateDir = "/run/initramfs/cos-state" // TODO: converge this constant with StateDir/RecoveryDir in dracut module from cos-toolkit
+
+	// Live image mountpoints
+	IsoBaseTree = "/run/rootfsbase"
+	LiveDir     = "/run/initramfs/live"
+
+	// Image file names
+	RecoverySquashFile   = "recovery.squashfs"
+	ActiveImgFile        = "active.img"
+	PassiveImgFile       = "passive.img"
+	RecoveryImgFile      = "recovery.img"
+	TransitionImgFile    = "transition.img"
+	TransitionSquashFile = "transition.squashfs"
+
+	// Yip stages evaluated on reset/upgrade/install action
 	AfterInstallChrootHook = "after-install-chroot"
 	AfterInstallHook       = "after-install"
 	PostInstallHook        = "post-install"
@@ -83,25 +104,13 @@ const (
 	AfterUpgradeHook       = "after-upgrade"
 	PostUpgradeHook        = "post-upgrade"
 	BeforeUpgradeHook      = "before-upgrade"
-	LuetCosignPlugin       = "luet-cosign"
-	LuetMtreePlugin        = "luet-mtree"
-	LuetDefaultRepoURI     = "quay.io/costoolkit/releases-green"
-	LuetRepoMaxPrio        = 1
-	LuetDefaultRepoPrio    = 90
-	UpgradeActive          = "active"
-	UpgradeRecovery        = "recovery"
-	ChannelSource          = "system/cos"
-	TransitionImgFile      = "transition.img"
-	TransitionSquashFile   = "transition.squashfs"
-	RunningStateDir        = "/run/initramfs/cos-state" // TODO: converge this constant with StateDir/RecoveryDir in dracut module from cos-toolkit
-	ActiveImgName          = "active"
-	PassiveImgName         = "passive"
-	RecoveryImgName        = "recovery"
-	GPT                    = "gpt"
-	BuildImgName           = "elemental"
-	UsrLocalPath           = "/usr/local"
-	OEMPath                = "/oem"
-	ConfigDir              = "/etc/elemental"
+
+	// Luet constants
+	LuetCosignPlugin    = "luet-cosign"
+	LuetMtreePlugin     = "luet-mtree"
+	LuetDefaultRepoURI  = "quay.io/costoolkit/releases-green"
+	LuetRepoMaxPrio     = 1
+	LuetDefaultRepoPrio = 90
 
 	// SELinux targeted policy paths
 	SELinuxTargetedPath        = "/etc/selinux/targeted"

--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -378,7 +378,7 @@ func (e *Elemental) CreateImgFromTree(root string, img *v1.Image, cleaner func()
 	return err
 }
 
-// CopyFileImg copies the files targed as the source of this image. It also applies the img label over the copied image.
+// CopyFileImg copies the files target as the source of this image. It also applies the img label over the copied image.
 func (e *Elemental) CopyFileImg(img *v1.Image) error {
 	if !img.Source.IsFile() {
 		return fmt.Errorf("Copying a file image requires an image source of file type")

--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -248,7 +248,7 @@ func (e Elemental) UnmountImage(img *v1.Image) error {
 	return err
 }
 
-// CreateFileSystemImage creates the image file for config.target
+// CreateFileSystemImage creates the image file for the given image
 func (e Elemental) CreateFileSystemImage(img *v1.Image) error {
 	e.config.Logger.Infof("Creating file system image %s", img.File)
 	err := utils.MkdirAll(e.config.Fs, filepath.Dir(img.File), cnst.DirPerm)
@@ -281,68 +281,141 @@ func (e Elemental) CreateFileSystemImage(img *v1.Image) error {
 	return nil
 }
 
-// DeployImage will deploy the given image into the target. This method
-// creates the filesystem image file, mounts it and unmounts it as needed.
-func (e *Elemental) DeployImage(img *v1.Image, leaveMounted bool) (info interface{}, err error) {
-	target := img.MountPoint
-	if !img.Source.IsFile() {
-		if img.FS != cnst.SquashFs {
-			err = e.CreateFileSystemImage(img)
-			if err != nil {
-				return nil, err
-			}
+// DeployImgTree will deploy the given image into the given root tree. Returns source metadata in info,
+// a tree cleaner function and error. The given root will be a bind mount of a temporary directory into the same
+// filesystem of img.File, this is helpful to make the deployment easily accessible in after-* hooks.
+func (e *Elemental) DeployImgTree(img *v1.Image, root string) (info interface{}, cleaner func() error, err error) {
+	// We prepare the rootTree next to the target image file, in the same base path
+	e.config.Logger.Infof("Preparing root tree for image: %s", img.File)
+	tmp := strings.TrimSuffix(img.File, filepath.Ext(img.File))
+	tmp += ".imgTree"
+	err = utils.MkdirAll(e.config.Fs, tmp, cnst.DirPerm)
+	if err != nil {
+		return nil, nil, err
+	}
 
-			err = e.MountImage(img, "rw")
-			if err != nil {
-				return nil, err
+	err = utils.MkdirAll(e.config.Fs, root, cnst.DirPerm)
+	if err != nil {
+		_ = e.config.Fs.RemoveAll(tmp)
+		return nil, nil, err
+	}
+	err = e.config.Mounter.Mount(tmp, root, "bind", []string{"bind"})
+	if err != nil {
+		_ = e.config.Fs.RemoveAll(tmp)
+		_ = e.config.Fs.RemoveAll(root)
+		return nil, nil, err
+	}
+
+	cleaner = func() error {
+		_ = e.config.Mounter.Unmount(root)
+		err := e.config.Fs.RemoveAll(root)
+		if err != nil {
+			return err
+		}
+		return e.config.Fs.RemoveAll(tmp)
+	}
+
+	info, err = e.DumpSource(root, img.Source)
+	if err != nil {
+		_ = cleaner()
+		return nil, nil, err
+	}
+	err = utils.CreateDirStructure(e.config.Fs, root)
+	if err != nil {
+		_ = cleaner()
+		return nil, nil, err
+	}
+
+	return info, cleaner, err
+}
+
+// CreateImgFromTree creates the given image from with the contents of the tree for the given root.
+func (e *Elemental) CreateImgFromTree(root string, img *v1.Image, cleaner func() error) (err error) {
+	if cleaner != nil {
+		defer func() {
+			cErr := cleaner()
+			if cErr != nil && err == nil {
+				err = cErr
 			}
-		} else {
-			target = utils.GetTempDir(e.config, "")
-			err := utils.MkdirAll(e.config.Fs, target, cnst.DirPerm)
-			if err != nil {
-				return nil, err
-			}
-			defer e.config.Fs.RemoveAll(target) // nolint:errcheck
+		}()
+	}
+
+	if img.FS == cnst.SquashFs {
+		e.config.Logger.Infof("Creating squashed image: %s", img.File)
+		squashOptions := append(cnst.GetDefaultSquashfsOptions(), e.config.SquashFsCompressionConfig...)
+		err = utils.CreateSquashFS(e.config.Runner, e.config.Logger, root, img.File, squashOptions)
+		if err != nil {
+			return err
 		}
 	} else {
-		target = img.File
-	}
-	info, err = e.DumpSource(target, img.Source)
-	if err != nil {
-		_ = e.UnmountImage(img)
-		return nil, err
-	}
-	if !img.Source.IsFile() {
-		err = utils.CreateDirStructure(e.config.Fs, target)
-		if err != nil {
-			return nil, err
-		}
-		if img.FS == cnst.SquashFs {
-			squashOptions := append(cnst.GetDefaultSquashfsOptions(), e.config.SquashFsCompressionConfig...)
-			err = utils.CreateSquashFS(e.config.Runner, e.config.Logger, target, img.File, squashOptions)
+		e.config.Logger.Infof("Creating filesystem image: %s", img.File)
+		if img.Size == 0 {
+			size, err := utils.DirSizeMB(e.config.Fs, root)
 			if err != nil {
-				return nil, err
+				return err
 			}
+			img.Size = size + cnst.ImgOverhead
 		}
-	} else if img.Label != "" && img.FS != cnst.SquashFs {
-		_, err = e.config.Runner.Run("tune2fs", "-L", img.Label, img.File)
+		err = e.CreateFileSystemImage(img)
 		if err != nil {
-			e.config.Logger.Errorf("Failed to apply label %s to $s", img.Label, img.File)
-			_ = e.config.Fs.Remove(img.File)
-			return nil, err
+			return err
 		}
 	}
 	if leaveMounted && img.Source.IsFile() {
 		err = e.MountImage(img, "rw")
 		if err != nil {
-			return nil, err
+			return err
+		}
+		defer func() {
+			mErr := e.UnmountImage(img)
+			if err == nil && mErr != nil {
+				err = mErr
+			}
+		}()
+		err = utils.SyncData(e.config.Logger, e.config.Fs, root, img.MountPoint)
+		if err != nil {
+			return err
 		}
 	}
-	if !leaveMounted {
-		err = e.UnmountImage(img)
-		if err != nil {
-			return nil, err
-		}
+	return err
+}
+
+// CopyFileImg copies the files targed as the source of this image. It also applies the img label over the copied image.
+func (e *Elemental) CopyFileImg(img *v1.Image) error {
+	if !img.Source.IsFile() {
+		return fmt.Errorf("Copying a file image requires an image source of file type")
+	}
+
+	err := utils.MkdirAll(e.config.Fs, filepath.Dir(img.File), cnst.DirPerm)
+	if err != nil {
+		return err
+	}
+
+	e.config.Logger.Infof("Copying image %s to %s", img.Source.Value(), img.File)
+	err = utils.CopyFile(e.config.Fs, img.Source.Value(), img.File)
+	if err != nil {
+		return err
+	}
+
+	if img.FS != cnst.SquashFs && img.Label != "" {
+		e.config.Logger.Infof("Setting label: %s ", img.Label)
+		_, err = e.config.Runner.Run("tune2fs", "-L", img.Label, img.File)
+	}
+	return err
+}
+
+// DeployImage will deploy the given image into the target. This method
+// creates the filesystem image file and fills it with the correspondant data
+func (e *Elemental) DeployImage(img *v1.Image) (interface{}, error) {
+	e.config.Logger.Infof("Deploying image: %s", img.File)
+	info, cleaner, err := e.DeployImgTree(img, cnst.WorkingImgDir)
+	if err != nil {
+		return nil, err
+	}
+
+	err = e.CreateImgFromTree(cnst.WorkingImgDir, img, cleaner)
+	if err != nil {
+		return nil, err
 	}
 	return info, nil
 }
@@ -379,11 +452,18 @@ func (e *Elemental) DumpSource(target string, imgSrc *v1.ImageSource) (info inte
 			return nil, err
 		}
 	} else if imgSrc.IsFile() {
-		err := utils.MkdirAll(e.config.Fs, filepath.Dir(target), cnst.DirPerm)
+		err = utils.MkdirAll(e.config.Fs, cnst.ImgSrcDir, cnst.DirPerm)
 		if err != nil {
 			return nil, err
 		}
-		err = utils.CopyFile(e.config.Fs, imgSrc.Value(), target)
+		img := &v1.Image{File: imgSrc.Value(), MountPoint: cnst.ImgSrcDir}
+		err = e.MountImage(img, "auto", "ro")
+		if err != nil {
+			return nil, err
+		}
+		defer e.UnmountImage(img) // nolint:errcheck
+		excludes := []string{"/mnt", "/proc", "/sys", "/dev", "/tmp", "/host", "/run"}
+		err = utils.SyncData(e.config.Logger, e.config.Fs, cnst.ImgSrcDir, target, excludes...)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -360,8 +360,6 @@ func (e *Elemental) CreateImgFromTree(root string, img *v1.Image, cleaner func()
 		if err != nil {
 			return err
 		}
-	}
-	if leaveMounted && img.Source.IsFile() {
 		err = e.MountImage(img, "rw")
 		if err != nil {
 			return err

--- a/pkg/error/exit-codes.go
+++ b/pkg/error/exit-codes.go
@@ -223,5 +223,14 @@ const HookPostReset = 73
 // Error occurred during post-install hook
 const HookPostInstall = 74
 
+// Error occurred while preparing the image root tree
+const DeployImgTree = 75
+
+// Error occurred while creating the OS filesystem image
+const CreateImgFromTree = 76
+
+// Error occurred while copying the filesystem image and setting new labels
+const CopyFileImg = 77
+
 // Unknown error
 const Unknown int = 255

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -83,20 +83,25 @@ func GetFullDeviceByLabel(runner v1.Runner, label string, attempts int) (*v1.Par
 
 // CopyFile Copies source file to target file using Fs interface. If target
 // is  directory source is copied into that directory using source name file.
-func CopyFile(fs v1.FS, source string, target string) (err error) {
+// File mode is preserved
+func CopyFile(fs v1.FS, source string, target string) error {
 	return ConcatFiles(fs, []string{source}, target)
 }
 
 // ConcatFiles Copies source files to target file using Fs interface.
 // Source files are concatenated into target file in the given order.
 // If target is a directory source is copied into that directory using
-// 1st source name file.
+// 1st source name file. The result keeps the file mode of the 1st source.
 func ConcatFiles(fs v1.FS, sources []string, target string) (err error) {
 	if len(sources) == 0 {
 		return fmt.Errorf("Empty sources list")
 	}
 	if dir, _ := IsDir(fs, target); dir {
 		target = filepath.Join(target, filepath.Base(sources[0]))
+	}
+	fInf, err := fs.Stat(sources[0])
+	if err != nil {
+		return err
 	}
 
 	targetFile, err := fs.Create(target)
@@ -115,19 +120,19 @@ func ConcatFiles(fs v1.FS, sources []string, target string) (err error) {
 	for _, source := range sources {
 		sourceFile, err = fs.Open(source)
 		if err != nil {
-			break
+			return err
 		}
 		_, err = io.Copy(targetFile, sourceFile)
 		if err != nil {
-			break
+			return err
 		}
 		err = sourceFile.Close()
 		if err != nil {
-			break
+			return err
 		}
 	}
 
-	return err
+	return fs.Chmod(target, fInf.Mode())
 }
 
 // Copies source file to target file using Fs interface

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -135,7 +135,8 @@ func ConcatFiles(fs v1.FS, sources []string, target string) (err error) {
 	return fs.Chmod(target, fInf.Mode())
 }
 
-// Copies source file to target file using Fs interface
+// CreateDirStructure creates essentials directories under the root tree that might not be present
+// within a container image (/dev, /run, etc.)
 func CreateDirStructure(fs v1.FS, target string) error {
 	for _, dir := range []string{"/run", "/dev", "/boot", "/usr/local", "/oem"} {
 		err := MkdirAll(fs, filepath.Join(target, dir), cnst.DirPerm)

--- a/pkg/utils/fs.go
+++ b/pkg/utils/fs.go
@@ -20,6 +20,7 @@ limitations under the License.
 package utils
 
 import (
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -35,7 +36,7 @@ import (
 	"github.com/twpayne/go-vfs/vfst"
 )
 
-// DirSize returns the accumulated size of all files in folder
+// DirSize returns the accumulated size of all files in folder. Result in bytes
 func DirSize(fs v1.FS, path string) (int64, error) {
 	var size int64
 	err := vfs.Walk(fs, path, func(_ string, info os.FileInfo, err error) error {
@@ -48,6 +49,21 @@ func DirSize(fs v1.FS, path string) (int64, error) {
 		return err
 	})
 	return size, err
+}
+
+// DirSizeMB returns the accumulated size of all files in folder. Result in Megabytes
+func DirSizeMB(fs v1.FS, path string) (uint, error) {
+	size, err := DirSize(fs, path)
+	if err != nil {
+		return 0, err
+	}
+
+	MB := int64(1024 * 1024)
+	sizeMB := (size/MB*MB + MB) / MB
+	if sizeMB > 0 {
+		return uint(sizeMB), nil
+	}
+	return 0, fmt.Errorf("Negative size calculation: %d", sizeMB)
 }
 
 // Check if a file or directory exists.

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -22,11 +22,12 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	eleefi "github.com/rancher/elemental-cli/pkg/efi"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	eleefi "github.com/rancher/elemental-cli/pkg/efi"
 
 	efi "github.com/canonical/go-efilib"
 	"github.com/jaypipes/ghw/pkg/block"


### PR DESCRIPTION
This commit refactors elemental image deploy procedure to always create and prepare the root tree in a temporary folder before synching it to a filesystem image most likely as a mounted loop device.

This change has a couple of immediate benefits:

1. We can pre-compute the root tree size before creating the filesystem  image. Hence image sizes can be adjusted to root-tree size. Currently in this PR the default size of the images is set to `0` which means it will use as much as the image requires plus and arbitrary overhead of 256MB (we could consider making it configurable if needed). The use of an static size is still possible by setting the partition size to any value greater than `0`.

2. There is no path differentiation between filesystems. The root tree is prepared following the same logic independently of the target filesystem. Squashfs is no longer an exception, building the image follows the same logic as it was any other writable filesystem.

We also can argue this is a simple, robust and flexible logic compared with the previous code. 

The counter part is having to prepare the root-tree to later on copy it to the final image, this causes the root-tree to be written twice, one to prepare it and another one to sync it to the target location.

Fixes #172
