### PR TITLE
Set labels used by grub to find system disks

### DIFF
--- a/docs/elemental_exit-codes.md
+++ b/docs/elemental_exit-codes.md
@@ -71,4 +71,5 @@
 | 75 | Error occurred while preparing the image root tree|
 | 76 | Error occurred while creating the OS filesystem image|
 | 77 | Error occurred while copying the filesystem image and setting new labels|
+| 78 | Error setting persistent GRUB variables|
 | 255 | Unknown error|

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -208,12 +208,13 @@ func (i InstallAction) Run() (err error) {
 	err = grub.SetPersistentVariables(
 		filepath.Join(i.spec.Partitions.State.MountPoint, constants.GrubOEMEnv),
 		map[string]string{
-			"state_label":    i.spec.Partitions.State.FilesystemLabel,
-			"active_label":   i.spec.Active.Label,
-			"passive_label":  i.spec.Passive.Label,
-			"recovery_label": i.spec.Recovery.Label,
-			"system_label":   i.spec.Partitions.Recovery.FilesystemLabel,
-			"oem_label":      i.spec.Partitions.OEM.FilesystemLabel,
+			"state_label":      i.spec.Partitions.State.FilesystemLabel,
+			"active_label":     i.spec.Active.Label,
+			"passive_label":    i.spec.Passive.Label,
+			"recovery_label":   i.spec.Recovery.Label,
+			"system_label":     i.spec.Partitions.Recovery.FilesystemLabel,
+			"oem_label":        i.spec.Partitions.OEM.FilesystemLabel,
+			"persistent_label": i.spec.Partitions.Persistent.FilesystemLabel,
 		},
 	)
 	if err != nil {

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -205,22 +205,10 @@ func (i InstallAction) Run() (err error) {
 		return elementalError.NewFromError(err, elementalError.HookAfterInstall)
 	}
 
-	grubEnv := map[string]string{
-		"state_label":    i.spec.Partitions.State.FilesystemLabel,
-		"active_label":   i.spec.Active.Label,
-		"passive_label":  i.spec.Passive.Label,
-		"recovery_label": i.spec.Recovery.Label,
-		"system_label":   i.spec.Partitions.Recovery.FilesystemLabel,
-		"oem_label":      i.spec.Partitions.OEM.FilesystemLabel,
-	}
-
-	if i.spec.Partitions.Persistent != nil {
-		grubEnv["persistent_label"] = i.spec.Partitions.Persistent.FilesystemLabel
-	}
-
+	grubVars := i.spec.GetGrubLabels()
 	err = grub.SetPersistentVariables(
 		filepath.Join(i.spec.Partitions.State.MountPoint, constants.GrubOEMEnv),
-		grubEnv,
+		grubVars,
 	)
 	if err != nil {
 		i.cfg.Logger.Error("Error setting GRUB labels: %s", err)

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -205,17 +205,22 @@ func (i InstallAction) Run() (err error) {
 		return elementalError.NewFromError(err, elementalError.HookAfterInstall)
 	}
 
+	grubEnv := map[string]string{
+		"state_label":    i.spec.Partitions.State.FilesystemLabel,
+		"active_label":   i.spec.Active.Label,
+		"passive_label":  i.spec.Passive.Label,
+		"recovery_label": i.spec.Recovery.Label,
+		"system_label":   i.spec.Partitions.Recovery.FilesystemLabel,
+		"oem_label":      i.spec.Partitions.OEM.FilesystemLabel,
+	}
+
+	if i.spec.Partitions.Persistent != nil {
+		grubEnv["persistent_label"] = i.spec.Partitions.Persistent.FilesystemLabel
+	}
+
 	err = grub.SetPersistentVariables(
 		filepath.Join(i.spec.Partitions.State.MountPoint, constants.GrubOEMEnv),
-		map[string]string{
-			"state_label":      i.spec.Partitions.State.FilesystemLabel,
-			"active_label":     i.spec.Active.Label,
-			"passive_label":    i.spec.Passive.Label,
-			"recovery_label":   i.spec.Recovery.Label,
-			"system_label":     i.spec.Partitions.Recovery.FilesystemLabel,
-			"oem_label":        i.spec.Partitions.OEM.FilesystemLabel,
-			"persistent_label": i.spec.Partitions.Persistent.FilesystemLabel,
-		},
+		grubEnv,
 	)
 	if err != nil {
 		i.cfg.Logger.Error("Error setting GRUB labels: %s", err)

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -21,7 +21,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/rancher/elemental-cli/pkg/constants"
 	cnst "github.com/rancher/elemental-cli/pkg/constants"
 	"github.com/rancher/elemental-cli/pkg/elemental"
 	elementalError "github.com/rancher/elemental-cli/pkg/error"
@@ -207,7 +206,7 @@ func (i InstallAction) Run() (err error) {
 
 	grubVars := i.spec.GetGrubLabels()
 	err = grub.SetPersistentVariables(
-		filepath.Join(i.spec.Partitions.State.MountPoint, constants.GrubOEMEnv),
+		filepath.Join(i.spec.Partitions.State.MountPoint, cnst.GrubOEMEnv),
 		grubVars,
 	)
 	if err != nil {

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -211,8 +211,8 @@ func (i InstallAction) Run() (err error) {
 			"state_label":    i.spec.Partitions.State.FilesystemLabel,
 			"active_label":   i.spec.Active.Label,
 			"passive_label":  i.spec.Passive.Label,
-			"recovery_label": i.spec.Partitions.Recovery.FilesystemLabel,
-			"system_label":   constants.SystemLabel,
+			"recovery_label": i.spec.Recovery.Label,
+			"system_label":   i.spec.Partitions.Recovery.FilesystemLabel,
 			"oem_label":      i.spec.Partitions.OEM.FilesystemLabel,
 		},
 	)

--- a/pkg/action/reset.go
+++ b/pkg/action/reset.go
@@ -218,8 +218,8 @@ func (r ResetAction) Run() (err error) {
 			"state_label":    r.spec.Partitions.State.FilesystemLabel,
 			"active_label":   r.spec.Active.Label,
 			"passive_label":  r.spec.Passive.Label,
-			"recovery_label": r.spec.Partitions.Recovery.FilesystemLabel,
-			"system_label":   cnst.SystemLabel,
+			"recovery_label": r.spec.State.Partitions[cnst.RecoveryPartName].FSLabel,
+			"system_label":   r.spec.Partitions.Recovery.FilesystemLabel,
 			"oem_label":      r.spec.Partitions.OEM.FilesystemLabel,
 		},
 	)

--- a/pkg/action/reset.go
+++ b/pkg/action/reset.go
@@ -215,12 +215,13 @@ func (r ResetAction) Run() (err error) {
 	err = grub.SetPersistentVariables(
 		filepath.Join(r.spec.Partitions.State.MountPoint, cnst.GrubOEMEnv),
 		map[string]string{
-			"state_label":    r.spec.Partitions.State.FilesystemLabel,
-			"active_label":   r.spec.Active.Label,
-			"passive_label":  r.spec.Passive.Label,
-			"recovery_label": r.spec.State.Partitions[cnst.RecoveryPartName].FSLabel,
-			"system_label":   r.spec.Partitions.Recovery.FilesystemLabel,
-			"oem_label":      r.spec.Partitions.OEM.FilesystemLabel,
+			"state_label":      r.spec.Partitions.State.FilesystemLabel,
+			"active_label":     r.spec.Active.Label,
+			"passive_label":    r.spec.Passive.Label,
+			"recovery_label":   r.spec.State.Partitions[cnst.RecoveryPartName].FSLabel,
+			"system_label":     r.spec.Partitions.Recovery.FilesystemLabel,
+			"oem_label":        r.spec.Partitions.OEM.FilesystemLabel,
+			"persistent_label": r.spec.Partitions.Persistent.FilesystemLabel,
 		},
 	)
 	if err != nil {

--- a/pkg/action/reset.go
+++ b/pkg/action/reset.go
@@ -212,6 +212,22 @@ func (r ResetAction) Run() (err error) {
 		return elementalError.NewFromError(err, elementalError.HookAfterReset)
 	}
 
+	err = grub.SetPersistentVariables(
+		filepath.Join(r.spec.Partitions.State.MountPoint, cnst.GrubOEMEnv),
+		map[string]string{
+			"state_label":    r.spec.Partitions.State.FilesystemLabel,
+			"active_label":   r.spec.Active.Label,
+			"passive_label":  r.spec.Passive.Label,
+			"recovery_label": r.spec.Partitions.Recovery.FilesystemLabel,
+			"system_label":   cnst.SystemLabel,
+			"oem_label":      r.spec.Partitions.OEM.FilesystemLabel,
+		},
+	)
+	if err != nil {
+		r.cfg.Logger.Error("Error setting GRUB labels: %s", err)
+		return elementalError.NewFromError(err, elementalError.SetGrubVariables)
+	}
+
 	// installation rebrand (only grub for now)
 	err = e.SetDefaultGrubEntry(
 		r.spec.Partitions.State.MountPoint,

--- a/pkg/action/reset.go
+++ b/pkg/action/reset.go
@@ -212,28 +212,10 @@ func (r ResetAction) Run() (err error) {
 		return elementalError.NewFromError(err, elementalError.HookAfterReset)
 	}
 
-	grubEnv := map[string]string{
-		"state_label":   r.spec.Partitions.State.FilesystemLabel,
-		"active_label":  r.spec.Active.Label,
-		"passive_label": r.spec.Passive.Label,
-		"system_label":  r.spec.Partitions.Recovery.FilesystemLabel,
-		"oem_label":     r.spec.Partitions.OEM.FilesystemLabel,
-	}
-
-	if r.spec.State != nil {
-		recoveryPart, ok := r.spec.State.Partitions[cnst.RecoveryPartName]
-		if ok {
-			grubEnv["recovery_label"] = recoveryPart.FSLabel
-		}
-	}
-
-	if r.spec.Partitions.Persistent != nil {
-		grubEnv["persistent_label"] = r.spec.Partitions.Persistent.FilesystemLabel
-	}
-
+	grubVars := r.spec.GetGrubLabels()
 	err = grub.SetPersistentVariables(
 		filepath.Join(r.spec.Partitions.State.MountPoint, cnst.GrubOEMEnv),
-		grubEnv,
+		grubVars,
 	)
 	if err != nil {
 		r.cfg.Logger.Error("Error setting GRUB labels: %s", err)

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -237,22 +237,10 @@ func (u *UpgradeAction) Run() (err error) {
 		return elementalError.NewFromError(err, elementalError.HookAfterUpgrade)
 	}
 
-	grubEnv := map[string]string{
-		"state_label":    u.spec.Partitions.State.FilesystemLabel,
-		"active_label":   u.spec.Active.Label,
-		"passive_label":  u.spec.Passive.Label,
-		"recovery_label": u.spec.Recovery.Label,
-		"system_label":   u.spec.Partitions.Recovery.FilesystemLabel,
-		"oem_label":      u.spec.Partitions.OEM.FilesystemLabel,
-	}
-
-	if u.spec.Partitions.Persistent != nil {
-		grubEnv["persistent_label"] = u.spec.Partitions.Persistent.FilesystemLabel
-	}
-
+	grubVars := u.spec.GetGrubLabels()
 	err = utils.NewGrub(&u.config.Config).SetPersistentVariables(
 		filepath.Join(u.spec.Partitions.State.MountPoint, constants.GrubOEMEnv),
-		grubEnv,
+		grubVars,
 	)
 	if err != nil {
 		u.Error("Error setting GRUB labels: %s", err)

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -243,8 +243,8 @@ func (u *UpgradeAction) Run() (err error) {
 			"state_label":    u.spec.Partitions.State.FilesystemLabel,
 			"active_label":   u.spec.Active.Label,
 			"passive_label":  u.spec.Passive.Label,
-			"recovery_label": u.spec.Partitions.Recovery.FilesystemLabel,
-			"system_label":   constants.SystemLabel,
+			"recovery_label": u.spec.Recovery.Label,
+			"system_label":   u.spec.Partitions.Recovery.FilesystemLabel,
 			"oem_label":      u.spec.Partitions.OEM.FilesystemLabel,
 		},
 	)

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -240,12 +240,13 @@ func (u *UpgradeAction) Run() (err error) {
 	err = utils.NewGrub(&u.config.Config).SetPersistentVariables(
 		filepath.Join(u.spec.Partitions.State.MountPoint, constants.GrubOEMEnv),
 		map[string]string{
-			"state_label":    u.spec.Partitions.State.FilesystemLabel,
-			"active_label":   u.spec.Active.Label,
-			"passive_label":  u.spec.Passive.Label,
-			"recovery_label": u.spec.Recovery.Label,
-			"system_label":   u.spec.Partitions.Recovery.FilesystemLabel,
-			"oem_label":      u.spec.Partitions.OEM.FilesystemLabel,
+			"state_label":      u.spec.Partitions.State.FilesystemLabel,
+			"active_label":     u.spec.Active.Label,
+			"passive_label":    u.spec.Passive.Label,
+			"recovery_label":   u.spec.Recovery.Label,
+			"system_label":     u.spec.Partitions.Recovery.FilesystemLabel,
+			"oem_label":        u.spec.Partitions.OEM.FilesystemLabel,
+			"persistent_label": u.spec.Partitions.Persistent.FilesystemLabel,
 		},
 	)
 	if err != nil {

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -237,6 +237,22 @@ func (u *UpgradeAction) Run() (err error) {
 		return elementalError.NewFromError(err, elementalError.HookAfterUpgrade)
 	}
 
+	err = utils.NewGrub(&u.config.Config).SetPersistentVariables(
+		filepath.Join(u.spec.Partitions.State.MountPoint, constants.GrubOEMEnv),
+		map[string]string{
+			"state_label":    u.spec.Partitions.State.FilesystemLabel,
+			"active_label":   u.spec.Active.Label,
+			"passive_label":  u.spec.Passive.Label,
+			"recovery_label": u.spec.Partitions.Recovery.FilesystemLabel,
+			"system_label":   constants.SystemLabel,
+			"oem_label":      u.spec.Partitions.OEM.FilesystemLabel,
+		},
+	)
+	if err != nil {
+		u.Error("Error setting GRUB labels: %s", err)
+		return elementalError.NewFromError(err, elementalError.SetGrubVariables)
+	}
+
 	// Only apply rebrand stage for system upgrades
 	if !u.spec.RecoveryUpgrade {
 		u.Info("rebranding")

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -237,17 +237,22 @@ func (u *UpgradeAction) Run() (err error) {
 		return elementalError.NewFromError(err, elementalError.HookAfterUpgrade)
 	}
 
+	grubEnv := map[string]string{
+		"state_label":    u.spec.Partitions.State.FilesystemLabel,
+		"active_label":   u.spec.Active.Label,
+		"passive_label":  u.spec.Passive.Label,
+		"recovery_label": u.spec.Recovery.Label,
+		"system_label":   u.spec.Partitions.Recovery.FilesystemLabel,
+		"oem_label":      u.spec.Partitions.OEM.FilesystemLabel,
+	}
+
+	if u.spec.Partitions.Persistent != nil {
+		grubEnv["persistent_label"] = u.spec.Partitions.Persistent.FilesystemLabel
+	}
+
 	err = utils.NewGrub(&u.config.Config).SetPersistentVariables(
 		filepath.Join(u.spec.Partitions.State.MountPoint, constants.GrubOEMEnv),
-		map[string]string{
-			"state_label":      u.spec.Partitions.State.FilesystemLabel,
-			"active_label":     u.spec.Active.Label,
-			"passive_label":    u.spec.Passive.Label,
-			"recovery_label":   u.spec.Recovery.Label,
-			"system_label":     u.spec.Partitions.Recovery.FilesystemLabel,
-			"oem_label":        u.spec.Partitions.OEM.FilesystemLabel,
-			"persistent_label": u.spec.Partitions.Persistent.FilesystemLabel,
-		},
+		grubEnv,
 	)
 	if err != nil {
 		u.Error("Error setting GRUB labels: %s", err)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -274,7 +274,7 @@ func NewInstallElementalParitions() v1.ElementalPartitions {
 func getActivePassiveAndRecoveryState(state *v1.InstallState) (active, passive, recovery *v1.ImageState) {
 	recovery = &v1.ImageState{
 		FS:    constants.LinuxImgFs,
-		Label: constants.RecoveryLabel,
+		Label: constants.SystemLabel,
 	}
 	passive = &v1.ImageState{
 		FS:    constants.LinuxImgFs,

--- a/pkg/error/exit-codes.go
+++ b/pkg/error/exit-codes.go
@@ -232,5 +232,8 @@ const CreateImgFromTree = 76
 // Error occurred while copying the filesystem image and setting new labels
 const CopyFileImg = 77
 
+// Error setting persistent GRUB variables
+const SetGrubVariables = 78
+
 // Unknown error
 const Unknown int = 255

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -369,7 +369,7 @@ func NewElementalPartitionsFromList(pl PartitionList, state *InstallState) Eleme
 	ep.OEM = pl.GetByNameOrLabel(constants.OEMPartName, lm[constants.OEMPartName])
 	ep.Recovery = pl.GetByNameOrLabel(constants.RecoveryPartName, lm[constants.RecoveryPartName])
 	ep.State = pl.GetByNameOrLabel(constants.StatePartName, lm[constants.StatePartName])
-	ep.Persistent = pl.GetByNameOrLabel(constants.PersistentPartName, lm[constants.PersistentLabel])
+	ep.Persistent = pl.GetByNameOrLabel(constants.PersistentPartName, lm[constants.PersistentPartName])
 
 	return ep
 }

--- a/pkg/types/v1/grub.go
+++ b/pkg/types/v1/grub.go
@@ -1,0 +1,80 @@
+/*
+Copyright © 2022 - 2023 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"github.com/rancher/elemental-cli/pkg/constants"
+)
+
+func (i InstallSpec) GetGrubLabels() map[string]string {
+	grubEnv := map[string]string{
+		"state_label":    i.Partitions.State.FilesystemLabel,
+		"active_label":   i.Active.Label,
+		"passive_label":  i.Passive.Label,
+		"recovery_label": i.Partitions.Recovery.FilesystemLabel,
+		"system_label":   i.Recovery.Label,
+		"oem_label":      i.Partitions.OEM.FilesystemLabel,
+	}
+
+	if i.Partitions.Persistent != nil {
+		grubEnv["persistent_label"] = i.Partitions.Persistent.FilesystemLabel
+	}
+
+	return grubEnv
+}
+
+func (u UpgradeSpec) GetGrubLabels() map[string]string {
+	grubVars := map[string]string{
+		"state_label":    u.Partitions.State.FilesystemLabel,
+		"active_label":   u.Active.Label,
+		"passive_label":  u.Passive.Label,
+		"recovery_label": u.Partitions.Recovery.FilesystemLabel,
+		"system_label":   u.Recovery.Label,
+		"oem_label":      u.Partitions.OEM.FilesystemLabel,
+	}
+
+	if u.Partitions.Persistent != nil {
+		grubVars["persistent_label"] = u.Partitions.Persistent.FilesystemLabel
+	}
+
+	return grubVars
+}
+
+func (r ResetSpec) GetGrubLabels() map[string]string {
+	grubVars := map[string]string{
+		"state_label":   r.Partitions.State.FilesystemLabel,
+		"active_label":  r.Active.Label,
+		"passive_label": r.Passive.Label,
+		"system_label":  r.Partitions.Recovery.FilesystemLabel,
+		"oem_label":     r.Partitions.OEM.FilesystemLabel,
+	}
+
+	if r.State != nil {
+		if recoveryPart, ok := r.State.Partitions[constants.RecoveryPartName]; ok {
+			grubVars["recovery_label"] = recoveryPart.FSLabel
+			if recoveryImg, ok := recoveryPart.Images[constants.RecoveryImgName]; ok {
+				grubVars["system_label"] = recoveryImg.Label
+			}
+		}
+	}
+
+	if r.Partitions.Persistent != nil {
+		grubVars["persistent_label"] = r.Partitions.Persistent.FilesystemLabel
+	}
+
+	return grubVars
+}

--- a/pkg/types/v1/grub.go
+++ b/pkg/types/v1/grub.go
@@ -56,11 +56,11 @@ func (u UpgradeSpec) GetGrubLabels() map[string]string {
 
 func (r ResetSpec) GetGrubLabels() map[string]string {
 	grubVars := map[string]string{
-		"state_label":   r.Partitions.State.FilesystemLabel,
-		"active_label":  r.Active.Label,
-		"passive_label": r.Passive.Label,
-		"system_label":  r.Partitions.Recovery.FilesystemLabel,
-		"oem_label":     r.Partitions.OEM.FilesystemLabel,
+		"state_label":    r.Partitions.State.FilesystemLabel,
+		"active_label":   r.Active.Label,
+		"passive_label":  r.Passive.Label,
+		"recovery_label": r.Partitions.Recovery.FilesystemLabel,
+		"oem_label":      r.Partitions.OEM.FilesystemLabel,
 	}
 
 	if r.State != nil {

--- a/pkg/utils/grub.go
+++ b/pkg/utils/grub.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	efilib "github.com/canonical/go-efilib"
+
 	cnst "github.com/rancher/elemental-cli/pkg/constants"
 	eleefi "github.com/rancher/elemental-cli/pkg/efi"
 	v1 "github.com/rancher/elemental-cli/pkg/types/v1"


### PR DESCRIPTION
This commit sets GRUB persistent variables for filesystem labels after install/upgrade/reset. These labels are used in the new GRUB configuration when booting the system.

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>