### PR TITLE
Deprecate disk related commands

### DIFF
--- a/cmd/build-disk.go
+++ b/cmd/build-disk.go
@@ -34,9 +34,10 @@ import (
 // pre-run check. This method is mostly used for testing purposes.
 func NewBuildDisk(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 	c := &cobra.Command{
-		Use:   "build-disk",
-		Short: "Build a raw recovery image",
-		Args:  cobra.NoArgs,
+		Use:        "build-disk",
+		Short:      "Build a raw recovery image",
+		Args:       cobra.NoArgs,
+		Deprecated: "it and can be changed or removed without a major version bump",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if addCheckRoot {
 				return CheckRoot()

--- a/cmd/convert-disk.go
+++ b/cmd/convert-disk.go
@@ -37,9 +37,10 @@ var outputAllowed = []string{"azure", "gce"}
 // pre-run check. This method is mostly used for testing purposes.
 func NewConvertDisk(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 	c := &cobra.Command{
-		Use:   "convert-disk RAW_DISK",
-		Short: fmt.Sprintf("converts between a raw disk and a cloud operator disk image (%s)", strings.Join(outputAllowed, ",")),
-		Args:  cobra.ExactArgs(1),
+		Use:        "convert-disk RAW_DISK",
+		Short:      fmt.Sprintf("converts between a raw disk and a cloud operator disk image (%s)", strings.Join(outputAllowed, ",")),
+		Args:       cobra.ExactArgs(1),
+		Deprecated: "it and can be changed or removed without a major version bump",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if addCheckRoot {
 				return CheckRoot()


### PR DESCRIPTION
With the change the commands do not appear in `elemental --help` and if used they run as they used to but with the deprecation warning.

```
$ elemental build-disk
Command "build-disk" is deprecated, it and can be changed or removed without a major version bump
...
```

Fixes #470