### PR TITLE
Reduce default partition sizes

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -53,8 +53,8 @@ const (
 	BiosFs             = ""
 	EfiSize            = uint(64)
 	OEMSize            = uint(64)
-	StateSize          = uint(15360)
-	RecoverySize       = uint(8192)
+	StateSize          = uint(8192)
+	RecoverySize       = uint(4096)
 	PersistentSize     = uint(0)
 	BiosSize           = uint(1)
 	ImgSize            = uint(0)

--- a/pkg/elemental/elemental_test.go
+++ b/pkg/elemental/elemental_test.go
@@ -378,13 +378,13 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 						"mkpart", "oem", "ext4", "133120", "264191",
 					}, {"mkfs.ext4", "-L", "COS_OEM", "/some/device2"}, {
 						"parted", "--script", "--machine", "--", "/some/device", "unit", "s",
-						"mkpart", "recovery", "ext4", "264192", "17041407",
+						"mkpart", "recovery", "ext4", "264192", "8652799",
 					}, {"mkfs.ext4", "-L", "COS_RECOVERY", "/some/device3"}, {
 						"parted", "--script", "--machine", "--", "/some/device", "unit", "s",
-						"mkpart", "state", "ext4", "17041408", "48498687",
+						"mkpart", "state", "ext4", "8652800", "25430015",
 					}, {"mkfs.ext4", "-L", "COS_STATE", "/some/device4"}, {
 						"parted", "--script", "--machine", "--", "/some/device", "unit", "s",
-						"mkpart", "persistent", "ext4", "48498688", "100%",
+						"mkpart", "persistent", "ext4", "25430016", "100%",
 					}, {"mkfs.ext4", "-L", "COS_PERSISTENT", "/some/device5"},
 				}
 

--- a/tests/mocks/runner_mock.go
+++ b/tests/mocks/runner_mock.go
@@ -131,6 +131,12 @@ func (r FakeRunner) MatchMilestones(cmdList [][]string) error {
 	return nil
 }
 
+// GetCmds returns the list of commands recorded by this FakeRunner instance
+// this is helpful to debug tests
+func (r FakeRunner) GetCmds() [][]string {
+	return r.cmds
+}
+
 func (r FakeRunner) GetLogger() v1.Logger {
 	return r.Logger
 }


### PR DESCRIPTION
This PR reduces default partition sizes for state and recovery partitions. State was set up to 15GB and it is mostly including active and passive images, which are about 1.3GB  each (they include a 256Mb overhead of free space). So there was way too much space reserved for them. Similar applies to Recovery image, originally set to 8GB and it only includes the recovery image which around 1.3GB again.

This PR reduces the sizes to the half, 8GB for state partition and 4GB for recovery partition. 

The theoretic minimum sizes are 4xOSsize for State partition and 3xOSsize on recovery. 
