### PR TITLE
Refactor cloud-init paths setup

### DIFF
--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -205,8 +205,7 @@ var _ = Describe("Config", Label("config"), func() {
 			// Flags overwrite the cosign-key set in config
 			Expect(cfg.CosignPubKey == "someOtherKey").To(BeTrue())
 			// Config.d overwrites the main config.yaml
-			Expect(len(cfg.CloudInitPaths) == 1).To(BeTrue())
-			Expect(cfg.CloudInitPaths[0] == "some/other/path").To(BeTrue())
+			Expect(cfg.CloudInitPaths).To(Equal(append(constants.GetCloudInitPaths(), "some/other/path")))
 			Expect(len(cfg.Repos)).To(Equal(1))
 			Expect(cfg.Repos[0].Name == "testrepo").To(BeTrue())
 		})

--- a/pkg/action/upgrade_test.go
+++ b/pkg/action/upgrade_test.go
@@ -69,6 +69,7 @@ var _ = Describe("Runtime Actions", func() {
 			conf.WithClient(client),
 			conf.WithCloudInitRunner(cloudInit),
 		)
+		Expect(config.Sanitize()).To(Succeed())
 	})
 
 	AfterEach(func() { cleanup() })

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -56,6 +56,8 @@ type Config struct {
 	Arch                      string       `yaml:"arch,omitempty" mapstructure:"arch"`
 	SquashFsCompressionConfig []string     `yaml:"squash-compression,omitempty" mapstructure:"squash-compression"`
 	SquashFsNoCompression     bool         `yaml:"squash-no-compression,omitempty" mapstructure:"squash-no-compression"`
+	CloudInitPaths            []string     `yaml:"cloud-init-paths,omitempty" mapstructure:"cloud-init-paths"`
+	Strict                    bool         `yaml:"strict,omitempty" mapstructure:"strict"`
 }
 
 // WriteInstallState writes the state.yaml file to the given state and recovery paths
@@ -113,11 +115,9 @@ func (c *Config) Sanitize() error {
 }
 
 type RunConfig struct {
-	Strict         bool     `yaml:"strict,omitempty" mapstructure:"strict"`
-	Reboot         bool     `yaml:"reboot,omitempty" mapstructure:"reboot"`
-	PowerOff       bool     `yaml:"poweroff,omitempty" mapstructure:"poweroff"`
-	CloudInitPaths []string `yaml:"cloud-init-paths,omitempty" mapstructure:"cloud-init-paths"`
-	EjectCD        bool     `yaml:"eject-cd,omitempty" mapstructure:"eject-cd"`
+	Reboot   bool `yaml:"reboot,omitempty" mapstructure:"reboot"`
+	PowerOff bool `yaml:"poweroff,omitempty" mapstructure:"poweroff"`
+	EjectCD  bool `yaml:"eject-cd,omitempty" mapstructure:"eject-cd"`
 
 	// 'inline' and 'squash' labels ensure config fields
 	// are embedded from a yaml and map PoV
@@ -127,6 +127,8 @@ type RunConfig struct {
 // Sanitize checks the consistency of the struct, returns error
 // if unsolvable inconsistencies are found
 func (r *RunConfig) Sanitize() error {
+	// Always include default cloud-init paths
+	r.CloudInitPaths = append(constants.GetCloudInitPaths(), r.CloudInitPaths...)
 	return r.Config.Sanitize()
 }
 

--- a/pkg/utils/runstage.go
+++ b/pkg/utils/runstage.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/mudler/yip/pkg/schema"
-	"github.com/rancher/elemental-cli/pkg/constants"
 	v1 "github.com/rancher/elemental-cli/pkg/types/v1"
 	"gopkg.in/yaml.v3"
 )
@@ -60,7 +59,6 @@ func checkYAMLError(cfg *v1.Config, allErrors, err error) error {
 func RunStage(cfg *v1.Config, stage string, strict bool, cloudInitPaths ...string) error {
 	var allErrors error
 
-	cloudInitPaths = append(constants.GetCloudInitPaths(), cloudInitPaths...)
 	cfg.Logger.Debugf("Cloud-init paths set to %v", cloudInitPaths)
 
 	stageBefore := fmt.Sprintf("%s.before", stage)
@@ -84,10 +82,12 @@ func RunStage(cfg *v1.Config, stage string, strict bool, cloudInitPaths ...strin
 	}
 
 	// Run all stages for each of the default cloud config paths + extra cloud config paths
-	for _, s := range []string{stageBefore, stage, stageAfter} {
-		err = cfg.CloudInitRunner.Run(s, filterNonExistingLocalURIs(cfg, cloudInitPaths...)...)
-		if err != nil {
-			allErrors = multierror.Append(allErrors, err)
+	if len(cloudInitPaths) > 0 {
+		for _, s := range []string{stageBefore, stage, stageAfter} {
+			err = cfg.CloudInitRunner.Run(s, filterNonExistingLocalURIs(cfg, cloudInitPaths...)...)
+			if err != nil {
+				allErrors = multierror.Append(allErrors, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
This commit includes the default cloud-init paths as part of the default configuration. In addition the cloud init paths are moved to the main configuration struct, as the could potentially be used in build configuration struct too.

In fact, the default cloud-init paths are only applied for the runtime configuration and not for the build time configuration (at build time the host is not necessarily an Elemental based OS).

Signed-off-by: David Cassany <dcassany@suse.com>