### PR TITLE
Fix version command to proper show version and commit

### DIFF
--- a/.obs/specfile/elemental-cli.spec
+++ b/.obs/specfile/elemental-cli.spec
@@ -23,7 +23,8 @@ Summary:        The command line client for Elemental
 License:        Apache-2.0
 Group:          System/Management
 Url:            https://github.com/rancher-sandbox/%{name}
-Source:         %{name}-%{version}.tar.gz
+Source:         %{name}-%{version}.tar
+Source1:        %{name}.obsinfo
 
 Requires:       dosfstools
 Requires:       e2fsprogs
@@ -49,9 +50,16 @@ Elemental functionality
 
 %prep
 %setup -q
+cp %{S:1} .
 
 %build
-GIT_TAG=%{git_tag} GIT_COMMIT=%{git_commit} make build
+export GIT_TAG=`echo "%{version}" | cut -d "+" -f 1`
+GIT_COMMIT=$(cat %{name}.obsinfo | grep commit: | cut -d" " -f 2)
+export GIT_COMMIT=${GIT_COMMIT:0:8}
+MTIME=$(cat %{name}.obsinfo | grep mtime: | cut -d" " -f 2)
+export COMMITDATE=$(date -d @${MTIME} +%Y%m%d)
+make build
+
 
 %install
 mkdir -p %{buildroot}%{_bindir}


### PR DESCRIPTION
This ensures the elemental-cli binaries include the proper version form the tag they are build and the commit hash.

This was fixes long a go for elemental-operator, apparently we did not fix it for the elemental-cli. This PR is applying the same logic as in elemental-operator spec. Note that this will require a small arrangement in `_service` file in OBS too. OBS SR is also ready [here](https://build.opensuse.org/request/show/1081476).