### PR TITLE
Add cmdline argument to ISO

### DIFF
--- a/pkg/live/common.go
+++ b/pkg/live/common.go
@@ -63,7 +63,7 @@ const (
 
 	menuentry "%s" --class os --unrestricted {
 		echo Loading kernel...
-		$linux ($root)` + constants.ISOKernelPath + ` cdroot root=live:CDLABEL=%s rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0 rd.cos.disable cos.setup=` + constants.ISOCloudInitPath + `
+		$linux ($root)` + constants.ISOKernelPath + ` cdroot root=live:CDLABEL=%s rd.live.dir=/ rd.live.squashimg=rootfs.squashfs rd.live.overlay.overlayfs=1 console=tty1 console=ttyS0 rd.cos.disable cos.setup=` + constants.ISOCloudInitPath + `
 		echo Loading initrd...
 		$initrd ($root)` + constants.ISOInitrdPath + `
 	}                                                                               


### PR DESCRIPTION
Add the `rd.live.overlay.overlayfs=1` cmdline argument since it seems to be needed to boot when building a tumbleweed ISO.