### PR TITLE
Remove squashfs specific path

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -130,14 +130,10 @@ func (i InstallAction) Run() (err error) {
 
 	// Set installation sources from a downloaded ISO
 	if i.spec.Iso != "" {
-		tmpDir, err := e.GetIso(i.spec.Iso)
+		isoCleaner, err := e.UpdateSourceFormISO(i.spec.Iso, &i.spec.Active)
+		cleanup.Push(isoCleaner)
 		if err != nil {
-			return elementalError.NewFromError(err, elementalError.DownloadFile)
-		}
-		cleanup.Push(func() error { return i.cfg.Fs.RemoveAll(tmpDir) })
-		err = e.UpdateSourcesFormDownloadedISO(tmpDir, &i.spec.Active, &i.spec.Recovery)
-		if err != nil {
-			return elementalError.NewFromError(err, elementalError.MoveFile)
+			return elementalError.NewFromError(err, elementalError.Unknown)
 		}
 	}
 

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -143,11 +143,7 @@ func (u *UpgradeAction) Run() (err error) {
 
 	if u.spec.RecoveryUpgrade {
 		upgradeImg = u.spec.Recovery
-		if upgradeImg.FS == constants.SquashFs {
-			finalImageFile = filepath.Join(u.spec.Partitions.Recovery.MountPoint, "cOS", constants.RecoverySquashFile)
-		} else {
-			finalImageFile = filepath.Join(u.spec.Partitions.Recovery.MountPoint, "cOS", constants.RecoveryImgFile)
-		}
+		finalImageFile = filepath.Join(u.spec.Partitions.Recovery.MountPoint, "cOS", constants.RecoveryImgFile)
 	} else {
 		upgradeImg = u.spec.Active
 		finalImageFile = filepath.Join(u.spec.Partitions.State.MountPoint, "cOS", constants.ActiveImgFile)

--- a/pkg/action/upgrade_test.go
+++ b/pkg/action/upgrade_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Runtime Actions", func() {
 		var l *v1mock.FakeLuet
 		activeImg := fmt.Sprintf("%s/cOS/%s", constants.RunningStateDir, constants.ActiveImgFile)
 		passiveImg := fmt.Sprintf("%s/cOS/%s", constants.RunningStateDir, constants.PassiveImgFile)
-		recoveryImgSquash := fmt.Sprintf("%s/cOS/%s", constants.LiveDir, constants.RecoverySquashFile)
+
 		recoveryImg := fmt.Sprintf("%s/cOS/%s", constants.LiveDir, constants.RecoveryImgFile)
 
 		BeforeEach(func() {
@@ -610,7 +610,7 @@ var _ = Describe("Runtime Actions", func() {
 					}
 					err = config.WriteInstallState(installState, statePath, statePath)
 					Expect(err).ShouldNot(HaveOccurred())
-					err = fs.WriteFile(recoveryImgSquash, []byte("recovery"), constants.FilePerm)
+					err = fs.WriteFile(recoveryImg, []byte("recovery"), constants.FilePerm)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					spec, err = conf.NewUpgradeSpec(config.Config)
@@ -628,10 +628,10 @@ var _ = Describe("Runtime Actions", func() {
 							// create the transition img for squash to fake it
 							_, _ = fs.Create(spec.Recovery.File)
 						}
-						if command == "mv" && args[0] == "-f" && args[1] == spec.Recovery.File && args[2] == recoveryImgSquash {
+						if command == "mv" && args[0] == "-f" && args[1] == spec.Recovery.File && args[2] == recoveryImg {
 							// fake "move"
 							f, _ := fs.ReadFile(spec.Recovery.File)
-							_ = fs.WriteFile(recoveryImgSquash, f, constants.FilePerm)
+							_ = fs.WriteFile(recoveryImg, f, constants.FilePerm)
 							_ = fs.RemoveAll(spec.Recovery.File)
 						}
 						return []byte{}, nil
@@ -640,12 +640,12 @@ var _ = Describe("Runtime Actions", func() {
 				})
 				It("Successfully upgrades recovery from docker image", Label("docker"), func() {
 					// This should be the old image
-					info, err := fs.Stat(recoveryImgSquash)
+					info, err := fs.Stat(recoveryImg)
 					Expect(err).ToNot(HaveOccurred())
 					// Image size should be empty
 					Expect(info.Size()).To(BeNumerically(">", 0))
 					Expect(info.IsDir()).To(BeFalse())
-					f, _ := fs.ReadFile(recoveryImgSquash)
+					f, _ := fs.ReadFile(recoveryImg)
 					Expect(f).To(ContainSubstring("recovery"))
 
 					spec.Recovery.Source = v1.NewDockerSrc("alpine")
@@ -656,12 +656,12 @@ var _ = Describe("Runtime Actions", func() {
 					Expect(l.UnpackCalled()).To(BeTrue())
 
 					// This should be the new image
-					info, err = fs.Stat(recoveryImgSquash)
+					info, err = fs.Stat(recoveryImg)
 					Expect(err).ToNot(HaveOccurred())
 					// Image size should be empty
 					Expect(info.Size()).To(BeNumerically("==", 0))
 					Expect(info.IsDir()).To(BeFalse())
-					f, _ = fs.ReadFile(recoveryImgSquash)
+					f, _ = fs.ReadFile(recoveryImg)
 					Expect(f).ToNot(ContainSubstring("recovery"))
 
 					// Transition squash should not exist
@@ -680,7 +680,7 @@ var _ = Describe("Runtime Actions", func() {
 					Expect(err).ToNot(HaveOccurred())
 
 					// This should be the new image
-					info, err := fs.Stat(recoveryImgSquash)
+					info, err := fs.Stat(recoveryImg)
 					Expect(err).ToNot(HaveOccurred())
 					// Image size should be empty
 					Expect(info.Size()).To(BeNumerically("==", 0))
@@ -693,12 +693,12 @@ var _ = Describe("Runtime Actions", func() {
 				})
 				It("Successfully upgrades recovery from channel upgrade", Label("channel"), func() {
 					// This should be the old image
-					info, err := fs.Stat(recoveryImgSquash)
+					info, err := fs.Stat(recoveryImg)
 					Expect(err).ToNot(HaveOccurred())
 					// Image size should be empty
 					Expect(info.Size()).To(BeNumerically(">", 0))
 					Expect(info.IsDir()).To(BeFalse())
-					f, _ := fs.ReadFile(recoveryImgSquash)
+					f, _ := fs.ReadFile(recoveryImg)
 					Expect(f).To(ContainSubstring("recovery"))
 
 					upgrade = action.NewUpgradeAction(config, spec)
@@ -708,12 +708,12 @@ var _ = Describe("Runtime Actions", func() {
 					Expect(l.UnpackChannelCalled()).To(BeTrue())
 
 					// This should be the new image
-					info, err = fs.Stat(recoveryImgSquash)
+					info, err = fs.Stat(recoveryImg)
 					Expect(err).ToNot(HaveOccurred())
 					// Image size should be empty
 					Expect(info.Size()).To(BeNumerically("==", 0))
 					Expect(info.IsDir()).To(BeFalse())
-					f, _ = fs.ReadFile(recoveryImgSquash)
+					f, _ = fs.ReadFile(recoveryImg)
 					Expect(f).ToNot(ContainSubstring("recovery"))
 
 					// Transition squash should not exist
@@ -778,7 +778,7 @@ var _ = Describe("Runtime Actions", func() {
 					Expect(info.Size()).To(BeNumerically("==", int64(spec.Recovery.Size*1024*1024)))
 
 					// Expect the rest of the images to not be there
-					for _, img := range []string{activeImg, passiveImg, recoveryImgSquash} {
+					for _, img := range []string{activeImg, passiveImg} {
 						_, err := fs.Stat(img)
 						Expect(err).To(HaveOccurred())
 					}
@@ -837,7 +837,7 @@ var _ = Describe("Runtime Actions", func() {
 					Expect(info.Size()).To(BeNumerically("==", int64(spec.Recovery.Size*1024*1024)))
 
 					// Expect the rest of the images to not be there
-					for _, img := range []string{activeImg, passiveImg, recoveryImgSquash} {
+					for _, img := range []string{activeImg, passiveImg} {
 						_, err := fs.Stat(img)
 						Expect(err).To(HaveOccurred())
 					}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -124,17 +124,10 @@ var _ = Describe("Types", Label("types", "config"), func() {
 				_, err = fs.Create(constants.ISOBaseTree)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				// Set recovery image detection detection
-				recoveryImgFile := filepath.Join(constants.LiveDir, constants.RecoverySquashFile)
-				err = utils.MkdirAll(fs, filepath.Dir(recoveryImgFile), constants.DirPerm)
-				Expect(err).ShouldNot(HaveOccurred())
-				_, err = fs.Create(recoveryImgFile)
-				Expect(err).ShouldNot(HaveOccurred())
-
 				spec := config.NewInstallSpec(*c)
 				Expect(spec.Firmware).To(Equal(v1.EFI))
 				Expect(spec.Active.Source.Value()).To(Equal(constants.ISOBaseTree))
-				Expect(spec.Recovery.Source.Value()).To(Equal(recoveryImgFile))
+				Expect(spec.Recovery.Source.Value()).To(Equal(spec.Active.File))
 				Expect(spec.PartTable).To(Equal(v1.GPT))
 
 				// No firmware partitions added yet

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -84,12 +84,10 @@ const (
 	LiveDir     = "/run/initramfs/live"
 
 	// Image file names
-	RecoverySquashFile   = "recovery.squashfs"
-	ActiveImgFile        = "active.img"
-	PassiveImgFile       = "passive.img"
-	RecoveryImgFile      = "recovery.img"
-	TransitionImgFile    = "transition.img"
-	TransitionSquashFile = "transition.squashfs"
+	ActiveImgFile     = "active.img"
+	PassiveImgFile    = "passive.img"
+	RecoveryImgFile   = "recovery.img"
+	TransitionImgFile = "transition.img"
 
 	// Yip stages evaluated on reset/upgrade/install action
 	AfterInstallChrootHook = "after-install-chroot"

--- a/pkg/elemental/elemental_test.go
+++ b/pkg/elemental/elemental_test.go
@@ -29,7 +29,6 @@ import (
 	. "github.com/onsi/gomega"
 	conf "github.com/rancher/elemental-cli/pkg/config"
 	"github.com/rancher/elemental-cli/pkg/constants"
-	cnst "github.com/rancher/elemental-cli/pkg/constants"
 	"github.com/rancher/elemental-cli/pkg/elemental"
 	v1 "github.com/rancher/elemental-cli/pkg/types/v1"
 	"github.com/rancher/elemental-cli/pkg/utils"
@@ -81,7 +80,7 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 		BeforeEach(func() {
 			parts = conf.NewInstallElementalParitions()
 
-			err := utils.MkdirAll(fs, "/some", cnst.DirPerm)
+			err := utils.MkdirAll(fs, "/some", constants.DirPerm)
 			Expect(err).ToNot(HaveOccurred())
 			_, err = fs.Create("/some/device")
 			Expect(err).ToNot(HaveOccurred())
@@ -145,7 +144,7 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 		BeforeEach(func() {
 			parts = conf.NewInstallElementalParitions()
 
-			err := utils.MkdirAll(fs, "/some", cnst.DirPerm)
+			err := utils.MkdirAll(fs, "/some", constants.DirPerm)
 			Expect(err).ToNot(HaveOccurred())
 			_, err = fs.Create("/some/device")
 			Expect(err).ToNot(HaveOccurred())
@@ -193,7 +192,7 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 		BeforeEach(func() {
 			parts = conf.NewInstallElementalParitions()
 
-			err := utils.MkdirAll(fs, "/some", cnst.DirPerm)
+			err := utils.MkdirAll(fs, "/some", constants.DirPerm)
 			Expect(err).ToNot(HaveOccurred())
 			_, err = fs.Create("/some/device")
 			Expect(err).ToNot(HaveOccurred())
@@ -282,14 +281,14 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 		var img *v1.Image
 		BeforeEach(func() {
 			img = &v1.Image{
-				Label:      cnst.ActiveLabel,
+				Label:      constants.ActiveLabel,
 				Size:       32,
-				File:       filepath.Join(cnst.StateDir, "cOS", cnst.ActiveImgFile),
-				FS:         cnst.LinuxImgFs,
-				MountPoint: cnst.ActiveDir,
-				Source:     v1.NewDirSrc(cnst.ISOBaseTree),
+				File:       filepath.Join(constants.StateDir, "cOS", constants.ActiveImgFile),
+				FS:         constants.LinuxImgFs,
+				MountPoint: constants.ActiveDir,
+				Source:     v1.NewDirSrc(constants.ISOBaseTree),
 			}
-			_ = utils.MkdirAll(fs, cnst.ISOBaseTree, cnst.DirPerm)
+			_ = utils.MkdirAll(fs, constants.ISOBaseTree, constants.DirPerm)
 			el = elemental.NewElemental(config)
 		})
 
@@ -341,7 +340,7 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 			install = conf.NewInstallSpec(*config)
 			install.Target = "/some/device"
 
-			err := utils.MkdirAll(fs, "/some", cnst.DirPerm)
+			err := utils.MkdirAll(fs, "/some", constants.DirPerm)
 			Expect(err).ToNot(HaveOccurred())
 			_, err = fs.Create("/some/device")
 			Expect(err).ToNot(HaveOccurred())
@@ -352,7 +351,7 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 			var efiPartCmds, partCmds, biosPartCmds [][]string
 			BeforeEach(func() {
 				partNum, printOut = 0, printOutput
-				err := utils.MkdirAll(fs, "/some", cnst.DirPerm)
+				err := utils.MkdirAll(fs, "/some", constants.DirPerm)
 				Expect(err).To(BeNil())
 				efiPartCmds = [][]string{
 					{
@@ -432,7 +431,7 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 		Describe("Run with failures", func() {
 			var runFunc func(cmd string, args ...string) ([]byte, error)
 			BeforeEach(func() {
-				err := utils.MkdirAll(fs, "/some", cnst.DirPerm)
+				err := utils.MkdirAll(fs, "/some", constants.DirPerm)
 				Expect(err).To(BeNil())
 				partNum, printOut = 0, printOutput
 				runFunc = func(cmd string, args ...string) ([]byte, error) {
@@ -801,7 +800,7 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 			disk := block.Disk{Name: "device", Partitions: []*block.Partition{
 				{
 					Name:            "device1",
-					FilesystemLabel: cnst.ActiveLabel,
+					FilesystemLabel: constants.ActiveLabel,
 				},
 			}}
 			ghwTest.AddDisk(disk)
@@ -810,17 +809,17 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 			runner.ReturnValue = []byte(
 				fmt.Sprintf(
 					`{"blockdevices": [{"label": "%s", "type": "loop", "path": "/some/device"}]}`,
-					cnst.ActiveLabel,
+					constants.ActiveLabel,
 				),
 			)
 			e := elemental.NewElemental(config)
-			Expect(e.CheckActiveDeployment([]string{cnst.ActiveLabel, cnst.PassiveLabel})).To(BeTrue())
+			Expect(e.CheckActiveDeployment([]string{constants.ActiveLabel, constants.PassiveLabel})).To(BeTrue())
 		})
 
 		It("Should not error out", func() {
 			runner.ReturnValue = []byte("")
 			e := elemental.NewElemental(config)
-			Expect(e.CheckActiveDeployment([]string{cnst.ActiveLabel, cnst.PassiveLabel})).To(BeFalse())
+			Expect(e.CheckActiveDeployment([]string{constants.ActiveLabel, constants.PassiveLabel})).To(BeFalse())
 		})
 	})
 	Describe("SelinuxRelabel", Label("SelinuxRelabel", "selinux"), func() {
@@ -916,82 +915,58 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 	})
 	Describe("GetIso", Label("GetIso", "iso"), func() {
 		var e *elemental.Elemental
+		var activeImg *v1.Image
 		BeforeEach(func() {
+			activeImg = &v1.Image{}
 			e = elemental.NewElemental(config)
 		})
-		It("Gets the iso and returns the temporary where it is stored", func() {
+		It("Gets the iso, mounts it and updates image source", func() {
 			tmpDir, err := utils.TempDir(fs, "", "elemental-test")
 			Expect(err).To(BeNil())
-			err = fs.WriteFile(fmt.Sprintf("%s/fake.iso", tmpDir), []byte("Hi"), cnst.FilePerm)
+			err = fs.WriteFile(fmt.Sprintf("%s/fake.iso", tmpDir), []byte("Hi"), constants.FilePerm)
 			Expect(err).To(BeNil())
 			iso := fmt.Sprintf("%s/fake.iso", tmpDir)
-			isoDir, err := e.GetIso(iso)
+
+			// Create the internal ISO file structure
+			rootfsImg := filepath.Join(os.TempDir(), "/elemental/iso", constants.ISORootFile)
+			Expect(utils.MkdirAll(fs, filepath.Dir(rootfsImg), constants.DirPerm)).To(Succeed())
+			Expect(fs.WriteFile(rootfsImg, []byte{}, constants.FilePerm)).To(Succeed())
+
+			isoClean, err := e.UpdateSourceFormISO(iso, activeImg)
 			Expect(err).To(BeNil())
-			// Confirm that the iso is stored in isoDir
-			utils.Exists(fs, filepath.Join(isoDir, "cOs.iso"))
+			Expect(activeImg.Source.IsFile()).To(BeTrue())
+			Expect(isoClean()).To(Succeed())
 		})
 		It("Fails if it cant find the iso", func() {
 			iso := "whatever"
 			e := elemental.NewElemental(config)
-			_, err := e.GetIso(iso)
+			isoClean, err := e.UpdateSourceFormISO(iso, activeImg)
 			Expect(err).ToNot(BeNil())
+			Expect(isoClean()).To(Succeed())
+		})
+		It("Fails creating the mountpoint", func() {
+			tmpDir, err := utils.TempDir(fs, "", "elemental-test")
+			Expect(err).To(BeNil())
+			err = fs.WriteFile(fmt.Sprintf("%s/fake.iso", tmpDir), []byte("Hi"), constants.FilePerm)
+			Expect(err).To(BeNil())
+			iso := fmt.Sprintf("%s/fake.iso", tmpDir)
+			config.Fs = vfs.NewReadOnlyFS(fs)
+
+			isoClean, err := e.UpdateSourceFormISO(iso, activeImg)
+			Expect(err).ToNot(BeNil())
+			Expect(isoClean()).To(Succeed())
 		})
 		It("Fails if it cannot mount the iso", func() {
 			mounter.ErrorOnMount = true
 			tmpDir, err := utils.TempDir(fs, "", "elemental-test")
 			Expect(err).To(BeNil())
-			err = fs.WriteFile(fmt.Sprintf("%s/fake.iso", tmpDir), []byte("Hi"), cnst.FilePerm)
+			err = fs.WriteFile(fmt.Sprintf("%s/fake.iso", tmpDir), []byte("Hi"), constants.FilePerm)
 			Expect(err).To(BeNil())
 			iso := fmt.Sprintf("%s/fake.iso", tmpDir)
-			_, err = e.GetIso(iso)
+			isoClean, err := e.UpdateSourceFormISO(iso, activeImg)
 			Expect(err).ToNot(BeNil())
 			Expect(err.Error()).To(ContainSubstring("mount error"))
-		})
-	})
-	Describe("UpdateSourcesFormDownloadedISO", Label("iso"), func() {
-		var e *elemental.Elemental
-		var activeImg, recoveryImg *v1.Image
-		BeforeEach(func() {
-			activeImg, recoveryImg = nil, nil
-			e = elemental.NewElemental(config)
-		})
-		It("updates active image", func() {
-			activeImg = &v1.Image{}
-			err := e.UpdateSourcesFormDownloadedISO("/some/dir", activeImg, recoveryImg)
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(activeImg.Source.IsDir()).To(BeTrue())
-			Expect(activeImg.Source.Value()).To(Equal("/some/dir/rootfs"))
-			Expect(recoveryImg).To(BeNil())
-		})
-		It("updates active and recovery image", func() {
-			activeImg = &v1.Image{File: "activeFile"}
-			recoveryImg = &v1.Image{}
-			err := e.UpdateSourcesFormDownloadedISO("/some/dir", activeImg, recoveryImg)
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(recoveryImg.Source.IsFile()).To(BeTrue())
-			Expect(recoveryImg.Source.Value()).To(Equal("activeFile"))
-			Expect(recoveryImg.Label).To(Equal(cnst.SystemLabel))
-			Expect(activeImg.Source.IsDir()).To(BeTrue())
-			Expect(activeImg.Source.Value()).To(Equal("/some/dir/rootfs"))
-		})
-		It("updates recovery only image", func() {
-			recoveryImg = &v1.Image{}
-			isoMnt := "/some/dir/iso"
-			err := utils.MkdirAll(fs, isoMnt, cnst.DirPerm)
-			Expect(err).ShouldNot(HaveOccurred())
-			recoverySquash := filepath.Join(isoMnt, cnst.RecoverySquashFile)
-			_, err = fs.Create(recoverySquash)
-			Expect(err).ShouldNot(HaveOccurred())
-			err = e.UpdateSourcesFormDownloadedISO("/some/dir", activeImg, recoveryImg)
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(recoveryImg.Source.IsFile()).To(BeTrue())
-			Expect(recoveryImg.Source.Value()).To(Equal(recoverySquash))
-			Expect(activeImg).To(BeNil())
-		})
-		It("fails to update recovery from active file", func() {
-			recoveryImg = &v1.Image{}
-			err := e.UpdateSourcesFormDownloadedISO("/some/dir", activeImg, recoveryImg)
-			Expect(err).Should(HaveOccurred())
+			Expect(isoClean()).To(Succeed())
 		})
 	})
 	Describe("CloudConfig", Label("CloudConfig", "cloud-config"), func() {
@@ -1002,13 +977,13 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 		It("Copies the cloud config file", func() {
 			testString := "In a galaxy far far away..."
 			cloudInit := []string{"/config.yaml"}
-			err := fs.WriteFile(cloudInit[0], []byte(testString), cnst.FilePerm)
+			err := fs.WriteFile(cloudInit[0], []byte(testString), constants.FilePerm)
 			Expect(err).To(BeNil())
 			Expect(err).To(BeNil())
 
 			err = e.CopyCloudConfig(cloudInit)
 			Expect(err).To(BeNil())
-			copiedFile, err := fs.ReadFile(fmt.Sprintf("%s/90_custom.yaml", cnst.OEMDir))
+			copiedFile, err := fs.ReadFile(fmt.Sprintf("%s/90_custom.yaml", constants.OEMDir))
 			Expect(err).To(BeNil())
 			Expect(copiedFile).To(ContainSubstring(testString))
 		})

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -160,12 +160,15 @@ func (i *InstallSpec) Sanitize() error {
 	if i.Partitions.State == nil || i.Partitions.State.MountPoint == "" {
 		return fmt.Errorf("undefined state partition")
 	}
-	// Set the image file name depending on the filesystem
-	recoveryMnt := constants.RecoveryDir
-	if i.Partitions.Recovery != nil && i.Partitions.Recovery.MountPoint != "" {
-		recoveryMnt = i.Partitions.Recovery.MountPoint
+
+	// Unset labels for squashfs filesystem
+	if i.Active.FS == constants.SquashFs {
+		i.Active.Label = ""
+		i.Passive.Label = ""
 	}
-	i.Recovery.File = filepath.Join(recoveryMnt, "cOS", constants.RecoveryImgFile)
+	if i.Recovery.FS == constants.SquashFs {
+		i.Recovery.Label = ""
+	}
 
 	// Check for extra partitions having set its size to 0
 	extraPartsSizeCheck := 0
@@ -210,6 +213,11 @@ func (r *ResetSpec) Sanitize() error {
 	if r.Partitions.State == nil || r.Partitions.State.MountPoint == "" {
 		return fmt.Errorf("undefined state partition")
 	}
+	// Unset labels for squashfs filesystem
+	if r.Active.FS == constants.SquashFs {
+		r.Active.Label = ""
+		r.Passive.Label = ""
+	}
 	return nil
 }
 
@@ -240,6 +248,14 @@ func (u *UpgradeSpec) Sanitize() error {
 		if u.Active.Source.IsEmpty() {
 			return fmt.Errorf("undefined upgrade source")
 		}
+	}
+	// Unset labels for squashfs filesystem
+	if u.Active.FS == constants.SquashFs {
+		u.Active.Label = ""
+		u.Passive.Label = ""
+	}
+	if u.Recovery.FS == constants.SquashFs {
+		u.Recovery.Label = ""
 	}
 	return nil
 }

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -165,11 +165,7 @@ func (i *InstallSpec) Sanitize() error {
 	if i.Partitions.Recovery != nil && i.Partitions.Recovery.MountPoint != "" {
 		recoveryMnt = i.Partitions.Recovery.MountPoint
 	}
-	if i.Recovery.FS == constants.SquashFs {
-		i.Recovery.File = filepath.Join(recoveryMnt, "cOS", constants.RecoverySquashFile)
-	} else {
-		i.Recovery.File = filepath.Join(recoveryMnt, "cOS", constants.RecoveryImgFile)
-	}
+	i.Recovery.File = filepath.Join(recoveryMnt, "cOS", constants.RecoveryImgFile)
 
 	// Check for extra partitions having set its size to 0
 	extraPartsSizeCheck := 0

--- a/pkg/types/v1/config_test.go
+++ b/pkg/types/v1/config_test.go
@@ -389,11 +389,14 @@ var _ = Describe("Types", Label("types", "config"), func() {
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(spec.Partitions.EFI).NotTo(BeNil())
 
-				// Sets recovery image file to img file
-				spec.Recovery.FS = constants.LinuxImgFs
+				// Sets image labels to empty string on squashfs
+				spec.Active.FS = constants.SquashFs
+				spec.Recovery.FS = constants.SquashFs
 				err = spec.Sanitize()
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(spec.Recovery.File).To(ContainSubstring(constants.RecoveryImgFile))
+				Expect(spec.Recovery.Label).To(BeEmpty())
+				Expect(spec.Active.Label).To(BeEmpty())
+				Expect(spec.Passive.Label).To(BeEmpty())
 
 				// Fails without state partition
 				spec.Partitions.State = nil
@@ -448,6 +451,13 @@ var _ = Describe("Types", Label("types", "config"), func() {
 			err := spec.Sanitize()
 			Expect(err).ShouldNot(HaveOccurred())
 
+			// Sets image labels to empty string on squashfs
+			spec.Active.FS = constants.SquashFs
+			err = spec.Sanitize()
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(spec.Active.Label).To(BeEmpty())
+			Expect(spec.Passive.Label).To(BeEmpty())
+
 			//Fails on missing state partition
 			spec.Partitions.State = nil
 			err = spec.Sanitize()
@@ -479,6 +489,15 @@ var _ = Describe("Types", Label("types", "config"), func() {
 			}
 			err := spec.Sanitize()
 			Expect(err).ShouldNot(HaveOccurred())
+
+			// Sets image labels to empty string on squashfs
+			spec.Active.FS = constants.SquashFs
+			spec.Recovery.FS = constants.SquashFs
+			err = spec.Sanitize()
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(spec.Recovery.Label).To(BeEmpty())
+			Expect(spec.Active.Label).To(BeEmpty())
+			Expect(spec.Passive.Label).To(BeEmpty())
 
 			//Fails on empty source for active upgrade
 			spec.Active.Source = v1.NewEmptySrc()

--- a/pkg/types/v1/config_test.go
+++ b/pkg/types/v1/config_test.go
@@ -389,12 +389,6 @@ var _ = Describe("Types", Label("types", "config"), func() {
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(spec.Partitions.EFI).NotTo(BeNil())
 
-				// Sets recovery image file to squashfs file
-				spec.Recovery.FS = constants.SquashFs
-				err = spec.Sanitize()
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(spec.Recovery.File).To(ContainSubstring(constants.RecoverySquashFile))
-
 				// Sets recovery image file to img file
 				spec.Recovery.FS = constants.LinuxImgFs
 				err = spec.Sanitize()


### PR DESCRIPTION
This commit removes the existence and checks for recovery.squashfs. It always uses recovery.img as the recovery image file regardless of the underlying filesystem.

In addition it also removes the checks for a separate recovery image in ISOs. We are no longer building isos with separate recovery images. The same feature is also possible by setting recovery to the appropriate source (local or remote) in config.yaml.

Part of rancher/elemental#488