### PR TITLE
Add init command

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -233,6 +233,24 @@ func ReadInstallSpec(r *v1.RunConfig, flags *pflag.FlagSet) (*v1.InstallSpec, er
 	return install, err
 }
 
+func ReadInitSpec(r *v1.RunConfig, flags *pflag.FlagSet) (*v1.InitSpec, error) {
+	init := config.NewInitSpec(r.Config)
+	vp := viper.Sub("init")
+	if vp == nil {
+		vp = viper.New()
+	}
+	// Bind install cmd flags
+	bindGivenFlags(vp, flags)
+	// Bind install env vars
+	viperReadEnv(vp, "INIT", constants.GetInitKeyEnvMap())
+
+	err := vp.Unmarshal(init, setDecoder, decodeHook)
+	if err != nil {
+		r.Logger.Warnf("error unmarshalling InitSpec: %s", err)
+	}
+	return init, err
+}
+
 func ReadResetSpec(r *v1.RunConfig, flags *pflag.FlagSet) (*v1.ResetSpec, error) {
 	reset, err := config.NewResetSpec(r.Config)
 	if err != nil {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,56 @@
+/*
+Copyright © 2022 - 2023 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"k8s.io/mount-utils"
+
+	"github.com/rancher/elemental-cli/cmd/config"
+	"github.com/rancher/elemental-cli/pkg/action"
+	elementalError "github.com/rancher/elemental-cli/pkg/error"
+)
+
+func InitCmd(root *cobra.Command) *cobra.Command {
+	c := &cobra.Command{
+		Use:   "init",
+		Short: "Initialize container image for booting",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.ReadConfigRun(viper.GetString("config-dir"), cmd.Flags(), &mount.FakeMounter{})
+			if err != nil {
+				cfg.Logger.Errorf("Error reading config: %s\n", err)
+				return elementalError.NewFromError(err, elementalError.ReadingRunConfig)
+			}
+
+			spec, err := config.ReadInitSpec(cfg, cmd.Flags())
+			if err != nil {
+				cfg.Logger.Errorf("Error reading spec: %s\n", err)
+				return elementalError.NewFromError(err, elementalError.ReadingSpecConfig)
+			}
+
+			cfg.Logger.Infof("Initializing system...")
+			return action.RunInit(cfg, spec)
+		},
+	}
+	root.AddCommand(c)
+	c.Flags().Bool("mkinitrd", true, "Run mkinitrd")
+	c.Flags().BoolP("force", "f", false, "Force run")
+	return c
+}
+
+var _ = InitCmd(rootCmd)

--- a/pkg/action/init-files/02-elemental-setup-initramfs.conf
+++ b/pkg/action/init-files/02-elemental-setup-initramfs.conf
@@ -1,0 +1,4 @@
+install_items+=" /usr/lib/systemd/system/elemental-setup-initramfs.service /etc/systemd/system/initrd.target.requires/elemental-setup-initramfs.service "
+install_items+=" /usr/lib/systemd/system/elemental-setup-rootfs.service /etc/systemd/system/initrd-fs.target.requires/elemental-setup-rootfs.service "
+install_items+=" /etc/hosts "
+add_dracutmodules+=" network "

--- a/pkg/action/init-files/50-elemental-initrd.conf
+++ b/pkg/action/init-files/50-elemental-initrd.conf
@@ -1,0 +1,5 @@
+hostonly_cmdline="no"
+hostonly="no"
+compress="xz"
+omit_dracutmodules+=" multipath "
+add_dracutmodules+=" livenet dmsquash-live "

--- a/pkg/action/init-files/bootargs.cfg
+++ b/pkg/action/init-files/bootargs.cfg
@@ -1,0 +1,8 @@
+# TODO we could sanity check $partlabel is set here so we can error out before even attempting to boot
+set kernel=/boot/vmlinuz
+if [ "${label}" == "${system_label}" ]; then
+  set kernelcmd="console=tty1 console=ttyS0 root=LABEL=$recovery_label cos-img/filename=$img security=selinux selinux=0 rd.neednet=1 rd.cos.oemlabel=$oem_label"
+else
+  set kernelcmd="console=tty1 console=ttyS0 root=LABEL=$state_label cos-img/filename=$img panic=5 security=selinux selinux=1 rd.neednet=1 rd.cos.oemlabel=$oem_label fsck.mode=force fsck.repair=yes"
+fi
+set initramfs=/boot/initrd

--- a/pkg/action/init-files/elemental-setup-boot.service
+++ b/pkg/action/init-files/elemental-setup-boot.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Elemental system configuration
+Before=getty.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/elemental run-stage boot
+
+[Install]
+WantedBy=multi-user.target

--- a/pkg/action/init-files/elemental-setup-initramfs.service
+++ b/pkg/action/init-files/elemental-setup-initramfs.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Elemental system initramfs setup before switch root
+DefaultDependencies=no
+After=initrd-fs.target
+Requires=initrd-fs.target
+Before=initrd.target
+
+[Service]
+RootDirectory=/sysroot
+BindPaths=/proc /sys /dev /run /tmp
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/elemental run-stage initramfs
+
+[Install]
+RequiredBy=initrd.target

--- a/pkg/action/init-files/elemental-setup-network.service
+++ b/pkg/action/init-files/elemental-setup-network.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Elemental setup after network
+After=network-online.target
+
+[Service]
+Nice=19
+IOSchedulingClass=2
+IOSchedulingPriority=7
+Type=oneshot
+ExecStart=/usr/bin/elemental run-stage network
+TimeoutStopSec=180
+KillMode=process
+KillSignal=SIGINT
+
+[Install]
+WantedBy=multi-user.target

--- a/pkg/action/init-files/elemental-setup-reconcile.service
+++ b/pkg/action/init-files/elemental-setup-reconcile.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Elemental setup reconciler
+
+[Service]
+Nice=19
+IOSchedulingClass=2
+IOSchedulingPriority=7
+Type=oneshot
+ExecStart=/bin/bash -c "systemd-inhibit /usr/bin/elemental run-stage reconcile"
+TimeoutStopSec=180
+KillMode=process
+KillSignal=SIGINT
+
+[Install]
+WantedBy=multi-user.target

--- a/pkg/action/init-files/elemental-setup-reconcile.timer
+++ b/pkg/action/init-files/elemental-setup-reconcile.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Elemental setup reconciler
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=60min
+Unit=elemental-setup-reconcile.service
+
+[Install]
+WantedBy=multi-user.target

--- a/pkg/action/init-files/elemental-setup-rootfs.service
+++ b/pkg/action/init-files/elemental-setup-rootfs.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Elemental system early rootfs setup
+DefaultDependencies=no
+After=initrd-root-fs.target
+Requires=initrd-root-fs.target
+Conflicts=initrd-switch-root.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStartPre=/usr/bin/ln -sf -t / /sysroot/system
+ExecStart=/usr/bin/elemental run-stage rootfs
+
+[Install]
+RequiredBy=initrd-fs.target

--- a/pkg/action/init-files/grub.cfg
+++ b/pkg/action/init-files/grub.cfg
@@ -1,0 +1,93 @@
+set timeout=10
+
+# Load custom env file
+set env_file="/grubenv"
+search --no-floppy --file --set=env_blk "${env_file}"
+
+# Load custom env file
+set oem_env_file="/grub_oem_env"
+search --no-floppy --file --set=oem_blk "${oem_env_file}"
+
+# Load custom config file
+set custom_menu="/grubmenu"
+search --no-floppy --file --set=menu_blk "${custom_menu}"
+
+# Load custom config file
+set custom="/grubcustom"
+search --no-floppy --file --set=custom_blk "${custom}"
+
+if [ "${oem_blk}" ] ; then
+  load_env -f "(${oem_blk})${oem_env_file}"
+fi
+
+if [ "${env_blk}" ] ; then
+  load_env -f "(${env_blk})${env_file}"
+fi
+
+# Save default
+if [ "${next_entry}" ]; then
+  set default="${next_entry}"
+  set selected_entry="${next_entry}"
+  set next_entry=
+  save_env -f "(${env_blk})${env_file}" next_entry
+else
+  set default="${saved_entry}"
+fi
+
+## Display a default menu entry if set
+if [ "${default_menu_entry}" ]; then
+  set display_name="${default_menu_entry}"
+else
+  set display_name="cOS"
+fi
+
+## Set a default fallback if set
+if [ "${default_fallback}" ]; then
+  set fallback="${default_fallback}"
+else
+  set fallback="0 1 2"
+fi
+
+insmod all_video
+insmod gfxterm
+insmod loopback
+insmod squash4
+
+menuentry "${display_name}" --id cos {
+  # label is kept around for backward compatibility
+  set label=${active_label}
+  set img=/cOS/active.img
+  loopback loop0 /$img
+  source (loop0)/etc/cos/bootargs.cfg
+  linux (loop0)$kernel $kernelcmd ${extra_cmdline} ${extra_active_cmdline}
+  initrd (loop0)$initramfs
+}
+
+menuentry "${display_name} (fallback)" --id fallback {
+  # label is kept around for backward compatibility
+  set label=${passive_label}
+  set img=/cOS/passive.img
+  loopback loop0 /$img
+  source (loop0)/etc/cos/bootargs.cfg
+  linux (loop0)$kernel $kernelcmd ${extra_cmdline} ${extra_passive_cmdline}
+  initrd (loop0)$initramfs
+}
+
+menuentry "${display_name} recovery" --id recovery {
+  # label is kept around for backward compatibility
+  set label=${system_label}
+  set img=/cOS/recovery.img
+  search --no-floppy --label --set=root $recovery_label
+  loopback loop0 /$img
+  source (loop0)/etc/cos/bootargs.cfg
+  linux (loop0)$kernel $kernelcmd ${extra_cmdline} ${extra_recovery_cmdline}
+  initrd (loop0)$initramfs
+}
+
+if [ "${menu_blk}" ]; then
+  source "(${menu_blk})${custom_menu}"
+fi
+
+if [ "${custom_blk}" ]; then
+  source "(${custom_blk})${custom}"
+fi

--- a/pkg/action/init.go
+++ b/pkg/action/init.go
@@ -1,0 +1,150 @@
+/*
+Copyright © 2022 - 2023 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package action
+
+import (
+	"embed"
+	"io/fs"
+	"path/filepath"
+	"strings"
+
+	"github.com/rancher/elemental-cli/pkg/constants"
+	elementalError "github.com/rancher/elemental-cli/pkg/error"
+	"github.com/rancher/elemental-cli/pkg/systemd"
+	v1 "github.com/rancher/elemental-cli/pkg/types/v1"
+	"github.com/rancher/elemental-cli/pkg/utils"
+)
+
+//go:embed init-files
+var files embed.FS
+
+const (
+	embeddedRoot = "init-files"
+)
+
+func RunInit(cfg *v1.RunConfig, spec *v1.InitSpec) error {
+	if exists, _ := utils.Exists(cfg.Fs, "/.dockerenv"); !exists && !spec.Force {
+		return elementalError.New("running outside of container, pass --force to run anyway", elementalError.StatFile)
+	}
+
+	entries, err := files.ReadDir(embeddedRoot)
+	if err != nil {
+		cfg.Config.Logger.Infof("Error reading embedded files: %s", err.Error())
+		return err
+	}
+
+	units := []*systemd.Unit{}
+	dracutConf := []fs.DirEntry{}
+
+	cfg.Config.Logger.Infof("Reading %v files.", len(entries))
+
+	for _, entry := range entries {
+		if IsSystemdUnit(entry) {
+			cfg.Config.Logger.Debugf("Loading systemd unit %v", entry.Name())
+
+			content, err := files.ReadFile(filepath.Join(embeddedRoot, entry.Name()))
+			if err != nil {
+				cfg.Config.Logger.Errorf("Error reading unit '%s': %v", entry.Name(), err.Error())
+				return err
+			}
+
+			units = append(units, systemd.NewUnit(entry.Name(), content))
+		} else if IsDracutConfig(entry) {
+			dracutConf = append(dracutConf, entry)
+		}
+	}
+
+	if err := utils.MkdirAll(cfg.Config.Fs, "/usr/lib/systemd/system", constants.DirPerm); err != nil {
+		cfg.Config.Logger.Errorf("Failed to create systemd dir: %v", err.Error)
+		return err
+	}
+
+	cfg.Config.Logger.Infof("Installing %v systemd units.", len(units))
+
+	for _, unit := range units {
+		cfg.Config.Logger.Debugf("Installing unit '%s'", unit.Name)
+
+		if err = systemd.Install(cfg.Config.Fs, unit); err != nil {
+			cfg.Config.Logger.Errorf("Error installing unit '%s': %v", unit.Name, err.Error())
+			return err
+		}
+
+		if err = systemd.Enable(cfg.Config.Runner, unit); err != nil {
+			cfg.Config.Logger.Errorf("Error enabling unit '%s': %v", unit.Name, err.Error())
+			return err
+		}
+	}
+
+	if err := utils.MkdirAll(cfg.Config.Fs, "/etc/dracut.conf.d", constants.DirPerm); err != nil {
+		cfg.Config.Logger.Errorf("Failed to create dracut conf dir: %v", err.Error)
+		return err
+	}
+
+	cfg.Config.Logger.Infof("Installing %v dracut config files.", len(dracutConf))
+
+	for _, conf := range dracutConf {
+		if err := ExtractFile(files, filepath.Join(embeddedRoot, conf.Name()), cfg.Config.Fs, filepath.Join("/etc/dracut.conf.d", conf.Name())); err != nil {
+			cfg.Config.Logger.Infof("Failed to copy dracut config %s: %s", conf.Name(), err.Error())
+			return err
+		}
+	}
+
+	if err := utils.MkdirAll(cfg.Config.Fs, "/etc/cos", constants.DirPerm); err != nil {
+		cfg.Config.Logger.Errorf("Failed to create cos conf dir: %v", err.Error)
+		return err
+	}
+
+	cfg.Config.Logger.Infof("Installing GRUB2 config files.", len(units))
+
+	if err := ExtractFile(files, filepath.Join(embeddedRoot, "grub.cfg"), cfg.Config.Fs, "/etc/cos/grub.cfg"); err != nil {
+		cfg.Config.Logger.Infof("Failed to copy grub.cfg: %s", err.Error())
+		return err
+	}
+
+	if err := ExtractFile(files, filepath.Join(embeddedRoot, "bootargs.cfg"), cfg.Config.Fs, "/etc/cos/bootargs.cfg"); err != nil {
+		cfg.Config.Logger.Infof("Failed to copy bootargs.cfg: %s", err.Error())
+		return err
+	}
+
+	grub := utils.NewGrub(&cfg.Config)
+	firstboot := map[string]string{"next_entry": "recovery"}
+	if err := grub.SetPersistentVariables("/etc/cos/grubenv_firstboot", firstboot); err != nil {
+		cfg.Config.Logger.Infof("Failed to set GRUB nextboot: %s", err.Error())
+		return err
+	}
+
+	cfg.Config.Logger.Infof("Make initrd.")
+	_, err = cfg.Runner.Run("mkinitrd")
+	return err
+}
+
+func ExtractFile(srcFs embed.FS, srcPath string, dstFs v1.FS, dstPath string) error {
+	content, err := srcFs.ReadFile(srcPath)
+	if err != nil {
+		return err
+	}
+
+	return dstFs.WriteFile(dstPath, content, 0644)
+}
+
+func IsSystemdUnit(entry fs.DirEntry) bool {
+	return !entry.IsDir() && strings.HasSuffix(entry.Name(), ".service") || strings.HasSuffix(entry.Name(), ".timer")
+}
+
+func IsDracutConfig(entry fs.DirEntry) bool {
+	return !entry.IsDir() && strings.HasSuffix(entry.Name(), ".conf")
+}

--- a/pkg/action/init_test.go
+++ b/pkg/action/init_test.go
@@ -1,0 +1,106 @@
+/*
+   Copyright © 2022 - 2023 SUSE LLC
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package action_test
+
+import (
+	"bytes"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	"github.com/twpayne/go-vfs"
+	"github.com/twpayne/go-vfs/vfst"
+
+	"github.com/rancher/elemental-cli/pkg/action"
+	"github.com/rancher/elemental-cli/pkg/config"
+	v1 "github.com/rancher/elemental-cli/pkg/types/v1"
+	"github.com/rancher/elemental-cli/pkg/utils"
+	v1mock "github.com/rancher/elemental-cli/tests/mocks"
+)
+
+var _ = Describe("Init Action", func() {
+	var cfg *v1.RunConfig
+	var runner *v1mock.FakeRunner
+	var fs vfs.FS
+	var logger v1.Logger
+	var cleanup func()
+	var memLog *bytes.Buffer
+
+	BeforeEach(func() {
+		runner = v1mock.NewFakeRunner()
+		memLog = &bytes.Buffer{}
+		logger = v1.NewBufferLogger(memLog)
+		logger.SetLevel(logrus.DebugLevel)
+		fs, cleanup, _ = vfst.NewTestFS(map[string]interface{}{})
+		cfg = config.NewRunConfig(
+			config.WithFs(fs),
+			config.WithRunner(runner),
+			config.WithLogger(logger),
+		)
+	})
+	AfterEach(func() {
+		cleanup()
+	})
+	Describe("Init System", Label("init"), func() {
+		var spec *v1.InitSpec
+		var enabledUnits []string
+		var mkinitrdCalled bool
+		BeforeEach(func() {
+			spec = config.NewInitSpec(cfg.Config)
+			enabledUnits = []string{}
+			mkinitrdCalled = false
+
+			runner.SideEffect = func(cmd string, args ...string) ([]byte, error) {
+				switch cmd {
+				case "systemctl":
+					if args[0] == "enable" {
+						enabledUnits = append(enabledUnits, args[1])
+					}
+					return []byte{}, nil
+				case "mkinitrd":
+					mkinitrdCalled = true
+					return []byte{}, nil
+				default:
+					return []byte{}, nil
+				}
+			}
+		})
+		It("Shows an error if /.dockerenv does not exist", func() {
+			err := action.RunInit(cfg, spec)
+			Expect(err).ToNot(BeNil())
+			Expect(len(enabledUnits)).To(Equal(0))
+		})
+		It("Successfully runs init and install files", func() {
+			err := fs.WriteFile("/.dockerenv", []byte{}, 0644)
+			Expect(err).To(BeNil())
+
+			err = action.RunInit(cfg, spec)
+			Expect(err).To(BeNil())
+
+			Expect(len(enabledUnits)).To(Equal(6))
+
+			for _, unit := range enabledUnits {
+				exists, err := utils.Exists(fs, fmt.Sprintf("/usr/lib/systemd/system/%v", unit))
+				Expect(err).To(BeNil())
+				Expect(exists).To(BeTrue())
+			}
+
+			Expect(mkinitrdCalled).To(BeTrue())
+		})
+	})
+})

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -219,6 +219,14 @@ func NewInstallSpec(cfg v1.Config) *v1.InstallSpec {
 	}
 }
 
+// NewInitSpec returns an InitSpec struct all based on defaults
+func NewInitSpec(cfg v1.Config) *v1.InitSpec {
+	return &v1.InitSpec{
+		RunMkinitrd: true,
+		Force:       false,
+	}
+}
+
 func NewInstallElementalParitions() v1.ElementalPartitions {
 	partitions := v1.ElementalPartitions{}
 	partitions.OEM = &v1.Partition{

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -180,6 +180,14 @@ func GetRunKeyEnvMap() map[string]string {
 	}
 }
 
+// GetInitKeyEnvMap returns environment variable bindings to InitSpec data
+func GetInitKeyEnvMap() map[string]string {
+	return map[string]string{
+		"mkinitrd": "MKINITRD",
+		"force":    "FORCE",
+	}
+}
+
 // GetInstallKeyEnvMap returns environment variable bindings to InstallSpec data
 func GetInstallKeyEnvMap() map[string]string {
 	return map[string]string{

--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -250,7 +250,6 @@ func (e Elemental) UnmountImage(img *v1.Image) error {
 
 // CreateFileSystemImage creates the image file for the given image
 func (e Elemental) CreateFileSystemImage(img *v1.Image) error {
-	e.config.Logger.Infof("Creating file system image %s", img.File)
 	err := utils.MkdirAll(e.config.Fs, filepath.Dir(img.File), cnst.DirPerm)
 	if err != nil {
 		return err

--- a/pkg/systemd/unit.go
+++ b/pkg/systemd/unit.go
@@ -1,0 +1,44 @@
+/*
+Copyright © 2022 - 2023 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package systemd
+
+import (
+	"path/filepath"
+
+	v1 "github.com/rancher/elemental-cli/pkg/types/v1"
+)
+
+type Unit struct {
+	Name    string
+	Content []byte
+}
+
+func NewUnit(name string, content []byte) *Unit {
+	return &Unit{
+		Name:    name,
+		Content: content,
+	}
+}
+
+func Install(fs v1.FS, unit *Unit) error {
+	return fs.WriteFile(filepath.Join("/usr/lib/systemd/system", unit.Name), unit.Content, 0644)
+}
+
+func Enable(runner v1.Runner, unit *Unit) error {
+	_, err := runner.Run("systemctl", "enable", unit.Name)
+	return err
+}

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -188,6 +188,11 @@ func (i *InstallSpec) Sanitize() error {
 	return i.Partitions.SetFirmwarePartitions(i.Firmware, i.PartTable)
 }
 
+type InitSpec struct {
+	RunMkinitrd bool `yaml:"mkinitrd,omitempty" mapstructure:"mkinitrd"`
+	Force       bool `yaml:"force,omitempty" mapstructure:"force"`
+}
+
 // ResetSpec struct represents all the reset action details
 type ResetSpec struct {
 	FormatPersistent bool `yaml:"reset-persistent,omitempty" mapstructure:"reset-persistent"`


### PR DESCRIPTION
The init command replaces the `system/cos-setup`,
`system/base-dracut-modules` and `system/grub2-config` packages.

It does this by:

- Installing systemd units for the boot-process
- Installing dracut modules and configuration
- Setting GRUB2 configuration and next_entry config

Adapting `cloud-config/*` and `system/immutable-rootfs` packages to elemental-cli would allow us to write a derivative Dockerfile like the following:

```Dockerfile
FROM rancher/elemental-cli as CLI
FROM opensuse/tumbleweed as OS

# install kernel, systemd, dracut, grub2 and any other handy tool
RUN zypper install --non-interactive <list of system packages>

COPY --from=CLI /usr/bin/elemental /usr/bin/elemental
RUN elemental init
```
