### PR TITLE
fix typo in deprecation text

### DIFF
--- a/cmd/build-disk.go
+++ b/cmd/build-disk.go
@@ -37,7 +37,7 @@ func NewBuildDisk(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 		Use:        "build-disk",
 		Short:      "Build a raw recovery image",
 		Args:       cobra.NoArgs,
-		Deprecated: "it and can be changed or removed without a major version bump",
+		Deprecated: "it can be changed or removed without a major version bump",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if addCheckRoot {
 				return CheckRoot()

--- a/cmd/convert-disk.go
+++ b/cmd/convert-disk.go
@@ -40,7 +40,7 @@ func NewConvertDisk(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 		Use:        "convert-disk RAW_DISK",
 		Short:      fmt.Sprintf("converts between a raw disk and a cloud operator disk image (%s)", strings.Join(outputAllowed, ",")),
 		Args:       cobra.ExactArgs(1),
-		Deprecated: "it and can be changed or removed without a major version bump",
+		Deprecated: "it can be changed or removed without a major version bump",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if addCheckRoot {
 				return CheckRoot()


### PR DESCRIPTION
Before:

> $ elemental build-disk
Command "build-disk" is deprecated, it and can be changed or removed without a major version bump

After:

> $ elemental build-disk
Command "build-disk" is deprecated, it can be changed or removed without a major version bump
