### PR TITLE
Make ISO related constants consistent

### DIFF
--- a/pkg/action/build-iso.go
+++ b/pkg/action/build-iso.go
@@ -153,14 +153,14 @@ func (b *BuildISOAction) ISORun() error {
 
 	if b.spec.Firmware == v1.EFI {
 		b.cfg.Logger.Info("Creating EFI image...")
-		err = b.createEFI(uefiDir, filepath.Join(isoTmpDir, constants.IsoEFIImg))
+		err = b.createEFI(uefiDir, filepath.Join(isoTmpDir, constants.ISOEFIImg))
 		if err != nil {
 			return err
 		}
 	}
 
 	b.cfg.Logger.Infof("Creating ISO image...")
-	err = b.burnISO(isoDir, filepath.Join(isoTmpDir, constants.IsoEFIImg))
+	err = b.burnISO(isoDir, filepath.Join(isoTmpDir, constants.ISOEFIImg))
 	if err != nil {
 		b.cfg.Logger.Errorf("Failed preparing ISO's root tree: %v", err)
 		return err
@@ -181,20 +181,20 @@ func (b BuildISOAction) prepareISORoot(isoDir string, rootDir string) error {
 	}
 	//TODO document boot/kernel and boot/initrd expectation in bootloader config
 	b.cfg.Logger.Debugf("Copying Kernel file %s to iso root tree", kernel)
-	err = utils.CopyFile(b.cfg.Fs, kernel, filepath.Join(isoDir, constants.IsoKernelPath))
+	err = utils.CopyFile(b.cfg.Fs, kernel, filepath.Join(isoDir, constants.ISOKernelPath))
 	if err != nil {
 		return elementalError.NewFromError(err, elementalError.CopyFile)
 	}
 
 	b.cfg.Logger.Debugf("Copying initrd file %s to iso root tree", initrd)
-	err = utils.CopyFile(b.cfg.Fs, initrd, filepath.Join(isoDir, constants.IsoInitrdPath))
+	err = utils.CopyFile(b.cfg.Fs, initrd, filepath.Join(isoDir, constants.ISOInitrdPath))
 	if err != nil {
 		return elementalError.NewFromError(err, elementalError.CopyFile)
 	}
 
 	b.cfg.Logger.Info("Creating squashfs...")
 	squashOptions := append(constants.GetDefaultSquashfsOptions(), b.cfg.SquashFsCompressionConfig...)
-	err = utils.CreateSquashFS(b.cfg.Runner, b.cfg.Logger, rootDir, filepath.Join(isoDir, constants.IsoRootFile), squashOptions)
+	err = utils.CreateSquashFS(b.cfg.Runner, b.cfg.Logger, rootDir, filepath.Join(isoDir, constants.ISORootFile), squashOptions)
 	return elementalError.NewFromError(err, elementalError.MKFSCall)
 }
 

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -139,7 +139,7 @@ var _ = Describe("Install action tests", func() {
 				}
 			}
 			// Need to create the IsoBaseTree, like if we are booting from iso
-			err = utils.MkdirAll(fs, constants.IsoBaseTree, constants.DirPerm)
+			err = utils.MkdirAll(fs, constants.ISOBaseTree, constants.DirPerm)
 			Expect(err).To(BeNil())
 
 			spec = conf.NewInstallSpec(config.Config)

--- a/pkg/action/reset_test.go
+++ b/pkg/action/reset_test.go
@@ -173,9 +173,9 @@ var _ = Describe("Reset action tests", func() {
 			Expect(runner.IncludesCmds([][]string{{"poweroff", "-f"}}))
 		})
 		It("Successfully resets from a squashfs recovery image", Label("channel"), func() {
-			err := utils.MkdirAll(config.Fs, constants.IsoBaseTree, constants.DirPerm)
+			err := utils.MkdirAll(config.Fs, constants.ISOBaseTree, constants.DirPerm)
 			Expect(err).ShouldNot(HaveOccurred())
-			spec.Active.Source = v1.NewDirSrc(constants.IsoBaseTree)
+			spec.Active.Source = v1.NewDirSrc(constants.ISOBaseTree)
 			Expect(reset.Run()).To(BeNil())
 		})
 		It("Successfully resets despite having errors on hooks", func() {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -179,7 +179,7 @@ func NewInstallSpec(cfg v1.Config) *v1.InstallSpec {
 	// Check if current host has EFI firmware
 	efiExists, _ := utils.Exists(cfg.Fs, constants.EfiDevice)
 	// Check the default ISO installation media is available
-	isoRootExists, _ := utils.Exists(cfg.Fs, constants.IsoBaseTree)
+	isoRootExists, _ := utils.Exists(cfg.Fs, constants.ISOBaseTree)
 	// Check the default ISO recovery installation media is available)
 	recoveryExists, _ := utils.Exists(cfg.Fs, recoveryImgFile)
 
@@ -195,7 +195,7 @@ func NewInstallSpec(cfg v1.Config) *v1.InstallSpec {
 	activeImg.FS = constants.LinuxImgFs
 	activeImg.MountPoint = constants.ActiveDir
 	if isoRootExists {
-		activeImg.Source = v1.NewDirSrc(constants.IsoBaseTree)
+		activeImg.Source = v1.NewDirSrc(constants.ISOBaseTree)
 	} else {
 		activeImg.Source = v1.NewEmptySrc()
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -119,9 +119,9 @@ var _ = Describe("Types", Label("types", "config"), func() {
 				Expect(err).ShouldNot(HaveOccurred())
 
 				// Set ISO base tree detection
-				err = utils.MkdirAll(fs, filepath.Dir(constants.IsoBaseTree), constants.DirPerm)
+				err = utils.MkdirAll(fs, filepath.Dir(constants.ISOBaseTree), constants.DirPerm)
 				Expect(err).ShouldNot(HaveOccurred())
-				_, err = fs.Create(constants.IsoBaseTree)
+				_, err = fs.Create(constants.ISOBaseTree)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				// Set recovery image detection detection
@@ -133,7 +133,7 @@ var _ = Describe("Types", Label("types", "config"), func() {
 
 				spec := config.NewInstallSpec(*c)
 				Expect(spec.Firmware).To(Equal(v1.EFI))
-				Expect(spec.Active.Source.Value()).To(Equal(constants.IsoBaseTree))
+				Expect(spec.Active.Source.Value()).To(Equal(constants.ISOBaseTree))
 				Expect(spec.Recovery.Source.Value()).To(Equal(recoveryImgFile))
 				Expect(spec.PartTable).To(Equal(v1.GPT))
 
@@ -147,14 +147,14 @@ var _ = Describe("Types", Label("types", "config"), func() {
 			})
 			It("sets installation defaults from install bios media without recovery", Label("install", "bios"), func() {
 				// Set ISO base tree detection
-				err = utils.MkdirAll(fs, filepath.Dir(constants.IsoBaseTree), constants.DirPerm)
+				err = utils.MkdirAll(fs, filepath.Dir(constants.ISOBaseTree), constants.DirPerm)
 				Expect(err).ShouldNot(HaveOccurred())
-				_, err = fs.Create(constants.IsoBaseTree)
+				_, err = fs.Create(constants.ISOBaseTree)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				spec := config.NewInstallSpec(*c)
 				Expect(spec.Firmware).To(Equal(v1.BIOS))
-				Expect(spec.Active.Source.Value()).To(Equal(constants.IsoBaseTree))
+				Expect(spec.Active.Source.Value()).To(Equal(constants.ISOBaseTree))
 				Expect(spec.Recovery.Source.Value()).To(Equal(spec.Active.File))
 				Expect(spec.PartTable).To(Equal(v1.GPT))
 
@@ -232,9 +232,9 @@ var _ = Describe("Types", Label("types", "config"), func() {
 					Expect(err).ShouldNot(HaveOccurred())
 
 					// Set squashfs detection
-					err = utils.MkdirAll(fs, filepath.Dir(constants.IsoBaseTree), constants.DirPerm)
+					err = utils.MkdirAll(fs, filepath.Dir(constants.ISOBaseTree), constants.DirPerm)
 					Expect(err).ShouldNot(HaveOccurred())
-					_, err = fs.Create(constants.IsoBaseTree)
+					_, err = fs.Create(constants.ISOBaseTree)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					spec, err := config.NewResetSpec(*c)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -80,7 +80,7 @@ const (
 	RunningStateDir = "/run/initramfs/cos-state" // TODO: converge this constant with StateDir/RecoveryDir in dracut module from cos-toolkit
 
 	// Live image mountpoints
-	IsoBaseTree = "/run/rootfsbase"
+	ISOBaseTree = "/run/rootfsbase"
 	LiveDir     = "/run/initramfs/live"
 
 	// Image file names
@@ -118,10 +118,10 @@ const (
 	SELinuxTargetedPolicyPath  = SELinuxTargetedPath + "/policy"
 
 	// Kernel and initrd paths are arbitrary and coupled to grub.cfg
-	IsoKernelPath    = "/boot/kernel"
-	IsoInitrdPath    = "/boot/initrd"
-	IsoRootFile      = "rootfs.squashfs"
-	IsoEFIImg        = "uefi.img"
+	ISOKernelPath    = "/boot/kernel"
+	ISOInitrdPath    = "/boot/initrd"
+	ISORootFile      = "rootfs.squashfs"
+	ISOEFIImg        = "uefi.img"
 	ISOLabel         = "COS_LIVE"
 	ISOCloudInitPath = LiveDir + "/iso-config"
 

--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -570,7 +570,7 @@ func (e *Elemental) GetIso(iso string) (tmpDir string, err error) {
 	if err != nil {
 		return "", err
 	}
-	err = e.config.Mounter.Mount(filepath.Join(isoMnt, cnst.IsoRootFile), rootfsMnt, "auto", []string{})
+	err = e.config.Mounter.Mount(filepath.Join(isoMnt, cnst.ISORootFile), rootfsMnt, "auto", []string{})
 	return tmpDir, err
 }
 

--- a/pkg/elemental/elemental_test.go
+++ b/pkg/elemental/elemental_test.go
@@ -287,9 +287,9 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 				File:       filepath.Join(cnst.StateDir, "cOS", cnst.ActiveImgFile),
 				FS:         cnst.LinuxImgFs,
 				MountPoint: cnst.ActiveDir,
-				Source:     v1.NewDirSrc(cnst.IsoBaseTree),
+				Source:     v1.NewDirSrc(cnst.ISOBaseTree),
 			}
-			_ = utils.MkdirAll(fs, cnst.IsoBaseTree, cnst.DirPerm)
+			_ = utils.MkdirAll(fs, cnst.ISOBaseTree, cnst.DirPerm)
 			el = elemental.NewElemental(config)
 		})
 

--- a/pkg/live/common.go
+++ b/pkg/live/common.go
@@ -38,7 +38,7 @@ const (
 	isoBootFile   = isoLoaderPath + "/eltorito.img"
 
 	//TODO use some identifer known to be unique
-	grubEfiCfg = "search --no-floppy --file --set=root " + constants.IsoKernelPath +
+	grubEfiCfg = "search --no-floppy --file --set=root " + constants.ISOKernelPath +
 		"\nset prefix=($root)" + grubPrefixDir +
 		"\nconfigfile $prefix/" + grubCfg
 
@@ -63,9 +63,9 @@ const (
 
 	menuentry "%s" --class os --unrestricted {
 		echo Loading kernel...
-		$linux ($root)` + constants.IsoKernelPath + ` cdroot root=live:CDLABEL=%s rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0 rd.cos.disable cos.setup=` + constants.ISOCloudInitPath + `
+		$linux ($root)` + constants.ISOKernelPath + ` cdroot root=live:CDLABEL=%s rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0 rd.cos.disable cos.setup=` + constants.ISOCloudInitPath + `
 		echo Loading initrd...
-		$initrd ($root)` + constants.IsoInitrdPath + `
+		$initrd ($root)` + constants.ISOInitrdPath + `
 	}                                                                               
 																					
 	if [ "${grub_platform}" = "efi" ]; then                                         


### PR DESCRIPTION
Some constants were using `Iso` prefix while others `ISO`. This PR just makes use of  `ISO` for all.

Signed-off-by: David Cassany <dcassany@suse.com>